### PR TITLE
fix(ddt): treat core names as strings rather than parsing as integers

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/p2p/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/p2p/authenticate.cljs
@@ -25,8 +25,8 @@
                     ;; wallet address starting with "0x" as a big
                     ;; integer.
                     core-config #js {:describe "a @core name"
-                                     :string true}]
-                (.options yargs "core" core-config)
+                                     :type "string"}]
+                (.positional yargs "core" core-config)
                 (ddt.options/options yargs)))
 
    :handler (fn [args]

--- a/src/main/com/kubelt/ddt/cmds/p2p/verify.cljs
+++ b/src/main/com/kubelt/ddt/cmds/p2p/verify.cljs
@@ -23,8 +23,8 @@
                     ;; wallet address starting with "0x" as a big
                     ;; integer.
                     core-config #js {:describe "a @core name"
-                                     :string true}]
-                (.options yargs "core" core-config)
+                                     :type "string"}]
+                (.positional yargs "core" core-config)
                 (ddt.options/options yargs)))
 
    :handler (fn [args]

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
@@ -23,8 +23,8 @@
                     ;; wallet address starting with "0x" as a big
                     ;; integer.
                     core-config #js {:describe "a @core name"
-                                     :string true}]
-                (.options yargs "core" core-config)
+                                     :type "string"}]
+                (.positional yargs "core" core-config)
                 (ddt.options/options yargs))
               yargs)
 

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/register.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/register.cljs
@@ -6,8 +6,8 @@
    [com.kubelt.sdk.v1 :as sdk]))
 
 (defonce command
-  {:command "init"
-   :desc "Initialize the SDK"
+  {:command "register"
+   :desc "Register with a core"
    :requiresArg false
 
    :builder (fn [^Yargs yargs]


### PR DESCRIPTION
# Description

Properly configures `core` argument to several `ddt` commands as being of `string` type. This prevents "naked" core addresses of the format `0x<hex string>` from being parsed by the CLI framework as integers.

Incidentally updates an incorrect doc string for a command.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
