### PR TITLE
fix(ddt): update path commands to output correct paths

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/path/cache.cljs
+++ b/src/main/com/kubelt/ddt/cmds/path/cache.cljs
@@ -3,6 +3,7 @@
   path."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.path :as path]))
 
 (defonce command
@@ -14,6 +15,6 @@
               yargs)
 
    :handler (fn [args]
-              (let [{app-name :$0}
-                    (js->clj args :keywordize-keys true)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
                 (println (path/cache app-name))))})

--- a/src/main/com/kubelt/ddt/cmds/path/config.cljs
+++ b/src/main/com/kubelt/ddt/cmds/path/config.cljs
@@ -3,6 +3,7 @@
   path."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.path :as path]))
 
 (defonce command
@@ -14,6 +15,6 @@
               yargs)
 
    :handler (fn [args]
-              (let [{app-name :$0}
-                    (js->clj args :keywordize-keys true)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
                 (println (path/config app-name))))})

--- a/src/main/com/kubelt/ddt/cmds/path/data.cljs
+++ b/src/main/com/kubelt/ddt/cmds/path/data.cljs
@@ -2,6 +2,7 @@
   "Invoke the path > data method to return the system configuration path."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.path :as path]))
 
 (defonce command
@@ -13,6 +14,6 @@
               yargs)
 
    :handler (fn [args]
-              (let [{app-name :$0}
-                    (js->clj args :keywordize-keys true)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
                 (println (path/data app-name))))})

--- a/src/main/com/kubelt/ddt/cmds/path/log.cljs
+++ b/src/main/com/kubelt/ddt/cmds/path/log.cljs
@@ -2,6 +2,7 @@
   "Invoke the path > log method to return the system configuration path."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.path :as path]))
 
 (defonce command
@@ -13,6 +14,6 @@
               yargs)
 
    :handler (fn [args]
-              (let [{app-name :$0}
-                    (js->clj args :keywordize-keys true)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
                 (println (path/log app-name))))})

--- a/src/main/com/kubelt/ddt/cmds/path/temp.cljs
+++ b/src/main/com/kubelt/ddt/cmds/path/temp.cljs
@@ -2,6 +2,7 @@
   "Invoke the path > temp method to return the system configuration path."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.lib.path :as path]))
 
 (defonce command
@@ -13,6 +14,6 @@
               yargs)
 
    :handler (fn [args]
-              (let [{app-name :$0}
-                    (js->clj args :keywordize-keys true)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
                 (println (path/temp app-name))))})


### PR DESCRIPTION
# Description

After recent changes to standard directory locations, these utility commands needed to be updated.

## Type of change

Please delete options that are not relevant.

- [x] Clean-up and refactor
