### PR TITLE
feat(dapp): Update web3modal style to match mocks + refactor into own component ns

### DIFF
--- a/dapp/src/dapp/components/web3_modal.cljs
+++ b/dapp/src/dapp/components/web3_modal.cljs
@@ -1,0 +1,49 @@
+(ns dapp.components.web3-modal
+  (:require
+   [com.kubelt.lib.promise :refer [promise]]
+   [com.kubelt.lib.crypto.hexify :as hexify]
+   [dapp.wallet :as wallet]
+   [ethers :as ethers]
+   [re-frame.core :as re-frame]
+   [taoensso.timbre :as log])
+  (:require
+   ["web3modal$default" :as Web3Modal]
+   ["@coinbase/wallet-sdk" :as CoinbaseWalletSDK]))
+
+(def provider-options
+  {:network "mainnet"
+   :cacheProvider true
+   :theme "dark"
+   :providerOptions {:walletlink {:package CoinbaseWalletSDK :options {:appName "Kubelt"}}}})
+
+(defn make-sign-fn
+  [provider wallet-address]
+  (fn [signable]
+    (promise
+     (fn [resolve _reject]
+       (let [signable-buffer (hexify/hex-string signable)]
+         (-> (.request provider (clj->js {:method "personal_sign"
+                                          :params [signable-buffer wallet-address]}))
+             (.then (fn [digest]
+                      (resolve digest)))))))))
+
+(defn open-modal []
+  (log/trace "open the modal")
+  (let [modal (Web3Modal. (clj->js provider-options))]
+    ;(.clearCachedProvider modal)
+    (-> (.connect modal)
+        ;; TODO: figure out why this won't re-prompt wallet if password was not entered at prompt
+        (.then (fn [provider]
+                 (log/debug {:provider provider})
+                 (-> (.request provider (clj->js {:method "eth_requestAccounts"}))
+                     (.then (fn [account]
+                              (let [raw-address (first (js->clj account))
+                                    wallet-address (ethers/utils.getAddress raw-address)
+                                    sign-fn (make-sign-fn provider wallet-address)
+                                    new-wallet {:com.kubelt/type :kubelt.type/wallet
+                                                :wallet/address wallet-address
+                                                :wallet/sign-fn sign-fn}]
+                                (re-frame/dispatch [::wallet/set-current-wallet new-wallet])))))))
+        (.catch (fn [error]
+                  (.clearCachedProvider modal)
+                  (log/error error))))))

--- a/dapp/src/dapp/pages/dashboard.cljs
+++ b/dapp/src/dapp/pages/dashboard.cljs
@@ -1,54 +1,8 @@
 (ns dapp.pages.dashboard
   (:require
-   [com.kubelt.lib.promise :refer [promise]]
-   [com.kubelt.lib.crypto.hexify :as hexify]
    [dapp.components.button :as button]
    [dapp.components.header :as header]
-   [dapp.wallet :as wallet]
-   [ethers :as ethers]
-   [re-frame.core :as re-frame]
-   [taoensso.timbre :as log])
-  (:require
-    ["web3modal$default" :as Web3Modal]
-    ["@coinbase/wallet-sdk" :as CoinbaseWalletSDK]))
-
-(def provider-options
-  {:network "mainnet"
-   :cacheProvider true
-   :theme "dark"
-   :providerOptions {:walletlink {:package CoinbaseWalletSDK :options {:appName "Kubelt"}}}})
-
-(defn make-sign-fn
-  [provider wallet-address]
-  (fn [signable]
-    (promise
-     (fn [resolve _reject]
-       (let [signable-buffer (hexify/hex-string signable)]
-         (-> (.request provider (clj->js {:method "personal_sign"
-                                          :params [signable-buffer wallet-address]}))
-             (.then (fn [digest]
-                      (resolve digest)))))))))
-
-(defn open-modal []
-  (log/trace "open the modal")
-  (let [modal (Web3Modal. (clj->js provider-options))]
-    ;(.clearCachedProvider modal)
-    (-> (.connect modal)
-        ;; TODO: figure out why this won't re-prompt wallet if password was not entered at prompt
-        (.then (fn [provider]
-                 ;; dispatch the provider
-                 (-> (.request provider (clj->js {:method "eth_requestAccounts"}))
-                     (.then (fn [account]
-                              (let [raw-address (first (js->clj account))
-                                    wallet-address (ethers/utils.getAddress raw-address)
-                                    sign-fn (make-sign-fn provider wallet-address)
-                                    new-wallet {:com.kubelt/type :kubelt.type/wallet
-                                                :wallet/address wallet-address
-                                                :wallet/sign-fn sign-fn}]
-                                (re-frame/dispatch [::wallet/set-current-wallet new-wallet])))))))
-        (.catch (fn [error]
-                  (.clearCachedProvider modal)
-                  (log/error {:msg "web3 modal error" :error error}))))))
+   [dapp.components.web3-modal :as web3-modal]))
 
 (defn connect-wallet
   []
@@ -69,7 +23,7 @@
                      :text "Connect a Wallet"
                      :on-click (fn [e]
                                  (.preventDefault e)
-                                 (open-modal))
+                                 (web3-modal/open-modal))
                      :variant :primary}]]))
 
 (defn dashboard-content


### PR DESCRIPTION
# Description

- Fixes modal not popping up when trying to connect wallet
- Cleans up the code from hooking up the authentication.
- Refactor's web3modal into its own component namespace
- Parameterize modal config options for using `testnet` or for general testing
- Fixed the flow so that the `authenticate!` promise is resolved

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing this was tricky. Need to figure out a way to mock the auth or do testing in re-frame. Still thinking about this. Going to introduce it in a later PR.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

# Video of flow

https://user-images.githubusercontent.com/24436662/163026815-d0d0eca6-fd1d-4977-9722-f686a97a0c19.mov

# The `auth-ctx` is `nil`

![Screen Shot 2022-04-12 at 12 05 36](https://user-images.githubusercontent.com/24436662/163026938-56eacaef-b324-47b6-89ae-01891464bb5b.png)

