### PR TITLE
Use www.paymi.com instead of paymi.com

### DIFF
--- a/www/content/en/showcase/paymi/index.md
+++ b/www/content/en/showcase/paymi/index.md
@@ -4,7 +4,7 @@ description: "Cashback rewards made easy."
 lead: "Cashback rewards made easy"
 draft: false
 images: ["paymi.jpg"]
-link: "http://paymi.com"
+link: "https://www.paymi.com"
 menu:
   showcase:
     parent: "browse"


### PR DESCRIPTION
Just a doc fix to solve that [http(s)://paymi.com/](http://paymi.com/) doesn't work in my browser nor my terminal

```
wget https://paymi.com/
--2022-04-11 21:13:13--  https://paymi.com/
Resolving paymi.com (paymi.com)... 75.2.60.5, 99.83.190.102, 75.2.70.75
Connecting to paymi.com (paymi.com)|75.2.60.5|:443... connected.
ERROR: no certificate subject alternative name matches
	requested host name ‘paymi.com’.
To connect to paymi.com insecurely, use `--no-check-certificate'.
```
