### PR TITLE
chore(sdk): work on cleaning up HTTP client

### DIFF
--- a/src/main/com/kubelt/ipfs/client.cljc
+++ b/src/main/com/kubelt/ipfs/client.cljc
@@ -7,6 +7,7 @@
    [malli.core :as malli]
    [malli.error :as me])
   (:require
+   [com.kubelt.lib.error :as lib.error]
    [com.kubelt.ipfs.api :as ipfs.api]
    [com.kubelt.ipfs.v0.node :as v0.node]
    [com.kubelt.ipfs.spec :as ipfs.spec]
@@ -237,11 +238,7 @@
          options (merge default-options options)]
      ;; Validate the options.
      (if-not (malli/validate ipfs.spec/init-options options)
-       (let [explain (-> ipfs.spec/init-options
-                         (malli/explain options)
-                         me/humanize)]
-         {:com.kubelt/type :kubelt.type/error
-          :error explain})
+       (lib.error/explain ipfs.spec/init-options options)
        ;; Options are valid, return the client.
        (let [{:keys [http/client]}
              (if (contains? options :http/client)
@@ -278,7 +275,7 @@
                                           (assoc :uri/port request-port)
                                           (assoc :response/keywordize? true))
                            ;; TODO validate response
-                           info (proto.http/request-sync client id-request)
+                           info (proto.http/request! client id-request)
                            ;; Extract some information from the response and
                            ;; store directly in the client. Some of these are
                            ;; the criteria along which we expect node behaviour
@@ -345,11 +342,7 @@
     request-map
     ;; Validate request-map.
     (not (malli/validate ipfs.spec/api-resource request-map))
-    (let [explain (-> ipfs.spec/api-resource
-                      (malli/explain request-map)
-                      me/humanize)]
-      {:com.kubelt/type :kubelt.type/error
-       :error explain})
+    (lib.error/explain ipfs.spec/api-resource request-map)
     ;; Perform the request!
     :else
     (let [;; TODO allow per-request override of keywordizing?
@@ -382,7 +375,7 @@
           ;; TODO supply promise/channel if requested
           http-client (get client :http/client)
           ;; By default perform synchronous request.
-          response (proto.http/request-sync http-client request)]
+          response (proto.http/request! http-client request)]
 
       ;; TODO promise, channel
       ;; TODO callback fns:
@@ -393,7 +386,7 @@
       ;; TODO parse response body
       ;; TODO validate response body, cf. :client/validate?
       ;; TODO transform response body, cf. :client/keywordize?
-      ;;@(proto.http/request-sync http-client request on-response)
+      ;;@(proto.http/request http-client request on-response)
 
       (if-let [body-fn (get request-map :response/body-fn)]
           (body-fn request-map response)

--- a/src/main/com/kubelt/proto/http.cljc
+++ b/src/main/com/kubelt/proto/http.cljc
@@ -2,14 +2,8 @@
   "A protocol for making HTTP requests."
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"})
 
-;; TODO tighten up this protocol
 
 (defprotocol HttpClient
   "A simple data-first HTTP client."
-  (request! [this m]
-    "Performs an HTTP request described by the given request map, returning a core.async channel from which the response may be taken.")
-  (request-sync [this request]
-    "Performs a synchronous HTTP request described by given request map,
-returning the response body directly." )
-  (request-cb [this request on-response]
-    "Performs an HTTP request described by given request map, invoking the given callback on completion."))
+  (request! [this request]
+    "Performs an HTTP request described by the given request map, returning a promise that resolves to the HTTP response."))

--- a/src/test/lib/http/request_test.cljc
+++ b/src/test/lib/http/request_test.cljc
@@ -1,0 +1,53 @@
+(ns lib.http.request-test
+  "Test various http request-related functionality."
+  {:copyright "©2022 Kubelt, Inc." :license "UNLICENSED"}
+  #?(:cljs
+     (:require
+      [cljs.test :as t :refer [deftest is testing use-fixtures]])
+     :clj
+     (:require
+      [clojure.test :as t :refer [deftest is testing use-fixtures]]))
+  (:require
+   [clojure.string :as str])
+  (:require
+   [malli.core :as malli])
+  (:require
+   [com.kubelt.lib.http.request :as http.request]
+   [com.kubelt.proto.http :as http])
+  #?(:browser
+     (:require
+      [com.kubelt.lib.http.browser :as lib.http])
+     :clj
+     (:require
+      [com.kubelt.lib.http.jvm :as lib.http])
+     :node
+     (:require
+      [com.kubelt.lib.http.node :as lib.http])))
+
+(deftest method?-test
+  (testing "get request"
+    (let [request {:http/method :get}]
+      (is (http.request/get? request)
+          "detect a GET request")))
+  (testing "patch request"
+    (let [request {:http/method :patch}]
+      (is (http.request/patch? request)
+          "detect a PATCH request")))
+  (testing "post request"
+    (let [request {:http/method :post}]
+      (is (http.request/post? request)
+          "detect a POST request")))
+  (testing "put request"
+    (let [request {:http/method :put}]
+      (is (http.request/put? request)
+          "detect a PUT request")))
+  (testing "delete request"
+    (let [request {:http/method :delete}]
+      (is (http.request/delete? request)
+          "detect a DELETE request"))))
+
+#_(deftest request-get-test
+  (testing "GET"
+    (let [c (lib.http/->HttpClient)
+          request {:com.kubelt/type :kubelt.type/http-request}]
+      )))


### PR DESCRIPTION
# Description

Clean up the protocol for making HTTP requests, standardizing on a promise-based approach. Note that JVM works a bit differently but isn't a platform target as of yet; that implementation is sometimes useful for REPL-based development.

- [x] update `HttpClient` protocol to have single `(request!)` method
- [x] misc cleanup of error handling (use utility to generate error maps)
- [x] clean up IPFS client usage of HTTP protocol
- [x] add a test namespace for HTTP requests
  - will be fleshed out in further work

## Type of change

Please delete options that are not relevant.

- [x] clean up and refactor

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
