### PR TITLE
chore(dapp): Re-add `test:dapp:release` which still runs on merges

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -244,6 +244,12 @@
    ;; can be run against `release` or `development` versions
    :task (shell {:dir "dapp/"} "npx cypress run")}
 
+  -test:dapp:release
+  {:depends [build:dapp:release test:dapp:ci:run test:dapp:ci]}
+
+  test:dapp:release
+  {:task (run '-test:dapp:release)}
+
   test:plugin:sanity
   {:doc ""
    :depends-on [build:plugin:sanity]


### PR DESCRIPTION
# Description

Removed the `test:dapp:release` task in a previous PR (https://github.com/kubelt/kubelt/pull/294) which still runs on merges.

This task runs the compilation steps in parallel, then runs the server start and testing stages one after the other. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran the `test:dapp:release` task locally. CI on merge shows that task is missing which it shouldn't fail on anymore

# Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
