### PR TITLE
feat(dapp): Finish auth-flow work with decoded JWT stored in re-frame app-db

### DIFF
--- a/dapp/resources/public/images/default-avatar.svg
+++ b/dapp/resources/public/images/default-avatar.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="33" viewBox="0 0 32 33" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<rect y="0.51416" width="32" height="32" rx="5" fill="url(#pattern0)"/>
+<defs>
+<pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+<use xlink:href="#image0_253_6058" transform="scale(0.03125)"/>
+</pattern>
+<image id="image0_253_6058" width="32" height="32" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAMJJREFUWEdjPDHhyn8GJPBlkRgyF4OdUXcCr/yMJgu88jxxr1DkGUcdMOAhsMfoFUoaQI9A9DiLUbiHN46XPFBCkSeUphhHHTDgIYCeCAnFMaF8TqicQE8jGOXAqAPoHgIqGzahlAOk5mO8hQIDAwOhcoRx1AGDLgTQ8zl6HBIq2wmpRy8nMNLAqAPoHgLolRF6HJFaLhDK9+gexGgPjDpg0IUAelmPnibQ5UmtzAimgVEH0DwE0CsjuhdEow4Y6BAAAJhMPdiVAMZtAAAAAElFTkSuQmCC"/>
+</defs>
+</svg>

--- a/dapp/src/dapp/components/header.cljs
+++ b/dapp/src/dapp/components/header.cljs
@@ -1,6 +1,29 @@
-(ns dapp.components.header)
+(ns dapp.components.header
+  (:require
+   [re-frame.core :as re-frame]))
 
 (defn render
-  []
-  [:div.header
-   {:class "bg-white h-10 drop-shadow"}])
+  [_]
+  (let [wallet (re-frame/subscribe [:dapp.wallet/wallet])]
+    (fn [logged-in?]
+      (let [address (:wallet/address @wallet)]
+        [:div.header
+         {:class "flex items-center justify-end bg-white h-16 drop-shadow"}
+         (when logged-in?
+           [:div.login-metadata
+            {:class "flex flex-row items-center justify-end ml-2 mr-4"}
+            [:div.address-info
+             {:class "flex flex-col items-end mr-4"}
+             [:p
+              {:class "text-xs text-gray-500"}
+              (str (subs address 0 10) "..." (subs address 32))]
+             [:a
+              {:on-click (fn [e]
+                           ;; TODO: when clicked, kill session and disconnect wallet
+                           (.preventDefault e))
+               :class "text-xs hover:underline"}
+              "Disconnect"]]
+            [:img
+             {:class "h-8"
+              ;; TODO: Lookup wallet avatar
+              :src "images/default-avatar.svg"}]])]))))

--- a/dapp/src/dapp/pages/dashboard.cljs
+++ b/dapp/src/dapp/pages/dashboard.cljs
@@ -2,32 +2,34 @@
   (:require
    [dapp.components.button :as button]
    [dapp.components.header :as header]
-   [dapp.components.web3-modal :as web3-modal]))
+   [dapp.components.web3-modal :as web3-modal]
+   [re-frame.core :as re-frame]))
 
 (defn connect-wallet
-  []
-  (fn []
-    [:div.connect-wallet
-     {:class "flex flex-col mt-36 content-center text-center"}
-     [:img
-      {:class "h-8"
-       :src "images/wallet.svg"}]
-     [:p
-      {:class "text-gray-900 text-sm mt-4"}
-      "Connect a Wallet"]
-     [:p
-      {:class "text-gray-500 text-sm my-1"}
-      "Get started by connecting your wallet."]
-     [button/render {:id "connect-a-wallet"
-                     :class "self-center mt-6"
-                     :text "Connect a Wallet"
-                     :on-click (fn [e]
-                                 (.preventDefault e)
-                                 (web3-modal/open-modal))
-                     :variant :primary}]]))
+  [_]
+  (fn [logged-in?]
+    (when-not logged-in?
+      [:div.connect-wallet
+       {:class "flex flex-col mt-36 content-center text-center"}
+       [:img
+        {:class "h-8"
+         :src "images/wallet.svg"}]
+       [:p
+        {:class "text-gray-900 text-sm mt-4"}
+        "Connect a Wallet"]
+       [:p
+        {:class "text-gray-500 text-sm my-1"}
+        "Get started by connecting your wallet."]
+       [button/render {:id "connect-a-wallet"
+                       :class "self-center mt-6"
+                       :text "Connect a Wallet"
+                       :on-click (fn [e]
+                                   (.preventDefault e)
+                                   (web3-modal/open-modal))
+                       :variant :primary}]])))
 
 (defn dashboard-content
-  []
+  [logged-in?]
   [:div.dashboard-content
    {:class "bg-gray-200 h-full flex flex-col"}
    [:h1
@@ -35,12 +37,13 @@
     "Dashboard"]
    ;; TODO: When wallet is disconnected or not logged in, show the `connect-wallet` component.
    ;; Wallet connected views to be worked on shortly.
-   [connect-wallet]])
+   [connect-wallet logged-in?]])
 
 (defn render
   []
-  (fn []
-    [:div.dashboard-container
-     {:class "w-4/5 flex flex-col"}
-     [header/render]
-     [dashboard-content]]))
+  (let [logged-in? (re-frame/subscribe [:dapp.wallet/logged-in?])]
+   (fn []
+     [:div.dashboard-container
+      {:class "w-4/5 flex flex-col"}
+      [header/render @logged-in?]
+      [dashboard-content @logged-in?]])))

--- a/dapp/src/dapp/wallet.cljs
+++ b/dapp/src/dapp/wallet.cljs
@@ -53,17 +53,34 @@
    (let [ctx (:sdk/ctx db)
          ;; `sdk.core/set-wallet` also validates the structure of `wallet`
          new-ctx (sdk.core/set-wallet ctx wallet)]
-     {:dispatch [::authenticate new-ctx]})))
+     {:db db
+      :dispatch [::authenticate! new-ctx]})))
 
 (re-frame/reg-event-db
- ::authenticate
+ ::authenticate!
  (fn [db [_ new-ctx]]
    (let [wallet-address (get-in new-ctx [:crypto/wallet :wallet/address])]
-     (.finally (sdk.core/authenticate! new-ctx wallet-address)
-               (fn [auth-ctx]
-                 (log/info {:message (str "Authenticating a new wallet with address: " wallet-address)})
-                 (log/info {:auth-ctx auth-ctx})))
-     (assoc db :sdk/ctx new-ctx))))
+     (-> (sdk.core/authenticate! new-ctx wallet-address)
+         (.then (fn [auth-ctx]
+                  (log/info {:message (str "Authenticating a new wallet with address: " wallet-address)})
+                  ;; must dispatch the next event within the promise
+                  (re-frame/dispatch [::authenticate-success auth-ctx])))
+         (.catch (fn [err]
+                   (log/error {:message (str "Failed to authenticate with wallet address: " wallet-address)
+                               :error err})
+                   (re-frame/dispatch [::authenticate-failure wallet-address err]))))
+     ;; needs to return `db` since this is a `reg-event-db`
+     db)))
+
+(re-frame/reg-event-db
+ ::authenticate-success
+ (fn [db [_ auth-ctx]]
+   (assoc db :sdk/ctx auth-ctx)))
+
+(re-frame/reg-event-db
+ ::authenticate-failure
+ (fn [db [_ wallet-address err]]
+   (assoc-in db [:sdk/ctx :errors wallet-address] err)))
 
 ; TODO
 ; Handle the account changed event

--- a/dapp/src/dapp/wallet.cljs
+++ b/dapp/src/dapp/wallet.cljs
@@ -106,3 +106,20 @@
 (re-frame/reg-sub ::current-account
   (fn [db]
     (:current-account db)))
+
+(re-frame/reg-sub
+ ::ctx
+ (fn [db]
+   (:sdk/ctx db)))
+
+(re-frame/reg-sub
+ ::wallet
+ (fn [db]
+   (get-in db [:sdk/ctx :crypto/wallet])))
+
+(re-frame/reg-sub
+ ::logged-in?
+ :<- [::ctx]
+ :<- [::wallet]
+ (fn [[ctx {:wallet/keys [address] :as _wallet}] _]
+   (sdk.core/logged-in? ctx address)))

--- a/src/main/com/kubelt/lib/jwt.cljc
+++ b/src/main/com/kubelt/lib/jwt.cljc
@@ -3,8 +3,7 @@
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
   #?(:node
      (:require
-      ["crypto" :as crypto]
-      [com.kubelt.lib.json :as lib.json]))
+      ["crypto" :as crypto]))
   #?(:cljs
      (:import
       [goog.crypt base64]))
@@ -18,7 +17,8 @@
    [taoensso.timbre :as log])
   (:require
    [com.kubelt.lib.base64 :as lib.base64]
-   [com.kubelt.lib.error :as lib.error]))
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.json :as lib.json]))
 
 ;; - iss (issuer): Issuer of the JWT
 ;; - sub (subject): Subject of the JWT (the user)

--- a/src/main/com/kubelt/sdk/v1/core.cljs
+++ b/src/main/com/kubelt/sdk/v1/core.cljs
@@ -84,9 +84,9 @@
 ;; TODO check for valid sys map.
 (defn logged-in?
   [sys core]
-  (let [sessions (get sys :crypto/session)]
+  (let [session-tokens (get-in sys [:crypto/session :vault/tokens])]
     ;; TODO validate the JWT using the current wallet
-    (contains? sessions core)))
+    (contains? session-tokens core)))
 
 (defn logged-in-js?
   [sys core]


### PR DESCRIPTION
# Description

- Update usage of `authenticate!` event to properly resolve the promise
- Update SDK `logged-in?` function to check one nested level deeper for appropriate token data
- Add frontend `logged-in?` state driven by SDK function which returns true when a wallet is logged in

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Connected a wallet several times via Metamask to ensure all data is present. Have to figure out a way to mock pando responses as well as SDK calls when testing with re-frame. To be addressed in a future PR.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# See video of completed auth flow

https://user-images.githubusercontent.com/24436662/163258573-f4ca9571-77db-41e8-8c51-1cfa7a0961e9.mov

# Correct data within app-db AFTER login

![Screen Shot 2022-04-13 at 13 31 35](https://user-images.githubusercontent.com/24436662/163258657-6f1296fe-48ae-4b58-8974-acdfceec1fd1.png)

![Screen Shot 2022-04-13 at 13 43 19](https://user-images.githubusercontent.com/24436662/163258670-d7091770-752a-49c6-91f5-0efcc394b4dd.png)
