### PR TITLE
[proposal] Refactor config process

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/sdk.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk.cljs
@@ -4,6 +4,7 @@
   (:require
    [com.kubelt.ddt.cmds.sdk.core :as sdk.core]
    [com.kubelt.ddt.cmds.sdk.init :as sdk.init]
+   [com.kubelt.ddt.cmds.sdk.options :as sdk.options]
    [com.kubelt.ddt.cmds.sdk.resource :as sdk.resource]
    [com.kubelt.ddt.cmds.sdk.workspace :as sdk.workspace]))
 
@@ -13,6 +14,7 @@
    :builder (fn [^js yargs]
               (-> yargs
                   (.command (clj->js sdk.init/command))
+                  (.command (clj->js sdk.options/command))
                   (.command (clj->js sdk.core/command))
                   (.command (clj->js sdk.resource/command))
                   (.command (clj->js sdk.workspace/command))

--- a/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
@@ -17,7 +17,9 @@
               yargs)
 
    :handler (fn [args]
-              (let [args-map (ddt.options/to-map args)
+              (let [;; Convert command line arguments to a Clojure map.
+                    args-map (ddt.options/to-map args)
+                    ;; Transform command line arguments into an SDK options map.
                     options (ddt.options/init-options args-map)
                     kbt (sdk/init options)]
                 (if (lib.error/error? kbt)

--- a/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
@@ -2,6 +2,7 @@
   "Invoke the SDK (options) method."
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.sdk.v1 :as sdk]))
 
@@ -11,10 +12,14 @@
    :requiresArg false
 
    :builder (fn [^Yargs yargs]
+              ;; Include the common options.
+              (ddt.options/options yargs)
               yargs)
 
    :handler (fn [args]
-              (let [kbt (sdk/init)]
+              (let [args-map (ddt.options/to-map args)
+                    options (ddt.options/init-options args-map)
+                    kbt (sdk/init options)]
                 (if (lib.error/error? kbt)
                   (prn (:error kbt))
                   (let [options (sdk/options kbt)]

--- a/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
@@ -1,0 +1,22 @@
+(ns com.kubelt.ddt.cmds.sdk.options
+  "Invoke the SDK (options) method."
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.sdk.v1 :as sdk]))
+
+(defonce command
+  {:command "options"
+   :desc "Print SDK options"
+   :requiresArg false
+
+   :builder (fn [^Yargs yargs]
+              yargs)
+
+   :handler (fn [args]
+              (let [kbt (sdk/init)]
+                (if (lib.error/error? kbt)
+                  (prn (:error kbt))
+                  (let [options (sdk/options kbt)]
+                    (prn options)
+                    (sdk/halt! kbt)))))})

--- a/src/main/com/kubelt/ddt/options.cljs
+++ b/src/main/com/kubelt/ddt/options.cljs
@@ -1,6 +1,10 @@
 (ns com.kubelt.ddt.options
   "Common options various sub-commands."
-  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
+  (:require
+   ["path" :as path])
+  (:require
+   [clojure.string :as cstr]))
 
 ;; Defaults
 ;; -----------------------------------------------------------------------------
@@ -11,8 +15,27 @@
 (def port-default
   9061)
 
+(def ipfs-port-default
+  5001)
+
 ;; Options
 ;; -----------------------------------------------------------------------------
+
+(def log-level
+  "log-level")
+
+(def log-config
+  #js {:describe "set the logging level"
+       :default "warn"
+       :choices #js ["log"
+                     "trace"
+                     "debug"
+                     "info"
+                     "warn"
+                     "error"
+                     "fatal"
+                     "report"
+                     "spy"]})
 
 (def tls-name
   "tls")
@@ -56,6 +79,59 @@
        :string true
        :nargs 1})
 
+(def ipfs-read-host
+  "ipfs-read-host")
+
+(def ipfs-read-host-config
+  #js {:describe "host address of IPFS read instance"
+       :requiresArg true
+       :demandOption "address is required"
+       :string true
+       :nargs 1
+       :default host-default})
+
+(def ipfs-read-port
+  "ipfs-read-port")
+
+(def ipfs-read-port-config
+  #js {:describe "port of IPFS read instance"
+       :requiresArg true
+       :demandOption "port is required"
+       :number true
+       :nargs 1
+       :default ipfs-port-default})
+
+(def ipfs-write-host
+  "ipfs-write-host")
+
+(def ipfs-write-host-config
+  #js {:describe "address of IPFS write instance"
+       :requiresArg true
+       :demandOption "address is required"
+       :string true
+       :nargs 1
+       :default host-default})
+
+(def ipfs-write-port
+  "ipfs-write-port")
+
+(def ipfs-write-port-config
+  #js {:describe "port of IPFS write instance"
+       :requiresArg true
+       :demandOption "port is required"
+       :number true
+       :nargs 1
+       :default ipfs-port-default})
+
+(def jwt-name
+  "jwt")
+
+(def jwt-config
+  #js {:describe "A core name and associated JWT"
+       :requiresArg true
+       :array true
+       :nargs 2})
+
 ;; All of these options are required. NB: the options with supplied
 ;; defaults won't cause an error if not supplied by user.
 (def required-options
@@ -68,15 +144,79 @@
 
 (defn options
   [yargs]
+  ;; Add --log-level option
+  (.option yargs log-level log-config)
   ;; Add --(no-)tls option
   (.option yargs tls-name tls-config)
   ;; Add --host option
   (.option yargs host-name host-config)
   ;; Add --port option
   (.option yargs port-name port-config)
+  ;; Add --ipfs-read-host option
+  (.option yargs ipfs-read-host ipfs-read-host-config)
+  ;; Add --ipfs-read-port option
+  (.option yargs ipfs-read-port ipfs-read-port-config)
+  ;; Add --ipfs-write-host option
+  (.option yargs ipfs-write-host ipfs-write-host-config)
+  ;; Add --ipfs-write-port option
+  (.option yargs ipfs-write-port ipfs-write-port-config)
   ;; Add --wallet option
   (.option yargs wallet-name wallet-config)
+  ;; Add --jwt option
+  (.option yargs jwt-name jwt-config)
   ;; Indicate which options must be provided
   (.demandOption yargs required-options)
   ;; Pretend like this is functional
   yargs)
+
+
+(defn to-map
+  "Convert arguments object to a Clojure map, ensuring that common options
+  are transformed appropriately."
+  [args]
+  (let [m (js->clj args :keywordize-keys true)
+        ;; Get the name of the application that was invoked; store in
+        ;; the arguments map as something that is namespace qualified,
+        ;; i.e. com.kubelt.$name.
+        base-name (.basename path (get m :$0))
+        app-name (cstr/join "." ["com" "kubelt" base-name])
+        ;; Store the p2p service coordinates as a multiaddress.
+        host (get m :host)
+        port (get m :port)
+        tls (get m :tls)
+        p2p-maddr (cstr/join "/" ["" "ip4" host "tcp" port])
+        p2p-scheme (if tls :https :http)
+        ;; Store coordinates of IPFS read host as a multiaddress.
+        ipfs-read-host (get m :ipfs-read-host)
+        ipfs-read-port (get m :ipfs-read-port)
+        ipfs-read (cstr/join "/" ["" "ip4" ipfs-read-host "tcp" ipfs-read-port])
+        ;; Store coordinates of IPFS write host as a multiaddress.
+        ipfs-write-host (get m :ipfs-write-host)
+        ipfs-write-port (get m :ipfs-write-port)
+        ipfs-write (cstr/join "/" ["" "ip4" ipfs-write-host "tcp" ipfs-write-port])
+        ;; Turn a sequence of core names and JWT strings into a map:
+        ;; ["aaa" "bbb" "ccc" "ddd"]
+        ;; => {"aaa" "bbb", "ccc" "ddd"}
+        jwts (get m :jwt)
+        credentials (apply hash-map jwts)]
+    (-> m
+        (assoc :app-name app-name)
+        (assoc :p2p-maddr p2p-maddr)
+        (assoc :p2p-scheme p2p-scheme)
+        (assoc :ipfs-read ipfs-read)
+        (assoc :ipfs-write ipfs-write)
+        (assoc :credentials credentials)
+        (update :log-level keyword))))
+
+(defn init-options
+  [m]
+  {:pre [(map? m)]}
+  (let []
+    {:credential/jwt (get m :credentials)
+     :log/level (get m :log-level)
+     :ipfs/read (get m :ipfs-read)
+     :ipfs/write (get m :ipfs-write)
+     :p2p/read (get m :p2p-maddr)
+     :p2p.read/scheme (get m :p2p-scheme)
+     :p2p/write (get m :p2p-maddr)
+     :p2p.write/scheme (get m :p2p-scheme)}))

--- a/src/main/com/kubelt/ddt/options.cljs
+++ b/src/main/com/kubelt/ddt/options.cljs
@@ -9,6 +9,12 @@
 ;; Defaults
 ;; -----------------------------------------------------------------------------
 
+(def scheme-default
+  "http")
+
+(def scheme-choices
+  #js ["http" "https"])
+
 (def host-default
   "127.0.0.1")
 
@@ -79,6 +85,17 @@
        :string true
        :nargs 1})
 
+(def ipfs-read-scheme
+  "ipfs-read-scheme")
+
+(def ipfs-read-scheme-config
+  #js {:describe "use http or https to talk to IPFS read instance"
+       :requiresArg true
+       :demandOption "scheme is required"
+       :choices scheme-choices
+       :nargs 1
+       :default scheme-default})
+
 (def ipfs-read-host
   "ipfs-read-host")
 
@@ -100,6 +117,17 @@
        :number true
        :nargs 1
        :default ipfs-port-default})
+
+(def ipfs-write-scheme
+  "ipfs-write-scheme")
+
+(def ipfs-write-scheme-config
+  #js {:describe "use http or https to talk to IPFS write instance"
+       :requiresArg true
+       :demandOption "scheme is required"
+       :choices scheme-choices
+       :nargs 1
+       :default scheme-default})
 
 (def ipfs-write-host
   "ipfs-write-host")
@@ -152,10 +180,14 @@
   (.option yargs host-name host-config)
   ;; Add --port option
   (.option yargs port-name port-config)
+  ;; Add --ipfs-read-scheme
+  (.option yargs ipfs-read-scheme ipfs-read-scheme-config)
   ;; Add --ipfs-read-host option
   (.option yargs ipfs-read-host ipfs-read-host-config)
   ;; Add --ipfs-read-port option
   (.option yargs ipfs-read-port ipfs-read-port-config)
+  ;; Add --ipfs-write-scheme
+  (.option yargs ipfs-write-scheme ipfs-write-scheme-config)
   ;; Add --ipfs-write-host option
   (.option yargs ipfs-write-host ipfs-write-host-config)
   ;; Add --ipfs-write-port option
@@ -190,10 +222,12 @@
         ipfs-read-host (get m :ipfs-read-host)
         ipfs-read-port (get m :ipfs-read-port)
         ipfs-read (cstr/join "/" ["" "ip4" ipfs-read-host "tcp" ipfs-read-port])
+        ipfs-read-scheme (keyword (get m :ipfs-read-scheme))
         ;; Store coordinates of IPFS write host as a multiaddress.
         ipfs-write-host (get m :ipfs-write-host)
         ipfs-write-port (get m :ipfs-write-port)
         ipfs-write (cstr/join "/" ["" "ip4" ipfs-write-host "tcp" ipfs-write-port])
+        ipfs-write-scheme (keyword (get m :ipfs-write-scheme))
         ;; Turn a sequence of core names and JWT strings into a map:
         ;; ["aaa" "bbb" "ccc" "ddd"]
         ;; => {"aaa" "bbb", "ccc" "ddd"}
@@ -204,18 +238,26 @@
         (assoc :p2p-maddr p2p-maddr)
         (assoc :p2p-scheme p2p-scheme)
         (assoc :ipfs-read ipfs-read)
+        (assoc :ipfs-read-scheme ipfs-read-scheme)
         (assoc :ipfs-write ipfs-write)
+        (assoc :ipfs-write-scheme ipfs-write-scheme)
         (assoc :credentials credentials)
         (update :log-level keyword))))
 
 (defn init-options
+  "Transform an argument map into a map of options that can be used to
+  initialize the SDK. The argument map should contain arguments provided
+  on the command line, and have been transformed from a JavaScript
+  object to a Clojure map using (to-map)."
   [m]
   {:pre [(map? m)]}
   (let []
     {:credential/jwt (get m :credentials)
      :log/level (get m :log-level)
      :ipfs/read (get m :ipfs-read)
+     :ipfs.read/scheme (get m :ipfs-read-scheme)
      :ipfs/write (get m :ipfs-write)
+     :ipfs.write/scheme (get m :ipfs-write-scheme)
      :p2p/read (get m :p2p-maddr)
      :p2p.read/scheme (get m :p2p-scheme)
      :p2p/write (get m :p2p-maddr)

--- a/src/main/com/kubelt/ipfs/client.cljc
+++ b/src/main/com/kubelt/ipfs/client.cljc
@@ -64,25 +64,62 @@
 ;; call (if any), the value that was specified as the default during
 ;; client creation (if any), or the default (if all else fails).
 (defn- request->scheme
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/scheme)
-   (get client :http/scheme)
+   (let [rw (name rw)
+         kw (keyword rw "scheme")]
+     (get client kw))
    default-scheme))
 
 (defn- request->domain
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/domain)
-   (get client :http/host)
+   (let [rw (name rw)
+         kw (keyword rw "host")]
+     (get client kw))
    default-host))
 
 (defn- request->port
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/port)
-   (get client :http/port)
+   ;; We want to get the value of either :read/port or :write/port.
+   ;; The rw parameter is either :read or :write
+   (let [rw (name rw)
+         kw (keyword rw "port")]
+     (get client kw))
    default-port))
+
+(defn- request-for
+  "Takes a client map containing configuration options, a request map
+  defining the request to perform, and a keyword indicating whether the
+  request to be performed should be directed at the :read IPFS node or
+  the :write IPFS node. Returns an updated request map with the target
+  URL and request options filled in using values taken from the client
+  configuration."
+  [request client read-or-write]
+  {:pre [(contains? #{:read :write} read-or-write)]}
+  (let [;; Get the HTTP request scheme for the request.
+        scheme (request->scheme request client read-or-write)
+        ;; Get the HTTP host for the request.
+        domain (request->domain request client read-or-write)
+        ;; Get the HTTP port for the request.
+        port (request->port request client read-or-write)
+        ;; Should response body be keywordized?
+        keywordize? (get client :client/keywordize?)
+        ;; Should response body be validated?
+        validate? (get client :client/validate?)]
+    (-> request
+        (assoc :uri/scheme scheme)
+        (assoc :uri/domain domain)
+        (assoc :uri/port port)
+        (assoc :response/keywordize? keywordize?)
+        (assoc :response/validate? validate?))))
 
 (defn- extract-node-id
   [m]
@@ -224,17 +261,24 @@
   :client/node-info? - fetch and store node information in client
   :client/timeout - request timeout in milliseconds
   :http/client - a pre-created HTTP client (must satisfy HttpClient)
-  :http/scheme - the transport scheme to use, e.g. :http, :https
-  :http/host - the IP address of the IPFS host
-  :http/port - the listening port of the IPFS host"
+  :read/scheme - the HTTP scheme to use for reads, e.g. :http, :https
+  :read/host - the IP address of the IPFS read host
+  :read/port - the listening port of the IPFS read host
+  :write/scheme - the HTTP scheme to use for writes, e.g. :http, :https
+  :write/host - the IP address of the IPFS write host
+  :write/port - the listening port of the IPFS write host"
   ([]
    (init {}))
   ([options]
-   (let [default-options {:http/scheme default-scheme
-                          :http/host default-host
-                          :http/port default-port
+   (let [default-options {:read/scheme default-scheme
+                          :read/host default-host
+                          :read/port default-port
+                          :write/scheme default-scheme
+                          :write/host default-host
+                          :write/port default-port
                           :client/validate? true
-                          :client/keywordize? true}
+                          :client/keywordize? true
+                          :client/timeout 5000}
          options (merge default-options options)]
      ;; Validate the options.
      (if-not (malli/validate ipfs.spec/init-options options)
@@ -259,21 +303,9 @@
             ;; to paper over differences in the various implementations.
             (merge options
                    (if (get options :client/node-info? true)
-                     (let [id-request (-> (v0.node/id) :http/request)
-                           ;; Get the HTTP request scheme for the request.
-                           request-scheme (request->scheme options id-request)
-                           ;; Get the HTTP host for the request.
-                           request-domain (request->domain options id-request)
-                           ;; Get the HTTP port for the request.
-                           request-port (request->port options id-request)
-                           ;; We always keywordize and validate this
-                           ;; response so we're storing data in known
-                           ;; format.
-                           id-request (-> id-request
-                                          (assoc :uri/scheme request-scheme)
-                                          (assoc :uri/domain request-domain)
-                                          (assoc :uri/port request-port)
-                                          (assoc :response/keywordize? true))
+                     (let [id-request (-> (v0.node/id)
+                                          :http/request
+                                          (request-for options :read))
                            ;; TODO validate response
                            info (proto.http/request! client id-request)
                            ;; Extract some information from the response and
@@ -345,32 +377,23 @@
     (lib.error/explain ipfs.spec/api-resource request-map)
     ;; Perform the request!
     :else
-    (let [;; TODO allow per-request override of keywordizing?
-          keywordize? (get client :client/keywordize? true)
-          ;; TODO perform validation if asked for.
-          ;; TODO allow per-request override of validation?
-          validate? (get client :client/validate? false)
-          ;; This stored map contains the HTTP request parameters we can
-          ;; pass to our HTTP client (once we've added a few missing
-          ;; bits).
-          request (get request-map :http/request)
-          ;; Get the HTTP request scheme for the request.
-          request-scheme (request->scheme client request)
-          ;; Get the HTTP host for the request.
-          request-domain (request->domain client request)
-          ;; Get the HTTP port for the request.
-          request-port (request->port client request)
-          ;; Add the request target details to the request map, along
-          ;; with any additional parameters that control how the result
-          ;; will be performed and/or the response processed.
-          request (-> request
-                      (assoc :uri/scheme request-scheme)
-                      (assoc :uri/domain request-domain)
-                      (assoc :uri/port request-port)
-                      ;; Should response body be keywordized?
-                      (assoc :response/keywordize? keywordize?)
-                      ;; Should response body be validated?
-                      (assoc :response/validate? validate?))
+    ;; TODO allow per-request override of keywordizing?
+    ;; TODO perform validation if asked for.
+    ;; TODO allow per-request override of validation?
+    ;; TODO categorize requests as being reads or writes and
+    ;; directing to the appropriate IPFS node (allowing user
+    ;; override).
+    (let [;; This stored map contains the HTTP request parameters we can
+          ;; pass to our HTTP client once we've added a few missing
+          ;; bits. The HTTP request is defined by the map available at
+          ;; key :http/request, and we fill it in using (request-for).
+          ;;
+          ;; This adds the request target details to the request map,
+          ;; along with any additional parameters that control how the
+          ;; result will be validated and/or the response processed.
+          request (-> request-map
+                      :http/request
+                      (request-for client :read))
           ;; TODO invoke callbacks if provided
           ;; TODO supply promise/channel if requested
           http-client (get client :http/client)

--- a/src/main/com/kubelt/ipfs/spec.cljc
+++ b/src/main/com/kubelt/ipfs/spec.cljc
@@ -102,16 +102,29 @@
      :description "An existing HTTP client to use."}
     ;; TODO tighten this up; satisfies? HttpClient
     :any]
-   [:http/scheme
+   [:read/scheme
     {:optional true
      :description "The protocol scheme to use to talk to IPFS"
      :example :http}
     spec.http/scheme]
-   [:http/host
+   [:read/host
     {:optional true
      :description "An IP address for the IPFS server"}
     spec.http/host]
-   [:http/port
+   [:read/port
+    {:optional true
+     :description "A TCP port for the IPFS server"}
+    spec.http/port]
+   [:write/scheme
+    {:optional true
+     :description "The protocol scheme to use to talk to IPFS"
+     :example :http}
+    spec.http/scheme]
+   [:write/host
+    {:optional true
+     :description "An IP address for hte IPFS server"}
+    spec.http/host]
+   [:write/port
     {:optional true
      :description "A TCP port for the IPFS server"}
     spec.http/port]])

--- a/src/main/com/kubelt/lib/config.cljs
+++ b/src/main/com/kubelt/lib/config.cljs
@@ -4,21 +4,36 @@
   (:require
    [clojure.string :as str]))
 
+;; Default logging level.
+(def log-level :warn)
+
 ;; Default configuration
 ;; -----------------------------------------------------------------------------
 
-(def log-level :info)
+;; By default we look for a local IPFS node.
+(def default-ipfs
+  {:ipfs/read "/ip4/127.0.0.1/tcp/5001"
+   :ipfs/write "/ip4/127.0.0.1/tcp/5001"})
 
 (def default-p2p
   {:p2p/read "/ip4/127.0.0.1/tcp/8787"
    :p2p/write "/ip4/127.0.0.1/tcp/8787"})
 
 (def default-logging
-  {:logging/min-level log-level})
+  {:log/level log-level})
+
+;; By default we have no JWTs available when initializing the SDK. When
+;; JWTs are supplied, it should be as a map from core name to
+;; corresponding JWT:
+;; {"0xF4E9A36d4D37B1F83706c58eF8e3AF559F4c1E2E" "<header>.<payload>.<signature>"}
+(def default-credentials
+  {:credential/jwt {}})
 
 (def default-config
-  (merge default-p2p
-         default-logging))
+  (merge default-ipfs
+         default-p2p
+         default-logging
+         default-credentials))
 
 ;; Internal
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/lib/config/opts.cljc
+++ b/src/main/com/kubelt/lib/config/opts.cljc
@@ -1,8 +1,10 @@
-(ns com.kubelt.lib.config
+(ns com.kubelt.lib.config.opts
   "Configuration-related support."
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [com.kubelt.lib.detect :as detect]
+   [com.kubelt.lib.wallet :as lib.wallet]))
 
 ;; Default logging level.
 (def log-level :warn)
@@ -29,7 +31,7 @@
 (def default-credentials
   {:credential/jwt {}})
 
-(def default-config
+(def sdk-defaults
   (merge default-ipfs
          default-p2p
          default-logging
@@ -48,14 +50,15 @@
 ;; Public
 ;; -----------------------------------------------------------------------------
 
-(defn obj->map
-  "Convert a JavaScript configuration object to a Clojure config map."
-  [o]
-  {:pre [(object? o)]}
-  (let [config (js->clj o :keywordize-keys true)]
-    (if (empty? config)
-      default-config
-      ;; Fix up any config map values that didn't translate from
-      ;; JavaScript.
-      (-> config
-          (update-in [:logging/min-level] log-level->keyword)))))
+#?(:node
+   (defn obj->map
+     "Convert a JavaScript configuration object to a Clojure config map."
+     [o]
+     {:pre [(object? o)]}
+     (let [config  (js->clj o :keywordize-keys true)]
+       (if (empty? config)
+         sdk-defaults
+       ;; Fix up any config map values that didn't translate from
+       ;; JavaScript.
+         (-> config
+             (update-in [:logging/min-level] log-level->keyword))))))

--- a/src/main/com/kubelt/lib/config/system.cljc
+++ b/src/main/com/kubelt/lib/config/system.cljc
@@ -1,0 +1,134 @@
+(ns com.kubelt.lib.config.system
+  "SDK system config"
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
+  (:require
+   [integrant.core :as ig]
+   [com.kubelt.lib.detect :as detect]
+   [com.kubelt.lib.vault :as lib.vault]
+   [com.kubelt.lib.wallet :as lib.wallet]))
+
+;; System
+;; -----------------------------------------------------------------------------
+;; For each key in the system map, if a corresponding method is
+;; implemented for the ig/init-key multimethod it will be invoked in
+;; order to initialize that part of the system. The return value is
+;; stored as part of the system configuration map. Initialization is
+;; performed recursively, making it possible to have nested subsystems.
+;;
+;; If methods are defined for the ig/halt-key! multimethod, they are
+;; invoked in order to tear down the system in the reverse order in
+;; which it was initialized.
+;;
+;; To begin the system:
+;;   (integrant.core/init)
+;; To stop the system:
+;;   (integrant.core/halt!)
+;;
+;; Cf. https://github.com/weavejester/integrant.
+
+(def default
+  {;; These empty defaults should be overridden from the SDK init
+   ;; options map.
+   :log/level nil
+   :ipfs/read-addr nil
+   :ipfs/read-scheme nil
+   :ipfs/write-addr nil
+   :ipfs/write-scheme nil
+   :p2p/read-addr nil
+   :p2p/write-addr nil
+   ;; Our common HTTP client.
+   :client/http {}
+   ;; Our connection to IPFS.
+   :client/ipfs {:ipfs/read {:http/scheme :http
+                             :ipfs/multiaddr (ig/ref :ipfs/read-addr)}
+                 :ipfs/write {:http/scheme :http
+                              :ipfs/multiaddr (ig/ref :ipfs/write-addr)}
+                 :client/http (ig/ref :client/http)}
+   ;; Our connection to the Kubelt p2p system. Typically write paths
+   ;; will go through a kubelt managed http gateway.
+   ;; TODO inject common HTTP client.
+   :client/p2p {:p2p/read {:http/scheme :http
+                           :http/address (ig/ref :p2p/read-addr)}
+                :p2p/write {:http/scheme :http
+                            :http/address (ig/ref :p2p/write-addr)}}
+   ;; A map from scope identifier to session token (JWT). Upon
+   ;; successfully authenticating against a core, the returned session
+   ;; token is kept here.
+   :crypto/session {}
+   ;; The current "wallet" implementation. This is provided externally
+   ;; by the user.
+   ;; TODO provide no-op wallet implementation, or try to detect wallet
+   ;; in the environment, e.g. metamask in browser.
+   :crypto/wallet {}})
+
+(defn config [default-system-config sdk-config]
+  ;; NB: inject supplied configuration into the system map before
+  ;; calling ig/init. The updated values will be passed to the system
+  ;; init fns.
+
+  (let [;; Use any JWTs supplied as options.
+        credentials       (get sdk-config :credential/jwt {})
+        ;; Use the wallet provided by the user, or default to a no-op
+        ;; wallet otherwise.
+        wallet            (or (get sdk-config :crypto/wallet)
+                              (lib.wallet/no-op))
+        ;; Get p2p connection addresses determined by whether or not we
+        ;; can detect a locally-running p2p node.
+        p2p-options       (detect/node-or-gateway (:client/p2p default-system-config) sdk-config)
+        ;; Get the address of the IPFS node we talk to.
+        ipfs-read         (get sdk-config :ipfs/read)
+        ipfs-read-scheme  (get sdk-config :ipfs.read/scheme)
+        ipfs-write        (get sdk-config :ipfs/write)
+        ipfs-write-scheme (get sdk-config :ipfs.write/scheme)
+        ;; Get the r/w addresses of the Kubelt gateways we talk to.
+        p2p-read          (get sdk-config :p2p/read)
+        p2p-write         (get sdk-config :p2p/write)
+        ;; Get the default minimum log level.
+        log-level         (get sdk-config :log/level)
+        ;; Update the system configuration map before initializing the
+        ;; system.
+        ]
+    ;; NB: If we provide an additional collection of keys when calling
+    ;; integrant.core/init, only those keys will be initialized.
+    ;;
+    ;; TODO use this mechanism to selectively initialize the system for
+    ;; the current context, i.e. in browser, node cli client, etc.
+    (-> default-system-config
+        (assoc :log/level log-level)
+        (assoc :ipfs/read-addr ipfs-read)
+        (assoc :ipfs/read-scheme ipfs-read-scheme)
+        (assoc :ipfs/write-addr ipfs-write)
+        (assoc :ipfs/write-scheme ipfs-write-scheme)
+        (assoc :p2p/read-addr p2p-read)
+        (assoc :p2p/write-addr p2p-write)
+        (assoc :crypto/session credentials)
+        (assoc :crypto/wallet wallet)
+        (assoc :client/p2p p2p-options))))
+
+
+(defn hidrate-options
+  "Return an options map that can be used to reinitialize the SDK."
+  [sys-map]
+  (let [ipfs-read (get sys-map :ipfs/read-addr)
+        ipfs-read-scheme (get sys-map :ipfs/read-scheme)
+        ipfs-write (get sys-map :ipfs/write-addr)
+        ipfs-write-scheme (get sys-map :ipfs/write-scheme)
+        p2p-read (get sys-map :p2p/read-addr)
+        p2p-read-scheme (get-in sys-map [:client/p2p :p2p/read :http/scheme])
+        p2p-write (get sys-map :p2p/write-addr)
+        p2p-write-scheme (get-in sys-map [:client/p2p :p2p/write :http/scheme])
+        log-level (get sys-map :log/level)
+        ;; TODO rename :crypto/session to :crypto/vault for clarity
+        credentials (lib.vault/tokens (:crypto/session sys-map))
+        wallet (get sys-map :crypto/wallet)]
+    {:log/level log-level
+     :ipfs/read ipfs-read
+     :ipfs.read/scheme ipfs-read-scheme
+     :ipfs/write ipfs-write
+     :ipfs.write/scheme ipfs-write-scheme
+     :p2p/read p2p-read
+     :p2p.read/scheme p2p-read-scheme
+     :p2p/write p2p-write
+     :p2p.write/scheme p2p-write-scheme
+     :crypto/wallet wallet
+     :credential/jwt credentials}))

--- a/src/main/com/kubelt/lib/detect.cljc
+++ b/src/main/com/kubelt/lib/detect.cljc
@@ -1,8 +1,6 @@
 (ns com.kubelt.lib.detect
   "Node and gateway detection."
-  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
-  (:require
-   [clojure.string :as str]))
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"})
 
 ;; Public
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -101,6 +101,21 @@
 (defmethod ig/init-key :p2p/write-addr [_ address]
   address)
 
+;; :client/http
+;; -----------------------------------------------------------------------------
+;; TODO support custom user agent string.
+
+(defmethod ig/init-key :client/http [_ value]
+  {:post [(not (nil? %))]}
+  (log/debug {:log/msg "init HTTP client"})
+  #?(:browser (http.browser/->HttpClient)
+     :node (http.node/->HttpClient)
+     :clj (http.jvm/->HttpClient)))
+
+(defmethod ig/halt-key! :client/http [_ client]
+  {:pre [(satisfies? proto.http/HttpClient client)]}
+  (log/debug {:log/msg "halt HTTP client"}))
+
 ;; :client/ipfs
 ;; -----------------------------------------------------------------------------
 ;; Send headers with each request:
@@ -177,21 +192,6 @@
 
 (defmethod ig/halt-key! :client/p2p [_ value]
   (log/debug {:log/msg "halt p2p client"}))
-
-;; :client/http
-;; -----------------------------------------------------------------------------
-;; TODO support custom user agent string.
-
-(defmethod ig/init-key :client/http [_ value]
-  {:post [(not (nil? %))]}
-  (log/debug {:log/msg "init HTTP client"})
-  #?(:browser (http.browser/->HttpClient)
-     :node (http.node/->HttpClient)
-     :clj (http.jvm/->HttpClient)))
-
-(defmethod ig/halt-key! :client/http [_ client]
-  {:pre [(satisfies? proto.http/HttpClient client)]}
-  (log/debug {:log/msg "halt HTTP client"}))
 
 ;; :crypto/session
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -10,6 +10,7 @@
    [com.kubelt.lib.jwt :as lib.jwt]
    [com.kubelt.lib.multiaddr :as lib.multiaddr]
    [com.kubelt.lib.util :as util]
+   [com.kubelt.lib.vault :as lib.vault]
    [com.kubelt.lib.wallet :as lib.wallet]
    [com.kubelt.proto.http :as proto.http])
   (:require
@@ -324,15 +325,17 @@
   "Return an options map that can be used to reinitialize the SDK."
   [sys-map]
   (let [ipfs-read (get sys-map :ipfs/read-addr)
-        ipfs-read-scheme (get-in sys-map [:client/ipfs :ipfs/read :http/scheme])
+        ipfs-read-scheme (get sys-map :ipfs/read-scheme)
         ipfs-write (get sys-map :ipfs/write-addr)
-        ipfs-write-scheme (get-in sys-map [:client/ipfs :ipfs/write :http/scheme])
+        ipfs-write-scheme (get sys-map :ipfs/write-scheme)
         p2p-read (get sys-map :p2p/read-addr)
         p2p-read-scheme (get-in sys-map [:client/p2p :p2p/read :http/scheme])
         p2p-write (get sys-map :p2p/write-addr)
         p2p-write-scheme (get-in sys-map [:client/p2p :p2p/write :http/scheme])
         log-level (get sys-map :log/level)
-        credentials {}]
+        ;; TODO rename :crypto/session to :crypto/vault for clarity
+        credentials (lib.vault/tokens (:crypto/session sys-map))
+        wallet (get sys-map :crypto/wallet)]
     {:log/level log-level
      :ipfs/read ipfs-read
      :ipfs.read/scheme ipfs-read-scheme
@@ -342,4 +345,5 @@
      :p2p.read/scheme p2p-read-scheme
      :p2p/write p2p-write
      :p2p.write/scheme p2p-write-scheme
+     :crypto/wallet wallet
      :credential/jwt credentials}))

--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -6,11 +6,8 @@
    [taoensso.timbre :as log])
   (:require
    [com.kubelt.ipfs.client :as ipfs.client]
-   [com.kubelt.lib.detect :as detect]
    [com.kubelt.lib.jwt :as lib.jwt]
    [com.kubelt.lib.multiaddr :as lib.multiaddr]
-   [com.kubelt.lib.util :as util]
-   [com.kubelt.lib.vault :as lib.vault]
    [com.kubelt.lib.wallet :as lib.wallet]
    [com.kubelt.proto.http :as proto.http])
   (:require
@@ -18,59 +15,6 @@
        :node [[com.kubelt.lib.http.node :as http.node]]
        :clj [[com.kubelt.lib.http.jvm :as http.jvm]])))
 
-;; System
-;; -----------------------------------------------------------------------------
-;; For each key in the system map, if a corresponding method is
-;; implemented for the ig/init-key multimethod it will be invoked in
-;; order to initialize that part of the system. The return value is
-;; stored as part of the system configuration map. Initialization is
-;; performed recursively, making it possible to have nested subsystems.
-;;
-;; If methods are defined for the ig/halt-key! multimethod, they are
-;; invoked in order to tear down the system in the reverse order in
-;; which it was initialized.
-;;
-;; To begin the system:
-;;   (integrant.core/init)
-;; To stop the system:
-;;   (integrant.core/halt!)
-;;
-;; Cf. https://github.com/weavejester/integrant.
-
-(def system
-  {;; These empty defaults should be overridden from the SDK init
-   ;; options map.
-   :log/level nil
-   :ipfs/read-addr nil
-   :ipfs/read-scheme nil
-   :ipfs/write-addr nil
-   :ipfs/write-scheme nil
-   :p2p/read-addr nil
-   :p2p/write-addr nil
-   ;; Our common HTTP client.
-   :client/http {}
-   ;; Our connection to IPFS.
-   :client/ipfs {:ipfs/read {:http/scheme :http
-                             :ipfs/multiaddr (ig/ref :ipfs/read-addr)}
-                 :ipfs/write {:http/scheme :http
-                              :ipfs/multiaddr (ig/ref :ipfs/write-addr)}
-                 :client/http (ig/ref :client/http)}
-   ;; Our connection to the Kubelt p2p system. Typically write paths
-   ;; will go through a kubelt managed http gateway.
-   ;; TODO inject common HTTP client.
-   :client/p2p {:p2p/read {:http/scheme :http
-                           :http/address (ig/ref :p2p/read-addr)}
-                :p2p/write {:http/scheme :http
-                            :http/address (ig/ref :p2p/write-addr)}}
-   ;; A map from scope identifier to session token (JWT). Upon
-   ;; successfully authenticating against a core, the returned session
-   ;; token is kept here.
-   :crypto/session {}
-   ;; The current "wallet" implementation. This is provided externally
-   ;; by the user.
-   ;; TODO provide no-op wallet implementation, or try to detect wallet
-   ;; in the environment, e.g. metamask in browser.
-   :crypto/wallet {}})
 
 ;; :log/level
 ;; -----------------------------------------------------------------------------
@@ -272,78 +216,10 @@
 ;; depend on it.
 (defn init
   "Initialize the SDK."
-  [options]
-  ;; NB: inject supplied configuration into the system map before
-  ;; calling ig/init. The updated values will be passed to the system
-  ;; init fns.
-  (let [;; Use any JWTs supplied as options.
-        credentials (get options :credential/jwt {})
-        ;; Use the wallet provided by the user, or default to a no-op
-        ;; wallet otherwise.
-        wallet (or (get options :crypto/wallet)
-                   (lib.wallet/no-op))
-        ;; Get p2p connection addresses determined by whether or not we
-        ;; can detect a locally-running p2p node.
-        default (:client/p2p system)
-        p2p-options (detect/node-or-gateway default options)
-        ;; Get the address of the IPFS node we talk to.
-        ipfs-read (get options :ipfs/read)
-        ipfs-read-scheme (get options :ipfs.read/scheme)
-        ipfs-write (get options :ipfs/write)
-        ipfs-write-scheme (get options :ipfs.write/scheme)
-        ;; Get the r/w addresses of the Kubelt gateways we talk to.
-        p2p-read (get options :p2p/read)
-        p2p-write (get options :p2p/write)
-        ;; Get the default minimum log level.
-        log-level (get options :log/level)
-        ;; Update the system configuration map before initializing the
-        ;; system.
-        system (-> system
-                   (assoc :log/level log-level)
-                   (assoc :ipfs/read-addr ipfs-read)
-                   (assoc :ipfs/read-scheme ipfs-read-scheme)
-                   (assoc :ipfs/write-addr ipfs-write)
-                   (assoc :ipfs/write-scheme ipfs-write-scheme)
-                   (assoc :p2p/read-addr p2p-read)
-                   (assoc :p2p/write-addr p2p-write)
-                   (assoc :crypto/session credentials)
-                   (assoc :crypto/wallet wallet)
-                   (assoc :client/p2p p2p-options))]
-    ;; NB: If we provide an additional collection of keys when calling
-    ;; integrant.core/init, only those keys will be initialized.
-    ;;
-    ;; TODO use this mechanism to selectively initialize the system for
-    ;; the current context, i.e. in browser, node cli client, etc.
-    (ig/init system)))
+  [system-config]
+  (ig/init system-config))
 
 (defn halt!
   "Clean-up resources used by the SDK."
   [sys-map]
   (ig/halt! sys-map))
-
-(defn options
-  "Return an options map that can be used to reinitialize the SDK."
-  [sys-map]
-  (let [ipfs-read (get sys-map :ipfs/read-addr)
-        ipfs-read-scheme (get sys-map :ipfs/read-scheme)
-        ipfs-write (get sys-map :ipfs/write-addr)
-        ipfs-write-scheme (get sys-map :ipfs/write-scheme)
-        p2p-read (get sys-map :p2p/read-addr)
-        p2p-read-scheme (get-in sys-map [:client/p2p :p2p/read :http/scheme])
-        p2p-write (get sys-map :p2p/write-addr)
-        p2p-write-scheme (get-in sys-map [:client/p2p :p2p/write :http/scheme])
-        log-level (get sys-map :log/level)
-        ;; TODO rename :crypto/session to :crypto/vault for clarity
-        credentials (lib.vault/tokens (:crypto/session sys-map))
-        wallet (get sys-map :crypto/wallet)]
-    {:log/level log-level
-     :ipfs/read ipfs-read
-     :ipfs.read/scheme ipfs-read-scheme
-     :ipfs/write ipfs-write
-     :ipfs.write/scheme ipfs-write-scheme
-     :p2p/read p2p-read
-     :p2p.read/scheme p2p-read-scheme
-     :p2p/write p2p-write
-     :p2p.write/scheme p2p-write-scheme
-     :crypto/wallet wallet
-     :credential/jwt credentials}))

--- a/src/main/com/kubelt/lib/vault.cljc
+++ b/src/main/com/kubelt/lib/vault.cljc
@@ -1,0 +1,28 @@
+(ns com.kubelt.lib.vault
+  "Work with a 'vault' that stores session tokens."
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"})
+
+;; Public
+;; -----------------------------------------------------------------------------
+
+(defn vault?
+  [x]
+  (and
+   (map? x)
+   (= :kubelt.type/vault (:com.kubelt/type x))))
+
+(defn tokens
+  "Return a map from core name to JWT token strings."
+  [vault]
+  {:pre [(vault? vault)]}
+  (letfn [(token-for [m [core decoded-jwt]]
+            ;; The original JWT string parts are preserved as :token
+            ;; and :signature when decoding a JWT
+            ;; using (lib.jwt/decode). We just stitch those pieces back
+            ;; together to get the original JWT.
+            (let [token (:token decoded-jwt)
+                  signature (:signature decoded-jwt)
+                  jwt-str (str token "." signature)]
+              (assoc m core jwt-str)))]
+    (let [token-map (:vault/tokens vault)]
+      (reduce token-for {} token-map))))

--- a/src/main/com/kubelt/sdk.cljs
+++ b/src/main/com/kubelt/sdk.cljs
@@ -46,6 +46,7 @@
 (def node-v1
   #js {:init sdk.v1/init-js
        :halt sdk.v1/halt-js!
+       :options sdk.v1/options-js
 
        ;; core
        :core #js {:authenticate sdk.v1.core/authenticate-js!

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -30,12 +30,7 @@
   an SDK instance."
   ;; The 0-arity implementation uses the default configuration.
   ([]
-   {:post [(map? %)]}
-   (let [config lib.config/default-config]
-     (if (m/validate spec.config/config config)
-       (lib.init/init config)
-       (lib.error/explain spec.config/config config))))
-
+   (init lib.config/default-config))
   ;; The 1-arity implementation expects a configuration map.
   ([config]
    {:pre [(map? config)] :post [(map? %)]}

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -95,3 +95,22 @@
        (if (lib.error/error? result)
          (reject (clj->js result))
          (resolve result))))))
+
+;; options
+;; -----------------------------------------------------------------------------
+
+(defn options
+  "Return the options map representing the SDK state, allowing for the SDK
+  to be re-instantiated."
+  [system]
+  {:pre [(map? system)]}
+  (lib.init/options system))
+
+(defn options-js
+  "Return an options object for the SDK from a JavaScript context."
+  [system]
+  {:pre [(map? system)] :post [(promise? %)]}
+  (promise
+   (fn [resolve reject]
+     (let [result (clj->js (options system))]
+       (resolve result)))))

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -5,7 +5,8 @@
    [malli.core :as m]
    [malli.error :as me])
   (:require
-   [com.kubelt.lib.config :as lib.config]
+   [com.kubelt.lib.config.opts :as lib.config.opts]
+   [com.kubelt.lib.config.system :as lib.config.system]
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.init :as lib.init]
    [com.kubelt.lib.promise :refer [promise promise?]]
@@ -30,14 +31,15 @@
   an SDK instance."
   ;; The 0-arity implementation uses the default configuration.
   ([]
-   (init lib.config/default-config))
+   (init {}))
   ;; The 1-arity implementation expects a configuration map.
   ([config]
    {:pre [(map? config)] :post [(map? %)]}
-   (if (m/validate spec.config/config config)
-     (let [config (merge lib.config/default-config config)]
-       (lib.init/init config))
-     (lib.error/explain spec.config/config config))))
+   (if (m/validate spec.config/sdk-config config)
+     (let [sdk-config (merge lib.config.opts/sdk-defaults config)
+           system-config (lib.config.system/config lib.config.system/default sdk-config)]
+       (lib.init/init system-config))
+     (lib.error/explain spec.config/sdk-config config))))
 
 ;; We deliberately resolve a ClojureScript data structure, without
 ;; converting to a JavaScript object. The returned system description is
@@ -59,7 +61,7 @@
   ;; The 1-arity implementation uses expects a configuration object.
   ([config]
    {:pre [(object? config)] :post [(promise? %)]}
-   (let [config (lib.config/obj->map config)]
+   (let [config (lib.config.opts/obj->map config)]
      (promise
       (fn [resolve reject]
         (let [result (init config)]
@@ -99,7 +101,7 @@
   to be re-instantiated."
   [system]
   {:pre [(map? system)]}
-  (lib.init/options system))
+  (lib.config.system/hidrate-options system))
 
 (defn options-js
   "Return an options object for the SDK from a JavaScript context."

--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -39,7 +39,7 @@
 ;; -----------------------------------------------------------------------------
 ;; Specifies the the configuration map passed to the sdk/init function.
 
-(def config
+(def sdk-config
   [:map {:closed true}
    [:log/level {:optional true} logging-level]
    [:credential/jwt {:optional true} credentials]
@@ -61,4 +61,4 @@
    {:title "Configuration"
     :description "The SDK configuration map"
     :example {:logging/min-level :info}}
-   config])
+   sdk-config])

--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -32,6 +32,13 @@
 (def multiaddr
   [:re #"^(/(\w+)/(\w+|\.)+)+$"])
 
+(def credentials
+  [:and
+   {:description "A map from core name to JWT strings."
+    :example {"0x123abc" "<header>.<payload>.<signature>"}}
+   ;; TODO flesh this out
+   [:map-of :string :string]])
+
 ;; config
 ;; -----------------------------------------------------------------------------
 ;; Specifies the the configuration map passed to the sdk/init function.
@@ -39,8 +46,12 @@
 (def config
   [:map {:closed true}
    [:sys/platform {:optional true} platform]
-   [:logging/min-level {:optional true} logging-level]
+   [:log/level {:optional true} logging-level]
+   [:credential/jwt {:optional true} credentials]
    [:crypto/wallet {:optional true} spec.wallet/wallet]
+   ;; TODO support IPFS Scheme
+   [:ipfs/read {:optional true} multiaddr]
+   [:ipfs/write {:optional true} multiaddr]
    [:p2p/read {:optional true} multiaddr]
    [:p2p.read/scheme {:optional true} spec.http/scheme]
    [:p2p/write {:optional true} multiaddr]

--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -10,10 +10,6 @@
 ;; the "Schema AST" map-based syntax instead as that should be faster to
 ;; instantiate for large schemas.
 
-(def platform
-  "Supported execution environments."
-  [:enum :platform.type/node :platform.type/browser :platform.type/jvm])
-
 (def logging-level
   "Logging levels defined by the timbre logging library."
   [:and
@@ -45,13 +41,13 @@
 
 (def config
   [:map {:closed true}
-   [:sys/platform {:optional true} platform]
    [:log/level {:optional true} logging-level]
    [:credential/jwt {:optional true} credentials]
    [:crypto/wallet {:optional true} spec.wallet/wallet]
-   ;; TODO support IPFS Scheme
    [:ipfs/read {:optional true} multiaddr]
+   [:ipfs.read/scheme {:optional true} spec.http/scheme]
    [:ipfs/write {:optional true} multiaddr]
+   [:ipfs.write/scheme {:optional true} spec.http/scheme]
    [:p2p/read {:optional true} multiaddr]
    [:p2p.read/scheme {:optional true} spec.http/scheme]
    [:p2p/write {:optional true} multiaddr]

--- a/src/test/lib/config_test.cljs
+++ b/src/test/lib/config_test.cljs
@@ -7,61 +7,61 @@
    [malli.core :as malli])
   (:require
    [com.kubelt.spec.config :as spec.config]
-   [com.kubelt.lib.config :as config]))
+   [com.kubelt.lib.config.opts :as config]))
 
 (deftest config-test
   (testing "default config is valid"
-    (let [default-config config/default-config]
-      (is (malli/validate spec.config/config default-config)
+    (let [default-config config/sdk-defaults]
+      (is (malli/validate spec.config/sdk-config default-config)
           "default options must be valid")))
 
   (testing "logging levels"
     (testing "log level"
       (let [options {:log/level :log}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :log is valid")))
     (testing "trace level"
       (let [options {:log/level :trace}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :trace is valid")))
     (testing "debug level"
       (let [options {:log/level :debug}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :debug is valid")))
     (testing "info level"
       (let [options {:log/level :info}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :info is valid")))
     (testing "warn level"
       (let [options {:log/level :warn}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :warn is valid")))
     (testing "error level"
       (let [options {:log/level :error}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :error is valid")))
     (testing "fatal level"
       (let [options {:log/level :fatal}]
-        (is (malli/validate spec.config/config options)
+        (is (malli/validate spec.config/sdk-config options)
             "logging min-level of :fatal is valid"))))
 
   (testing "p2p settings"
     (testing "invalid address"
       (let [options {:p2p/read "127.0.0.1"}]
-        (is (not (malli/validate spec.config/config options))
+        (is (not (malli/validate spec.config/sdk-config options))
             "a dotted-quad is not a valid address"))
       (let [options {:p2p/read "localhost"}]
-        (is (not (malli/validate spec.config/config options))
+        (is (not (malli/validate spec.config/sdk-config options))
             "localhost is not a valid host name")))
 
     (testing "multiaddr"
       (testing "localhost"
         (let [options {:p2p/read "/ip4/127.0.0.1"}]
-          (is (malli/validate spec.config/config options)
+          (is (malli/validate spec.config/sdk-config options)
               "loopback IP is a valid network address"))
         (let [options {:p2p/read "/ip4/localhost"}]
-          (is (malli/validate spec.config/config options)
+          (is (malli/validate spec.config/sdk-config options)
               "localhost is a valid network address"))
         (let [options {:p2p/read "/ip4/127.0.0.1/tcp/8080"}]
-          (is (malli/validate spec.config/config options)
+          (is (malli/validate spec.config/sdk-config options)
               "localhost:8080 is a valid network address"))))))

--- a/src/test/lib/config_test.cljs
+++ b/src/test/lib/config_test.cljs
@@ -17,31 +17,31 @@
 
   (testing "logging levels"
     (testing "log level"
-      (let [options {:logging/min-level :log}]
+      (let [options {:log/level :log}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :log is valid")))
     (testing "trace level"
-      (let [options {:logging/min-level :trace}]
+      (let [options {:log/level :trace}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :trace is valid")))
     (testing "debug level"
-      (let [options {:logging/min-level :debug}]
+      (let [options {:log/level :debug}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :debug is valid")))
     (testing "info level"
-      (let [options {:logging/min-level :info}]
+      (let [options {:log/level :info}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :info is valid")))
     (testing "warn level"
-      (let [options {:logging/min-level :warn}]
+      (let [options {:log/level :warn}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :warn is valid")))
     (testing "error level"
-      (let [options {:logging/min-level :error}]
+      (let [options {:log/level :error}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :error is valid")))
     (testing "fatal level"
-      (let [options {:logging/min-level :fatal}]
+      (let [options {:log/level :fatal}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :fatal is valid"))))
 

--- a/src/test/lib/detect_test.cljs
+++ b/src/test/lib/detect_test.cljs
@@ -4,7 +4,7 @@
    [cljs.test :as t :refer [deftest is testing use-fixtures]]
    [clojure.string :as str])
   (:require
-   [com.kubelt.lib.config :as config]
+   [com.kubelt.lib.config.opts :as config]
    [com.kubelt.lib.detect :as detect]))
 
 (deftest local-node?-test


### PR DESCRIPTION
# Description

I'm trying here following:
- Decouple `sdk-config` (the one api receives on sdk/init), from the sdk `system-config` one.
Why? To improve understanding on how config values flow from received, transformed, merged with default configs to finally generate/return a sdk(-system)
pipeline:
`input-config` => `sdk-config` => `system-config` => `sdk-system` 

- also keeping cljc as much of possible to easy env integration ... But this point I'm not really sure if makes sense 🤔 