### PR TITLE
WIP integrant promises

### DIFF
--- a/packages/sdk-js/__tests__/api-v1.js
+++ b/packages/sdk-js/__tests__/api-v1.js
@@ -53,6 +53,7 @@ tap.test('SDK v1 has expected API', (t) => {
     check(kbt, [], 'v1');
     check(kbt, ['v1'], 'init');
     check(kbt, ['v1'], 'halt');
+    check(kbt, ['v1'], 'options');
     check(kbt, ['v1', 'core'], 'authenticate'),
     check(kbt, ['v1'], 'workspace');
     check(kbt, ['v1', 'workspace'], 'available');
@@ -95,7 +96,7 @@ tap.test('sdk init', (t) => {
 
     tap.test('with valid config', (t) => {
         return kbt.v1.init({
-            "logging/min-level": "info",
+            "log/level": "info",
         }).then((sdk) => {
             t.type(sdk, 'object');
             return kbt.v1.halt(sdk);

--- a/src/main/com/kubelt/ddt/cmds/sdk.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk.cljs
@@ -4,6 +4,7 @@
   (:require
    [com.kubelt.ddt.cmds.sdk.core :as sdk.core]
    [com.kubelt.ddt.cmds.sdk.init :as sdk.init]
+   [com.kubelt.ddt.cmds.sdk.options :as sdk.options]
    [com.kubelt.ddt.cmds.sdk.resource :as sdk.resource]
    [com.kubelt.ddt.cmds.sdk.workspace :as sdk.workspace]))
 
@@ -13,6 +14,7 @@
    :builder (fn [^js yargs]
               (-> yargs
                   (.command (clj->js sdk.init/command))
+                  (.command (clj->js sdk.options/command))
                   (.command (clj->js sdk.core/command))
                   (.command (clj->js sdk.resource/command))
                   (.command (clj->js sdk.workspace/command))

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
@@ -2,8 +2,6 @@
   "Invoke the 'sdk core authenticate' method."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   ["path" :as path])
-  (:require
    [cljs.core.async :as async :refer [<!]]
    [clojure.string :as cstr])
   (:require
@@ -26,30 +24,27 @@
               yargs)
 
    :handler (fn [args]
-              (let [args-map (js->clj args :keywordize-keys true)
-                    {:keys [host port tls]} args-map
-                    base-name (.basename path (get args-map :$0))
-                    app-name (cstr/join "." ["com" "kubelt" base-name])
-                    wallet-name (get args-map :wallet)
-                    maddr (str "/ip4/" host "/tcp/" port)
-                    scheme (if tls :https :http)]
-                (ddt.prompt/ask-password!
-                 (fn [err result]
-                   (ddt.util/exit-if err)
-                   (async/go
-                     (let [password (.-password result)
-                           wallet (<! (lib.wallet/load app-name wallet-name password))
-                           kbt (sdk/init {:crypto/wallet wallet
-                                          :p2p/read maddr
-                                          :p2p.read/scheme scheme
-                                          :p2p/write maddr
-                                          :p2p.write/scheme scheme})
-                           address (:wallet/address wallet)]
-                       (-> (sdk.core/authenticate! kbt address)
-                           (.then (fn [result]
-                                    (prn result)))
-                           (.catch (fn [e]
-                                     (println (ex-message e))
-                                     (prn (ex-data e))))
-                           (.finally (fn []
-                                       (sdk/halt! kbt))))))))))})
+              (ddt.prompt/ask-password!
+               (fn [err result]
+                 (ddt.util/exit-if err)
+                 (async/go
+                   (let [args-map (ddt.options/to-map args)
+                         ;; Load the wallet.
+                         app-name (get args-map :app-name)
+                         wallet-name (get args-map :wallet)
+                         password (.-password result)
+                         wallet (<! (lib.wallet/load app-name wallet-name password))
+                         ;; Transform command line arguments into an SDK options map.
+                         options (-> args-map
+                                     ddt.options/init-options
+                                     (assoc :crypto/wallet wallet))
+                         kbt (sdk/init options)
+                         address (:wallet/address wallet)]
+                     (-> (sdk.core/authenticate! kbt address)
+                         (.then (fn [result]
+                                  (prn result)))
+                         (.catch (fn [e]
+                                   (println (ex-message e))
+                                   (prn (ex-data e))))
+                         (.finally (fn []
+                                     (sdk/halt! kbt)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
@@ -1,0 +1,29 @@
+(ns com.kubelt.ddt.cmds.sdk.options
+  "Invoke the SDK (options) method."
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.ddt.options :as ddt.options]
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.sdk.v1 :as sdk]))
+
+(defonce command
+  {:command "options"
+   :desc "Print SDK options"
+   :requiresArg false
+
+   :builder (fn [^Yargs yargs]
+              ;; Include the common options.
+              (ddt.options/options yargs)
+              yargs)
+
+   :handler (fn [args]
+              (let [;; Convert command line arguments to a Clojure map.
+                    args-map (ddt.options/to-map args)
+                    ;; Transform command line arguments into an SDK options map.
+                    options (ddt.options/init-options args-map)
+                    kbt (sdk/init options)]
+                (if (lib.error/error? kbt)
+                  (prn (:error kbt))
+                  (let [options (sdk/options kbt)]
+                    (prn options)
+                    (sdk/halt! kbt)))))})

--- a/src/main/com/kubelt/ddt/options.cljs
+++ b/src/main/com/kubelt/ddt/options.cljs
@@ -1,18 +1,47 @@
 (ns com.kubelt.ddt.options
   "Common options various sub-commands."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   ["path" :as path])
+  (:require
+   [clojure.string :as cstr]))
 
 ;; Defaults
 ;; -----------------------------------------------------------------------------
 
+(def scheme-default
+  "http")
+
+(def scheme-choices
+  #js ["http" "https"])
+
 (def host-default
   "127.0.0.1")
 
-(def port-default
-  9061)
+(def p2p-port-default
+  8787)
+
+(def ipfs-port-default
+  5001)
 
 ;; Options
 ;; -----------------------------------------------------------------------------
+
+(def log-level
+  "log-level")
+
+(def log-config
+  #js {:describe "set the logging level"
+       :default "warn"
+       :choices #js ["log"
+                     "trace"
+                     "debug"
+                     "info"
+                     "warn"
+                     "error"
+                     "fatal"
+                     "report"
+                     "spy"]})
 
 (def tls-name
   "tls")
@@ -43,7 +72,7 @@
        :demandOption "service port is required"
        :number true
        :nargs 1
-       :default port-default})
+       :default p2p-port-default})
 
 (def wallet-name
   "wallet")
@@ -55,6 +84,81 @@
        :demandOption "wallet must be specified"
        :string true
        :nargs 1})
+
+(def ipfs-read-scheme
+  "ipfs-read-scheme")
+
+(def ipfs-read-scheme-config
+  #js {:describe "use http or https to talk to IPFS read instance"
+       :requiresArg true
+       :demandOption "scheme is required"
+       :choices scheme-choices
+       :nargs 1
+       :default scheme-default})
+
+(def ipfs-read-host
+  "ipfs-read-host")
+
+(def ipfs-read-host-config
+  #js {:describe "host address of IPFS read instance"
+       :requiresArg true
+       :demandOption "address is required"
+       :string true
+       :nargs 1
+       :default host-default})
+
+(def ipfs-read-port
+  "ipfs-read-port")
+
+(def ipfs-read-port-config
+  #js {:describe "port of IPFS read instance"
+       :requiresArg true
+       :demandOption "port is required"
+       :number true
+       :nargs 1
+       :default ipfs-port-default})
+
+(def ipfs-write-scheme
+  "ipfs-write-scheme")
+
+(def ipfs-write-scheme-config
+  #js {:describe "use http or https to talk to IPFS write instance"
+       :requiresArg true
+       :demandOption "scheme is required"
+       :choices scheme-choices
+       :nargs 1
+       :default scheme-default})
+
+(def ipfs-write-host
+  "ipfs-write-host")
+
+(def ipfs-write-host-config
+  #js {:describe "address of IPFS write instance"
+       :requiresArg true
+       :demandOption "address is required"
+       :string true
+       :nargs 1
+       :default host-default})
+
+(def ipfs-write-port
+  "ipfs-write-port")
+
+(def ipfs-write-port-config
+  #js {:describe "port of IPFS write instance"
+       :requiresArg true
+       :demandOption "port is required"
+       :number true
+       :nargs 1
+       :default ipfs-port-default})
+
+(def jwt-name
+  "jwt")
+
+(def jwt-config
+  #js {:describe "A core name and associated JWT"
+       :requiresArg true
+       :array true
+       :nargs 2})
 
 ;; All of these options are required. NB: the options with supplied
 ;; defaults won't cause an error if not supplied by user.
@@ -68,15 +172,90 @@
 
 (defn options
   [yargs]
+  ;; Add --log-level option
+  (.option yargs log-level log-config)
   ;; Add --(no-)tls option
   (.option yargs tls-name tls-config)
   ;; Add --host option
   (.option yargs host-name host-config)
   ;; Add --port option
   (.option yargs port-name port-config)
+  ;; Add --ipfs-read-scheme
+  (.option yargs ipfs-read-scheme ipfs-read-scheme-config)
+  ;; Add --ipfs-read-host option
+  (.option yargs ipfs-read-host ipfs-read-host-config)
+  ;; Add --ipfs-read-port option
+  (.option yargs ipfs-read-port ipfs-read-port-config)
+  ;; Add --ipfs-write-scheme
+  (.option yargs ipfs-write-scheme ipfs-write-scheme-config)
+  ;; Add --ipfs-write-host option
+  (.option yargs ipfs-write-host ipfs-write-host-config)
+  ;; Add --ipfs-write-port option
+  (.option yargs ipfs-write-port ipfs-write-port-config)
   ;; Add --wallet option
   (.option yargs wallet-name wallet-config)
+  ;; Add --jwt option
+  (.option yargs jwt-name jwt-config)
   ;; Indicate which options must be provided
   (.demandOption yargs required-options)
   ;; Pretend like this is functional
   yargs)
+
+
+(defn to-map
+  "Convert arguments object to a Clojure map, ensuring that common options
+  are transformed appropriately."
+  [args]
+  (let [m (js->clj args :keywordize-keys true)
+        ;; Get the name of the application that was invoked; store in
+        ;; the arguments map as something that is namespace qualified,
+        ;; i.e. com.kubelt.$name.
+        base-name (.basename path (get m :$0))
+        app-name (cstr/join "." ["com" "kubelt" base-name])
+        ;; Store the p2p service coordinates as a multiaddress.
+        host (get m :host)
+        port (get m :port)
+        tls (get m :tls)
+        p2p-maddr (cstr/join "/" ["" "ip4" host "tcp" port])
+        p2p-scheme (if tls :https :http)
+        ;; Store coordinates of IPFS read host as a multiaddress.
+        ipfs-read-host (get m :ipfs-read-host)
+        ipfs-read-port (get m :ipfs-read-port)
+        ipfs-read (cstr/join "/" ["" "ip4" ipfs-read-host "tcp" ipfs-read-port])
+        ipfs-read-scheme (keyword (get m :ipfs-read-scheme))
+        ;; Store coordinates of IPFS write host as a multiaddress.
+        ipfs-write-host (get m :ipfs-write-host)
+        ipfs-write-port (get m :ipfs-write-port)
+        ipfs-write (cstr/join "/" ["" "ip4" ipfs-write-host "tcp" ipfs-write-port])
+        ipfs-write-scheme (keyword (get m :ipfs-write-scheme))
+        ;; Turn a sequence of core names and JWT strings into a map:
+        ;; ["aaa" "bbb" "ccc" "ddd"]
+        ;; => {"aaa" "bbb", "ccc" "ddd"}
+        jwts (get m :jwt)
+        credentials (apply hash-map jwts)]
+    (-> m
+        (assoc :app-name app-name)
+        (assoc :p2p-scheme p2p-scheme)
+        (assoc :p2p-maddr p2p-maddr)
+        (assoc :ipfs-read ipfs-read)
+        (assoc :ipfs-read-scheme ipfs-read-scheme)
+        (assoc :ipfs-write ipfs-write)
+        (assoc :ipfs-write-scheme ipfs-write-scheme)
+        (assoc :credentials credentials)
+        (update :log-level keyword))))
+
+(defn init-options
+  "Transform an argument map into a map of options that can be used to
+  initialize the SDK. The argument map should contain arguments provided
+  on the command line, and have been transformed from a JavaScript
+  object to a Clojure map using (to-map)."
+  [m]
+  {:pre [(map? m)]}
+  {:credential/jwt (get m :credentials)
+   :log/level (get m :log-level)
+   :ipfs/read (get m :ipfs-read)
+   :ipfs.read/scheme (get m :ipfs-read-scheme)
+   :ipfs/write (get m :ipfs-write)
+   :ipfs.write/scheme (get m :ipfs-write-scheme)
+   :p2p/scheme (get m :p2p-scheme)
+   :p2p/multiaddr (get m :p2p-maddr)})

--- a/src/main/com/kubelt/ipfs/client.cljc
+++ b/src/main/com/kubelt/ipfs/client.cljc
@@ -339,12 +339,14 @@
              ;; write nodes.
              (-> (lib.promise/all [read-p write-p])
                  (.then (fn [[read-info write-info]]
-                          ;; Returns the final shape of the client map.
-                          ;;(merge options read-info))
-                          (-> {:com.kubelt/type :kubelt.type/ipfs-client
-                               :http/client client}
-                              (assoc :node/read read-info)
-                              (assoc :node/write write-info))))))))))))
+                            ;; Returns the final shape of the client map.
+                            ;;(merge options read-info))
+                          (let [data (-> {:com.kubelt/type :kubelt.type/ipfs-client
+                                          :http/client client}
+                                         (assoc :node/read read-info)
+                                         (assoc :node/write write-info))]
+                            (reset! (:started options) data)
+                            data)))))))))))
 
 #?(:cljs
    (defn init-js

--- a/src/main/com/kubelt/ipfs/client.cljc
+++ b/src/main/com/kubelt/ipfs/client.cljc
@@ -8,6 +8,7 @@
    [malli.error :as me])
   (:require
    [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.promise :as lib.promise]
    [com.kubelt.ipfs.api :as ipfs.api]
    [com.kubelt.ipfs.v0.node :as v0.node]
    [com.kubelt.ipfs.spec :as ipfs.spec]
@@ -64,25 +65,62 @@
 ;; call (if any), the value that was specified as the default during
 ;; client creation (if any), or the default (if all else fails).
 (defn- request->scheme
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/scheme)
-   (get client :http/scheme)
+   (let [rw (name rw)
+         kw (keyword rw "scheme")]
+     (get client kw))
    default-scheme))
 
 (defn- request->domain
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/domain)
-   (get client :http/host)
+   (let [rw (name rw)
+         kw (keyword rw "host")]
+     (get client kw))
    default-host))
 
 (defn- request->port
-  [client request]
+  [request client rw]
+  {:pre [(contains? #{:read :write} rw)]}
   (or
    (get request :uri/port)
-   (get client :http/port)
+   ;; We want to get the value of either :read/port or :write/port.
+   ;; The rw parameter is either :read or :write
+   (let [rw (name rw)
+         kw (keyword rw "port")]
+     (get client kw))
    default-port))
+
+(defn- request-for
+  "Takes a client map containing configuration options, a request map
+  defining the request to perform, and a keyword indicating whether the
+  request to be performed should be directed at the :read IPFS node or
+  the :write IPFS node. Returns an updated request map with the target
+  URL and request options filled in using values taken from the client
+  configuration."
+  [request client read-or-write]
+  {:pre [(contains? #{:read :write} read-or-write)]}
+  (let [;; Get the HTTP request scheme for the request.
+        scheme (request->scheme request client read-or-write)
+        ;; Get the HTTP host for the request.
+        domain (request->domain request client read-or-write)
+        ;; Get the HTTP port for the request.
+        port (request->port request client read-or-write)
+        ;; Should response body be keywordized?
+        keywordize? (get client :client/keywordize?)
+        ;; Should response body be validated?
+        validate? (get client :client/validate?)]
+    (-> request
+        (assoc :uri/scheme scheme)
+        (assoc :uri/domain domain)
+        (assoc :uri/port port)
+        (assoc :response/keywordize? keywordize?)
+        (assoc :response/validate? validate?))))
 
 (defn- extract-node-id
   [m]
@@ -129,6 +167,40 @@
   (if-let [protocol-version (get m :protocol-version)]
     protocol-version
     :unknown))
+
+#?(:cljs
+   (defn- info-request
+     "Return a promise that resolves to a map of details about the remote
+     node. This node information, e.g. node type (Go, JavaScript) is used
+     to paper over differences in the various IPFS implementations."
+     [client options read-or-write]
+     (let [request (-> (v0.node/id)
+                       :http/request
+                       (request-for options read-or-write))
+           ;; TODO validate response
+           info-p (proto.http/request! client request)]
+       (-> info-p
+           (.then (fn [info]
+                    (let [;; Extract some information from the response and
+                          ;; store directly in the client. Some of these are
+                          ;; the criteria along which we expect node behaviour
+                          ;; to vary.
+                          node-id (extract-node-id info)
+                          node-key (extract-node-key info)
+                          node-type (extract-node-type info)
+                          node-version (extract-node-version info)
+                          node-addresses (extract-node-addresses info)
+                          node-proto-version (extract-node-proto-version info)
+                          node-protocols (extract-node-protocols info)]
+                      {:ipfs.node/id node-id
+                       :ipfs.node/key node-key
+                       :ipfs.node/type node-type
+                       :ipfs.node/version node-version
+                       :ipfs.node/protocol node-proto-version
+                       :ipfs.node/addresses node-addresses
+                       :ipfs.node/protocols node-protocols})))
+           (.catch (fn [e]
+                     {}))))))
 
 ;; Public
 ;; -----------------------------------------------------------------------------
@@ -224,17 +296,24 @@
   :client/node-info? - fetch and store node information in client
   :client/timeout - request timeout in milliseconds
   :http/client - a pre-created HTTP client (must satisfy HttpClient)
-  :http/scheme - the transport scheme to use, e.g. :http, :https
-  :http/host - the IP address of the IPFS host
-  :http/port - the listening port of the IPFS host"
+  :read/scheme - the HTTP scheme to use for reads, e.g. :http, :https
+  :read/host - the IP address of the IPFS read host
+  :read/port - the listening port of the IPFS read host
+  :write/scheme - the HTTP scheme to use for writes, e.g. :http, :https
+  :write/host - the IP address of the IPFS write host
+  :write/port - the listening port of the IPFS write host"
   ([]
    (init {}))
   ([options]
-   (let [default-options {:http/scheme default-scheme
-                          :http/host default-host
-                          :http/port default-port
+   (let [default-options {:read/scheme default-scheme
+                          :read/host default-host
+                          :read/port default-port
+                          :write/scheme default-scheme
+                          :write/host default-host
+                          :write/port default-port
                           :client/validate? true
-                          :client/keywordize? true}
+                          :client/keywordize? true
+                          :client/timeout 5000}
          options (merge default-options options)]
      ;; Validate the options.
      (if-not (malli/validate ipfs.spec/init-options options)
@@ -249,52 +328,23 @@
          (if-not (satisfies? proto.http/HttpClient client)
            {:com.kubelt/type :kubelt.type/error
             :error "invalid HTTP client"}
-           ;; The final shape of the client map.
-           (merge
-            {:com.kubelt/type :kubelt.type/ipfs-client
-             ;;:client/options options
-             :http/client client}
-            ;; Fetch and store node information, e.g. node type (Go,
-            ;; JavaScript) unless told not to. We use this information
-            ;; to paper over differences in the various implementations.
-            (merge options
-                   (if (get options :client/node-info? true)
-                     (let [id-request (-> (v0.node/id) :http/request)
-                           ;; Get the HTTP request scheme for the request.
-                           request-scheme (request->scheme options id-request)
-                           ;; Get the HTTP host for the request.
-                           request-domain (request->domain options id-request)
-                           ;; Get the HTTP port for the request.
-                           request-port (request->port options id-request)
-                           ;; We always keywordize and validate this
-                           ;; response so we're storing data in known
-                           ;; format.
-                           id-request (-> id-request
-                                          (assoc :uri/scheme request-scheme)
-                                          (assoc :uri/domain request-domain)
-                                          (assoc :uri/port request-port)
-                                          (assoc :response/keywordize? true))
-                           ;; TODO validate response
-                           info (proto.http/request! client id-request)
-                           ;; Extract some information from the response and
-                           ;; store directly in the client. Some of these are
-                           ;; the criteria along which we expect node behaviour
-                           ;; to vary.
-                           node-id (extract-node-id info)
-                           node-key (extract-node-key info)
-                           node-type (extract-node-type info)
-                           node-version (extract-node-version info)
-                           node-addresses (extract-node-addresses info)
-                           node-proto-version (extract-node-proto-version info)
-                           node-protocols (extract-node-protocols info)]
-                       {:ipfs.node/id node-id
-                        :ipfs.node/key node-key
-                        :ipfs.node/type node-type
-                        :ipfs.node/version node-version
-                        :ipfs.node/protocol node-proto-version
-                        :ipfs.node/addresses node-addresses
-                        :ipfs.node/protocols node-protocols})
-                     {})))))))))
+           (let [node-info? (get options :client/node-info? true)
+                 read-p (if-not node-info?
+                          (lib.promise/resolved {})
+                          (info-request client options :read))
+                 write-p (if-not node-info?
+                           (lib.promise/resolved {})
+                           (info-request client options :write))]
+             ;; TODO make simultaneous requests for info to read and
+             ;; write nodes.
+             (-> (lib.promise/all [read-p write-p])
+                 (.then (fn [[read-info write-info]]
+                          ;; Returns the final shape of the client map.
+                          ;;(merge options read-info))
+                          (-> {:com.kubelt/type :kubelt.type/ipfs-client
+                               :http/client client}
+                              (assoc :node/read read-info)
+                              (assoc :node/write write-info))))))))))))
 
 #?(:cljs
    (defn init-js
@@ -345,32 +395,23 @@
     (lib.error/explain ipfs.spec/api-resource request-map)
     ;; Perform the request!
     :else
-    (let [;; TODO allow per-request override of keywordizing?
-          keywordize? (get client :client/keywordize? true)
-          ;; TODO perform validation if asked for.
-          ;; TODO allow per-request override of validation?
-          validate? (get client :client/validate? false)
-          ;; This stored map contains the HTTP request parameters we can
-          ;; pass to our HTTP client (once we've added a few missing
-          ;; bits).
-          request (get request-map :http/request)
-          ;; Get the HTTP request scheme for the request.
-          request-scheme (request->scheme client request)
-          ;; Get the HTTP host for the request.
-          request-domain (request->domain client request)
-          ;; Get the HTTP port for the request.
-          request-port (request->port client request)
-          ;; Add the request target details to the request map, along
-          ;; with any additional parameters that control how the result
-          ;; will be performed and/or the response processed.
-          request (-> request
-                      (assoc :uri/scheme request-scheme)
-                      (assoc :uri/domain request-domain)
-                      (assoc :uri/port request-port)
-                      ;; Should response body be keywordized?
-                      (assoc :response/keywordize? keywordize?)
-                      ;; Should response body be validated?
-                      (assoc :response/validate? validate?))
+    ;; TODO allow per-request override of keywordizing?
+    ;; TODO perform validation if asked for.
+    ;; TODO allow per-request override of validation?
+    ;; TODO categorize requests as being reads or writes and
+    ;; directing to the appropriate IPFS node (allowing user
+    ;; override).
+    (let [;; This stored map contains the HTTP request parameters we can
+          ;; pass to our HTTP client once we've added a few missing
+          ;; bits. The HTTP request is defined by the map available at
+          ;; key :http/request, and we fill it in using (request-for).
+          ;;
+          ;; This adds the request target details to the request map,
+          ;; along with any additional parameters that control how the
+          ;; result will be validated and/or the response processed.
+          request (-> request-map
+                      :http/request
+                      (request-for client :read))
           ;; TODO invoke callbacks if provided
           ;; TODO supply promise/channel if requested
           http-client (get client :http/client)

--- a/src/main/com/kubelt/ipfs/spec.cljc
+++ b/src/main/com/kubelt/ipfs/spec.cljc
@@ -102,16 +102,29 @@
      :description "An existing HTTP client to use."}
     ;; TODO tighten this up; satisfies? HttpClient
     :any]
-   [:http/scheme
+   [:read/scheme
     {:optional true
      :description "The protocol scheme to use to talk to IPFS"
      :example :http}
     spec.http/scheme]
-   [:http/host
+   [:read/host
     {:optional true
      :description "An IP address for the IPFS server"}
     spec.http/host]
-   [:http/port
+   [:read/port
+    {:optional true
+     :description "A TCP port for the IPFS server"}
+    spec.http/port]
+   [:write/scheme
+    {:optional true
+     :description "The protocol scheme to use to talk to IPFS"
+     :example :http}
+    spec.http/scheme]
+   [:write/host
+    {:optional true
+     :description "An IP address for the IPFS server"}
+    spec.http/host]
+   [:write/port
     {:optional true
      :description "A TCP port for the IPFS server"}
     spec.http/port]])

--- a/src/main/com/kubelt/lib/config.cljs
+++ b/src/main/com/kubelt/lib/config.cljs
@@ -4,21 +4,38 @@
   (:require
    [clojure.string :as str]))
 
+;; Default logging level.
+(def log-level :warn)
+
 ;; Default configuration
 ;; -----------------------------------------------------------------------------
 
-(def log-level :info)
+;; By default we look for a local IPFS node.
+(def default-ipfs
+  {:ipfs/read "/ip4/127.0.0.1/tcp/5001"
+   :ipfs.read/scheme :http
+   :ipfs/write "/ip4/127.0.0.1/tcp/5001"
+   :ipfs.write/scheme :http})
 
 (def default-p2p
-  {:p2p/read "/ip4/127.0.0.1/tcp/8787"
-   :p2p/write "/ip4/127.0.0.1/tcp/8787"})
+  {:p2p/multiaddr "/ip4/127.0.0.1/tcp/8787"
+   :p2p/scheme :http})
 
 (def default-logging
-  {:logging/min-level log-level})
+  {:log/level log-level})
+
+;; By default we have no JWTs available when initializing the SDK. When
+;; JWTs are supplied, it should be as a map from core name to
+;; corresponding JWT:
+;; {"0xF4E9A36d4D37B1F83706c58eF8e3AF559F4c1E2E" "<header>.<payload>.<signature>"}
+(def default-credentials
+  {:credential/jwt {}})
 
 (def default-config
-  (merge default-p2p
-         default-logging))
+  (merge default-ipfs
+         default-p2p
+         default-logging
+         default-credentials))
 
 ;; Internal
 ;; -----------------------------------------------------------------------------
@@ -43,4 +60,4 @@
       ;; Fix up any config map values that didn't translate from
       ;; JavaScript.
       (-> config
-          (update-in [:logging/min-level] log-level->keyword)))))
+          (update-in [:log/level] log-level->keyword)))))

--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -39,6 +39,8 @@
 (def system
   {;; These empty defaults should be overridden from the SDK init
    ;; options map.
+   :system/started nil
+
    :log/level nil
    :ipfs/read-addr nil
    :ipfs/read-scheme nil
@@ -53,7 +55,8 @@
                              :ipfs/multiaddr (ig/ref :ipfs/read-addr)}
                  :ipfs/write {:http/scheme (ig/ref :ipfs/write-scheme)
                               :ipfs/multiaddr (ig/ref :ipfs/write-addr)}
-                 :client/http (ig/ref :client/http)}
+                 :client/http (ig/ref :client/http)
+                 :started (ig/ref :system/started)}
    ;; Our connection to the Kubelt p2p system.
    :client/p2p {:http/scheme (ig/ref :p2p/scheme)
                 :p2p/multiaddr (ig/ref :p2p/multiaddr)}
@@ -70,11 +73,15 @@
 ;; :log/level
 ;; -----------------------------------------------------------------------------
 
+(defmethod ig/init-key :system/started [_ _]
+  (atom nil))
+
 (defmethod ig/init-key :log/level [_ min-level]
   ;; Initialize the logging system.
   (when min-level
     (log/merge-config! {:min-level min-level}))
   min-level)
+
 
 ;; :ipfs/read-addr
 ;; -----------------------------------------------------------------------------
@@ -169,6 +176,7 @@
                      :write/scheme write-scheme
                      :write/host write-host
                      :write/port write-port
+                     :started (:started value)
                      ;; Set a global timeout for *all* requests:
                      ;;:client/timeout 5000
                      }]

--- a/src/main/com/kubelt/lib/p2p.cljs
+++ b/src/main/com/kubelt/lib/p2p.cljs
@@ -15,9 +15,9 @@
   [sys core]
   {:pre [(string? core)]}
   (let [client (get sys :client/http)
-        scheme (get-in sys [:client/p2p :p2p/read :http/scheme])
-        host (get-in sys [:client/p2p :p2p/write :address/host])
-        port (get-in sys [:client/p2p :p2p/write :address/port])
+        scheme (get-in sys [:client/p2p :http/scheme])
+        host (get-in sys [:client/p2p :http/host])
+        port (get-in sys [:client/p2p :http/port])
 
         wallet (get sys :crypto/wallet)
         address (get wallet :wallet/address)
@@ -47,9 +47,10 @@
   [sys core nonce signature]
   {:pre [(every? string? [core nonce])]}
   (let [client (get sys :client/http)
-        scheme (get-in sys [:client/p2p :p2p/read :http/scheme])
-        host (get-in sys [:client/p2p :p2p/write :address/host])
-        port (get-in sys [:client/p2p :p2p/write :address/port])
+        scheme (get-in sys [:client/p2p :http/scheme])
+        host (get-in sys [:client/p2p :http/host])
+        port (get-in sys [:client/p2p :http/port])
+
         body {:nonce nonce :signature signature}
         body-str (lib.json/edn->json-str body)
 

--- a/src/main/com/kubelt/lib/vault.cljc
+++ b/src/main/com/kubelt/lib/vault.cljc
@@ -1,0 +1,28 @@
+(ns com.kubelt.lib.vault
+  "Work with a 'vault' that stores session tokens."
+  {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"})
+
+;; Public
+;; -----------------------------------------------------------------------------
+
+(defn vault?
+  [x]
+  (and
+   (map? x)
+   (= :kubelt.type/vault (:com.kubelt/type x))))
+
+(defn tokens
+  "Return a map from core name to JWT token strings."
+  [vault]
+  {:pre [(vault? vault)]}
+  (letfn [(token-for [m [core decoded-jwt]]
+            ;; The original JWT string parts are preserved as :token
+            ;; and :signature when decoding a JWT
+            ;; using (lib.jwt/decode). We just stitch those pieces back
+            ;; together to get the original JWT.
+            (let [token (:token decoded-jwt)
+                  signature (:signature decoded-jwt)
+                  jwt-str (str token "." signature)]
+              (assoc m core jwt-str)))]
+    (let [token-map (:vault/tokens vault)]
+      (reduce token-for {} token-map))))

--- a/src/main/com/kubelt/sdk.cljs
+++ b/src/main/com/kubelt/sdk.cljs
@@ -46,6 +46,7 @@
 (def node-v1
   #js {:init sdk.v1/init-js
        :halt sdk.v1/halt-js!
+       :options sdk.v1/options-js
 
        ;; core
        :core #js {:authenticate sdk.v1.core/authenticate-js!

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -95,3 +95,24 @@
        (if (lib.error/error? result)
          (reject (clj->js result))
          (resolve result))))))
+
+;; options
+;; -----------------------------------------------------------------------------
+
+(defn options
+  "Return the options map representing the SDK state, allowing for the SDK
+  to be re-instantiated."
+  [system]
+  {:pre [(map? system)]}
+  (lib.init/options system))
+
+(defn options-js
+  "Return an options object for the SDK from a JavaScript context."
+  [system]
+  {:pre [(map? system)] :post [(promise? %)]}
+  (promise
+   (fn [resolve reject]
+     (let [result (options system)]
+       (if (lib.error/error? result)
+         (reject (clj->js result))
+         (resolve (clj->js result)))))))

--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -10,10 +10,6 @@
 ;; the "Schema AST" map-based syntax instead as that should be faster to
 ;; instantiate for large schemas.
 
-(def platform
-  "Supported execution environments."
-  [:enum :platform.type/node :platform.type/browser :platform.type/jvm])
-
 (def logging-level
   "Logging levels defined by the timbre logging library."
   [:and
@@ -32,19 +28,28 @@
 (def multiaddr
   [:re #"^(/(\w+)/(\w+|\.)+)+$"])
 
+(def credentials
+  [:and
+   {:description "A map from core name to JWT strings."
+    :example {"0x123abc" "<header>.<payload>.<signature>"}}
+   ;; TODO flesh this out
+   [:map-of :string :string]])
+
 ;; config
 ;; -----------------------------------------------------------------------------
 ;; Specifies the the configuration map passed to the sdk/init function.
 
 (def config
   [:map {:closed true}
-   [:sys/platform {:optional true} platform]
-   [:logging/min-level {:optional true} logging-level]
+   [:log/level {:optional true} logging-level]
+   [:credential/jwt {:optional true} credentials]
    [:crypto/wallet {:optional true} spec.wallet/wallet]
-   [:p2p/read {:optional true} multiaddr]
-   [:p2p.read/scheme {:optional true} spec.http/scheme]
-   [:p2p/write {:optional true} multiaddr]
-   [:p2p.write/scheme {:optional true} spec.http/scheme]])
+   [:ipfs/read {:optional true} multiaddr]
+   [:ipfs.read/scheme {:optional true} spec.http/scheme]
+   [:ipfs/write {:optional true} multiaddr]
+   [:ipfs.write/scheme {:optional true} spec.http/scheme]
+   [:p2p/multiaddr {:optional true} multiaddr]
+   [:p2p/scheme {:optional true} spec.http/scheme]])
 
 (def config-schema
   "Schema for SDK configuration map."

--- a/src/test/lib/config_test.cljs
+++ b/src/test/lib/config_test.cljs
@@ -17,31 +17,31 @@
 
   (testing "logging levels"
     (testing "log level"
-      (let [options {:logging/min-level :log}]
+      (let [options {:log/level :log}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :log is valid")))
     (testing "trace level"
-      (let [options {:logging/min-level :trace}]
+      (let [options {:log/level :trace}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :trace is valid")))
     (testing "debug level"
-      (let [options {:logging/min-level :debug}]
+      (let [options {:log/level :debug}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :debug is valid")))
     (testing "info level"
-      (let [options {:logging/min-level :info}]
+      (let [options {:log/level :info}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :info is valid")))
     (testing "warn level"
-      (let [options {:logging/min-level :warn}]
+      (let [options {:log/level :warn}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :warn is valid")))
     (testing "error level"
-      (let [options {:logging/min-level :error}]
+      (let [options {:log/level :error}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :error is valid")))
     (testing "fatal level"
-      (let [options {:logging/min-level :fatal}]
+      (let [options {:log/level :fatal}]
         (is (malli/validate spec.config/config options)
             "logging min-level of :fatal is valid"))))
 


### PR DESCRIPTION
after sdk init ... 
`(:client/ipfs sdk)` => `#object[Promise [object Promise]]`


`@(:system/started sdk)` => `{:com.kubelt/type :kubelt.type/ipfs-client, :http/client #com.kubelt.lib.http.node.HttpClient{}, :node/read {:ipfs.node/id :unknown, :ipfs.node/key :unknown, :ipfs.node/type :unknown, :ipfs.node/version :unknown, :ipfs.node/protocol :unknown, :ipfs.node/addresses :unknown, :ipfs.node/protocols :unknown}, :node/write {:ipfs.node/id :unknown, :ipfs.node/key :unknown, :ipfs.node/type :unknown, :ipfs.node/version :unknown, :ipfs.node/protocol :unknown, :ipfs.node/addresses :unknown, :ipfs.node/protocols :unknown}}` 

so the idea is adding another function to sdk api

```
(defn started? [sdk]
   @(:system/started sdk))
```