### PR TITLE
chore(sdk): rename options for consistency

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/sdk/init.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/init.cljs
@@ -2,9 +2,6 @@
   "Invoke the SDK (init) method."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   ["fs" :as fs]
-   ["path" :as path])
-  (:require
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.sdk.v1 :as sdk]))
 

--- a/src/main/com/kubelt/ddt/cmds/wallet/sign.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/sign.cljs
@@ -7,23 +7,27 @@
    [cljs.core.async :as async :refer [<!]]
    [clojure.string :as cstr])
   (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
    [com.kubelt.ddt.util :as ddt.util]
    [com.kubelt.lib.base64 :as lib.base64]
    [com.kubelt.lib.wallet :as lib.wallet]))
 
 (defonce command
-  {:command "sign <wallet> <data>"
+  {:command "sign <data>"
    :desc "Sign some base64-encoded data"
    :requiresArg false
 
    :builder (fn [^Yargs yargs]
+              ;; Include common options.
+              (ddt.options/options yargs)
               yargs)
 
    :handler (fn [args]
-              (let [args-map (js->clj args :keywordize-keys true)
-                    {:keys [wallet data]} args-map
-                    app-name (get args-map :$0)]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)
+                    wallet (get args-map :wallet)
+                    data (get args-map :data)]
                 ;; Check to see if named wallet exists.
                 (if-not (lib.wallet/has-wallet? app-name wallet)
                   (let [message (str "wallet '" wallet "' doesn't exist")]
@@ -35,6 +39,7 @@
                      (let [password (.-password result)
                            wallet (<! (lib.wallet/load app-name wallet password))
                            sign-fn (get wallet :wallet/sign-fn)
-                           decoded (lib.base64/decode-string data)
-                           signature (sign-fn decoded)]
-                       (println signature)))))))})
+                           decoded (lib.base64/decode-string data)]
+                       (-> (sign-fn decoded)
+                           (.then (fn [signature]
+                                    (println signature))))))))))})

--- a/src/main/com/kubelt/ddt/options.cljs
+++ b/src/main/com/kubelt/ddt/options.cljs
@@ -221,12 +221,12 @@
         ;; Store coordinates of IPFS read host as a multiaddress.
         ipfs-read-host (get m :ipfs-read-host)
         ipfs-read-port (get m :ipfs-read-port)
-        ipfs-read (cstr/join "/" ["" "ip4" ipfs-read-host "tcp" ipfs-read-port])
+        ipfs-read-maddr (cstr/join "/" ["" "ip4" ipfs-read-host "tcp" ipfs-read-port])
         ipfs-read-scheme (keyword (get m :ipfs-read-scheme))
         ;; Store coordinates of IPFS write host as a multiaddress.
         ipfs-write-host (get m :ipfs-write-host)
         ipfs-write-port (get m :ipfs-write-port)
-        ipfs-write (cstr/join "/" ["" "ip4" ipfs-write-host "tcp" ipfs-write-port])
+        ipfs-write-maddr (cstr/join "/" ["" "ip4" ipfs-write-host "tcp" ipfs-write-port])
         ipfs-write-scheme (keyword (get m :ipfs-write-scheme))
         ;; Turn a sequence of core names and JWT strings into a map:
         ;; ["aaa" "bbb" "ccc" "ddd"]
@@ -237,9 +237,9 @@
         (assoc :app-name app-name)
         (assoc :p2p-scheme p2p-scheme)
         (assoc :p2p-maddr p2p-maddr)
-        (assoc :ipfs-read ipfs-read)
+        (assoc :ipfs-read-maddr ipfs-read-maddr)
         (assoc :ipfs-read-scheme ipfs-read-scheme)
-        (assoc :ipfs-write ipfs-write)
+        (assoc :ipfs-write-maddr ipfs-write-maddr)
         (assoc :ipfs-write-scheme ipfs-write-scheme)
         (assoc :credentials credentials)
         (update :log-level keyword))))
@@ -253,9 +253,9 @@
   {:pre [(map? m)]}
   {:credential/jwt (get m :credentials)
    :log/level (get m :log-level)
-   :ipfs/read (get m :ipfs-read)
+   :ipfs.read/multiaddr (get m :ipfs-read-maddr)
    :ipfs.read/scheme (get m :ipfs-read-scheme)
-   :ipfs/write (get m :ipfs-write)
+   :ipfs.write/multiaddr (get m :ipfs-write-maddr)
    :ipfs.write/scheme (get m :ipfs-write-scheme)
    :p2p/scheme (get m :p2p-scheme)
    :p2p/multiaddr (get m :p2p-maddr)})

--- a/src/main/com/kubelt/lib/config.cljs
+++ b/src/main/com/kubelt/lib/config.cljs
@@ -12,9 +12,9 @@
 
 ;; By default we look for a local IPFS node.
 (def default-ipfs
-  {:ipfs/read "/ip4/127.0.0.1/tcp/5001"
+  {:ipfs.read/multiaddr "/ip4/127.0.0.1/tcp/5001"
    :ipfs.read/scheme :http
-   :ipfs/write "/ip4/127.0.0.1/tcp/5001"
+   :ipfs.write/multiaddr "/ip4/127.0.0.1/tcp/5001"
    :ipfs.write/scheme :http})
 
 (def default-p2p

--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -40,19 +40,19 @@
   {;; These empty defaults should be overridden from the SDK init
    ;; options map.
    :log/level nil
-   :ipfs/read-addr nil
-   :ipfs/read-scheme nil
-   :ipfs/write-addr nil
-   :ipfs/write-scheme nil
+   :ipfs.read/multiaddr nil
+   :ipfs.read/scheme nil
+   :ipfs.write/multiaddr nil
+   :ipfs.write/scheme nil
    :p2p/scheme nil
    :p2p/multiaddr nil
    ;; Our common HTTP client.
    :client/http {}
    ;; Our connection to IPFS.
-   :client/ipfs {:ipfs/read {:http/scheme (ig/ref :ipfs/read-scheme)
-                             :ipfs/multiaddr (ig/ref :ipfs/read-addr)}
-                 :ipfs/write {:http/scheme (ig/ref :ipfs/write-scheme)
-                              :ipfs/multiaddr (ig/ref :ipfs/write-addr)}
+   :client/ipfs {:ipfs/read {:http/scheme (ig/ref :ipfs.read/scheme)
+                             :ipfs/multiaddr (ig/ref :ipfs.read/multiaddr)}
+                 :ipfs/write {:http/scheme (ig/ref :ipfs.write/scheme)
+                              :ipfs/multiaddr (ig/ref :ipfs.write/multiaddr)}
                  :client/http (ig/ref :client/http)}
    ;; Our connection to the Kubelt p2p system.
    :client/p2p {:http/scheme (ig/ref :p2p/scheme)
@@ -79,26 +79,26 @@
 ;; :ipfs/read-addr
 ;; -----------------------------------------------------------------------------
 
-(defmethod ig/init-key :ipfs/read-addr [_ address]
+(defmethod ig/init-key :ipfs.read/multiaddr [_ address]
   ;; Return the multiaddress string.
   address)
 
 ;; :ipfs/read-scheme
 ;; -----------------------------------------------------------------------------
 
-(defmethod ig/init-key :ipfs/read-scheme [_ scheme]
+(defmethod ig/init-key :ipfs.read/scheme [_ scheme]
   scheme)
 
 ;; :ipfs/write-addr
 ;; -----------------------------------------------------------------------------
 
-(defmethod ig/init-key :ipfs/write-addr [_ address]
+(defmethod ig/init-key :ipfs.write/multiaddr [_ address]
   address)
 
 ;; :ipfs/write-scheme
 ;; -----------------------------------------------------------------------------
 
-(defmethod ig/init-key :ipfs/write-scheme [_ scheme]
+(defmethod ig/init-key :ipfs.write/scheme [_ scheme]
   scheme)
 
 ;; :p2p/multiaddr
@@ -269,9 +269,9 @@
         wallet (or (get options :crypto/wallet)
                    (lib.wallet/no-op))
         ;; Get the address of the IPFS node we talk to.
-        ipfs-read (get options :ipfs/read)
+        ipfs-read-maddr (get options :ipfs.read/multiaddr)
         ipfs-read-scheme (get options :ipfs.read/scheme)
-        ipfs-write (get options :ipfs/write)
+        ipfs-write-maddr (get options :ipfs.write/multiaddr)
         ipfs-write-scheme (get options :ipfs.write/scheme)
         ;; Get the address of the Kubelt gateway we talk to.
         p2p-scheme (get options :p2p/scheme)
@@ -282,10 +282,10 @@
         ;; system.
         system (-> system
                    (assoc :log/level log-level)
-                   (assoc :ipfs/read-addr ipfs-read)
-                   (assoc :ipfs/read-scheme ipfs-read-scheme)
-                   (assoc :ipfs/write-addr ipfs-write)
-                   (assoc :ipfs/write-scheme ipfs-write-scheme)
+                   (assoc :ipfs.read/multiaddr ipfs-read-maddr)
+                   (assoc :ipfs.read/scheme ipfs-read-scheme)
+                   (assoc :ipfs.write/multiaddr ipfs-write-maddr)
+                   (assoc :ipfs.write/scheme ipfs-write-scheme)
                    (assoc :p2p/scheme p2p-scheme)
                    (assoc :p2p/multiaddr p2p-multiaddr)
                    (assoc :crypto/session credentials)
@@ -305,10 +305,10 @@
 (defn options
   "Return an options map that can be used to reinitialize the SDK."
   [sys-map]
-  (let [ipfs-read (get sys-map :ipfs/read-addr)
-        ipfs-read-scheme (get sys-map :ipfs/read-scheme)
-        ipfs-write (get sys-map :ipfs/write-addr)
-        ipfs-write-scheme (get sys-map :ipfs/write-scheme)
+  (let [ipfs-read-maddr (get sys-map :ipfs.read/multiaddr)
+        ipfs-read-scheme (get sys-map :ipfs.read/scheme)
+        ipfs-write-maddr (get sys-map :ipfs.write/multiaddr)
+        ipfs-write-scheme (get sys-map :ipfs.write/scheme)
         p2p-multiaddr (get sys-map :p2p/multiaddr)
         p2p-scheme (get sys-map :p2p/scheme)
         log-level (get sys-map :log/level)
@@ -316,9 +316,9 @@
         credentials (lib.vault/tokens (:crypto/session sys-map))
         wallet (get sys-map :crypto/wallet)]
     {:log/level log-level
-     :ipfs/read ipfs-read
+     :ipfs.read/multiaddr ipfs-read-maddr
      :ipfs.read/scheme ipfs-read-scheme
-     :ipfs/write ipfs-write
+     :ipfs.write/multiaddr ipfs-write-maddr
      :ipfs.write/scheme ipfs-write-scheme
      :p2p/scheme p2p-scheme
      :p2p/multiaddr p2p-multiaddr

--- a/src/main/com/kubelt/spec/config.cljc
+++ b/src/main/com/kubelt/spec/config.cljc
@@ -44,9 +44,9 @@
    [:log/level {:optional true} logging-level]
    [:credential/jwt {:optional true} credentials]
    [:crypto/wallet {:optional true} spec.wallet/wallet]
-   [:ipfs/read {:optional true} multiaddr]
+   [:ipfs.read/multiaddr {:optional true} multiaddr]
    [:ipfs.read/scheme {:optional true} spec.http/scheme]
-   [:ipfs/write {:optional true} multiaddr]
+   [:ipfs.write/multiaddr {:optional true} multiaddr]
    [:ipfs.write/scheme {:optional true} spec.http/scheme]
    [:p2p/multiaddr {:optional true} multiaddr]
    [:p2p/scheme {:optional true} spec.http/scheme]])

--- a/src/test/lib/config_test.cljs
+++ b/src/test/lib/config_test.cljs
@@ -56,12 +56,12 @@
 
     (testing "multiaddr"
       (testing "localhost"
-        (let [options {:ipfs/read "/ip4/127.0.0.1"}]
+        (let [options {:ipfs.read/multiaddr "/ip4/127.0.0.1"}]
           (is (malli/validate spec.config/config options)
               "loopback IP is a valid network address"))
-        (let [options {:ipfs/read "/ip4/localhost"}]
+        (let [options {:ipfs.read/multiaddr "/ip4/localhost"}]
           (is (malli/validate spec.config/config options)
               "localhost is a valid network address"))
-        (let [options {:ipfs/read "/ip4/127.0.0.1/tcp/8080"}]
+        (let [options {:ipfs.read/multiaddr "/ip4/127.0.0.1/tcp/8080"}]
           (is (malli/validate spec.config/config options)
               "localhost:8080 is a valid network address"))))))


### PR DESCRIPTION
# Description

Rename some of the keys in the`init` options map for consistency:

- [x] `:ipfs/read` to `ipfs.read/multiaddr`
- [x] `:ipfs/write` to `ipfs.write/multiaddr`
- [x] misc related fixes  

## Type of change

Please delete options that are not relevant.

- [x] Clean-up and refactor