### PR TITLE
CHORE(Sanity): Remove kItem definition dependency

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -166,7 +166,7 @@
 
   watch:plugin:sanity
   {:doc "Build plugin for Sanity CMS on file change"
-   :depends [build:sdk-web:release]
+   :depends [build:sdk-web:develop]
    :task (shell "npx lerna run watch --scope sanity-plugin-kubelt")}
 
   test:sdk:cljs:develop

--- a/packages/sanity-plugin-kubelt/src/actions/KubeltPublishAction.tsx
+++ b/packages/sanity-plugin-kubelt/src/actions/KubeltPublishAction.tsx
@@ -12,55 +12,6 @@ import KubeltPublishModal from "../containers/PublishModal/KubeltPublishModal";
 import { useAccount } from "../hooks/useAccount";
 import sanityService from "../services/sanityService";
 
-function PatchButton({
-  doc,
-  enabled,
-}: {
-  doc: {
-    _id: string;
-    _type: string;
-    name: string;
-  };
-  enabled: boolean;
-}) {
-  const { patch } = useDocumentOperation(doc._id, doc._type) as {
-    patch;
-    publish;
-  };
-
-  const patchKubeltName = () => {
-    let kuSlug = "";
-
-    const docId = doc._id;
-    if (docId.startsWith("drafts.")) {
-      docId.replace("drafts.", "");
-    }
-
-    kuSlug = `${doc._type}:${doc._type}_${doc._id}`;
-
-    if (doc.name) {
-      kuSlug = `${kuSlug}-${slugify(doc.name, {
-        lower: true,
-      })}`;
-    }
-
-    patch.execute([{ set: { kItem: { name: `${kuSlug}` } } }]);
-  };
-
-  return (
-    <Button
-      icon={EditIcon}
-      text="Patch"
-      disabled={!enabled}
-      onClick={() => patchKubeltName()}
-      tone="primary"
-      style={{
-        marginRight: "0.4em",
-      }}
-    />
-  );
-}
-
 function KubeltPublishAction({ published, draft, onComplete }) {
   if (!sanityService.IsInit) {
     // Sanity Client configuration is injected by the part:s system at runtime

--- a/packages/sanity-plugin-kubelt/src/badges/KubeltNamedBadge.tsx
+++ b/packages/sanity-plugin-kubelt/src/badges/KubeltNamedBadge.tsx
@@ -1,7 +1,0 @@
-export function KubeltNamedBadge(props) {
-  return {
-    label: "Kubelt Named",
-    title: "Document is named on Kubelt",
-    color: "warning",
-  };
-}

--- a/packages/sanity-plugin-kubelt/src/resolvers/badgeResolver.ts
+++ b/packages/sanity-plugin-kubelt/src/resolvers/badgeResolver.ts
@@ -2,8 +2,6 @@
 // @ts-ignore
 import defaultResolve from "part:@sanity/base/document-badges";
 
-import { KubeltNamedBadge } from "../badges/KubeltNamedBadge";
-
 /**
  * This applies a badge to any object that has the kubeltItem schema applied
  * and is indeed named. This is a bit old and might be removed.
@@ -13,9 +11,6 @@ export default function resolveDocumentBadges(props) {
   const combinedObj = { ...published, ...draft };
 
   const badges = [];
-  if (combinedObj.kItem && combinedObj.kItem.name !== "") {
-    badges.push(KubeltNamedBadge);
-  }
 
   return [...defaultResolve(props), ...badges];
 }

--- a/packages/sanity-plugin-kubelt/src/services/semanticService.test.ts
+++ b/packages/sanity-plugin-kubelt/src/services/semanticService.test.ts
@@ -117,10 +117,6 @@ test("Objects drop primitive keys", () => {
     _id: "foobar",
     _type: "person",
     name: "Not Zorro",
-    kItem: {
-      _type: "kubeltItem",
-      name: "sfdfdfdf",
-    },
     slug: {
       _type: "slug",
       current: "not-zorro",
@@ -135,7 +131,6 @@ test("Objects drop primitive keys", () => {
   const semanticObj = semanticService.semantify(obj);
 
   expect(semanticObj).not.toBeNull();
-  expect(semanticObj["kItem"]).not.toBeDefined();
   expect(semanticObj["slug"]).not.toBeDefined();
   expect(semanticObj["address"]).not.toBeDefined();
   expect(semanticObj["@context"]).toBeDefined();


### PR DESCRIPTION
# Description

This is a long-coming removal of code as the initial idea was to append properties to objects to be marked in the Kubelt system. This idea has been put on hold and the final shape will look very much differently.

Closes #164 

## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Sanity Studio flow
- [x] test:all:develop
- [x] test:all:release

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
