### PR TITLE
fix(ddt): recursively create config wallet path

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
@@ -2,11 +2,8 @@
   "Invoke the wallet (init) method."
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
   (:require
-   ["process" :as process])
-  (:require
-   [clojure.string :as cstr])
-  (:require
    [com.kubelt.ddt.prompt :as ddt.prompt]
+   [com.kubelt.ddt.util :as ddt.util]
    [com.kubelt.lib.wallet :as lib.wallet]))
 
 (defonce command
@@ -27,13 +24,11 @@
                 ;; can't be overwritten so throw an error if so.
                 (if (lib.wallet/has-wallet? app-name wallet-name)
                   (let [message (str "wallet '" wallet-name "' already exists")]
-                    (println (str "error: " message))
-                    (.exit process 1)))
+                    (ddt.util/exit-if message)))
                 (ddt.prompt/confirm-password!
                  (fn [err result]
                    (when err
-                     (println (str "error: " err))
-                     (.exit process 1))
+                     (ddt.util/exit-if err))
                    (let [password (.-password result)]
                      (let [wallet-path (lib.wallet/init app-name wallet-name password)]
                        (println "initialized wallet:" wallet-name)))))))})

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -63,7 +63,11 @@
   [app-name]
   (let [wallet-dirp (wallet-dir app-name)]
     (when-not (.existsSync fs wallet-dirp)
-      (.mkdirSync fs wallet-dirp))
+      (let [mode "0700"
+            recursive? true
+            options #js {:mode mode
+                         :recursive recursive?}]
+        (.mkdirSync fs wallet-dirp options)))
     wallet-dirp))
 
 (defn- name->path


### PR DESCRIPTION
# Description

Fixes an error that occurred when making a CLI wallet directory when the parent `.config/ddt` directory didn't already exists. Recursively creates the wallet directory and specifies the config directory mode as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
