### PR TITLE
Add default multiaddr malli.generator in cljs

### DIFF
--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -26,7 +26,11 @@
 ;; TODO refine this regex to better match a multiaddr
 ;; TODO move into com.kubelt.spec.multiaddr
 (def multiaddr
-  [:re #"^(/(\w+)/(\w+|\.)+)+$"])
+  [:re #?(;; cljs can't generate re values  so providing a default one
+          :cljs {:gen/fmap (fn [_] "/ip4/127.0.0.1/tcp/5001")}
+          ;; TODO: add test.check dependency, required for clj env
+          :clj {})
+   #"^(/(\w+)/(\w+|\.)+)+$"])
 
 (def credentials
   [:and


### PR DESCRIPTION
# Description

- Adapt sdk config spec to work with malli.generator

To try it:
```clojure 
(malli.generator/generate com.kubelt.spec.config/config)
;; 
{:ipfs.read/scheme :http,
 :ipfs/write "/ip4/127.0.0.1/tcp/5001",
 :ipfs.write/scheme :https,
 :p2p/multiaddr "/ip4/127.0.0.1/tcp/5001"}
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
