### PR TITLE
chore(dapp): Add auth test for wallet authenticate/disconnect via dapp

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -172,6 +172,16 @@ jobs:
     needs: changes
     if: needs.changes.outputs.dapp == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    services:
+      cloudflare-worker:
+        image: ghcr.io/kubelt/cloudflare-worker:latest
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.github_token }}
+        ports:
+          - 8787:8787
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
@@ -179,7 +189,7 @@ jobs:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - run: npm install
+      - run: npm ci
       - uses: turtlequeue/setup-babashka@v1.3.0
         with:
           babashka-version: 0.7.8
@@ -187,6 +197,8 @@ jobs:
       - run: npm run build:dapp:release
       - run: npm run test:dapp:ci:compile
       # Run Cypress tests AFTER the server is running
+      # Install cypress if it didn't get cached properly
+      - run: npm install cypress --save-dev
       - run: npm run test:dapp:ci:run
       # Compile and run re-frame tests with karma
       - run: npm run test:dapp-karma:ci:compile

--- a/dapp/src/dapp/core.cljs
+++ b/dapp/src/dapp/core.cljs
@@ -64,6 +64,8 @@
                   (fn [db]
                     (:current-user db)))
 
+(re-frame/reg-sub ::db (fn [db] db))
+
 (defn init []
   (re-frame/clear-subscription-cache!)
   (re-frame/dispatch-sync [::initialize-db])

--- a/dapp/src/dapp/wallet.cljs
+++ b/dapp/src/dapp/wallet.cljs
@@ -88,14 +88,21 @@
  (fn [db [_ wallet-address err]]
    (assoc-in db [:sdk/ctx :errors wallet-address] err)))
 
-(re-frame/reg-event-db
+;; Two events for disconnect for testing async completion via re-frame-test
+(re-frame/reg-event-fx
  ::disconnect
- (fn [{:keys [web3-modal] :as db} [_ wallet-address]]
+ (fn [{:keys [db]} [_ wallet-address]]
    (log/info {:message (str "Disconnecting from address: " wallet-address)})
    ;; Clear the provider from the web3-modal object
-   (.clearCachedProvider web3-modal)
+   (.clearCachedProvider (:web3-modal db))
    ;; Reset the SDK context to `init` state
-   (assoc db :sdk/ctx (sdk.v1/init))))
+   {:db (assoc db :sdk/ctx (sdk.v1/init))
+    :dispatch [::disconnect-success]}))
+
+(re-frame/reg-event-db
+ ::disconnect-success
+ (fn [db _]
+   (dissoc db :web3-modal)))
 
 ; TODO
 ; Handle the account changed event

--- a/dapp/test/dapp/integration/auth_test.cljs
+++ b/dapp/test/dapp/integration/auth_test.cljs
@@ -5,8 +5,11 @@
    [re-frame.core :as re-frame])
   (:require
    [com.kubelt.lib.wallet :as lib.wallet]
+   [com.kubelt.lib.wallet.shared :as lib.wallet.shared]
    [dapp.core]
-   [dapp.wallet]))
+   [dapp.wallet])
+  (:require
+   ["web3modal$default" :as Web3Modal]))
 
 (deftest init-sdk-and-wallet
   (rf-test/run-test-sync
@@ -17,10 +20,47 @@
        (is (contains? @ctx :crypto/wallet))
        (is (lib.wallet/valid? @wallet))))))
 
-(deftest gen-wallet-and-authenticate
-  (rf-test/run-test-sync
-   (re-frame/dispatch [:dapp.core/initialize-db])
-   (testing "Generate wallet and authenticate"
-     ;; TODO: Implement once wallet features are ported to
-     ;; browser targets.
-     (is (true? true)))))
+;; Requires connection to cloudflare-worker OR appropriate backend to run correctly
+(deftest gen-wallet-authenticate-and-disconnect
+  (rf-test/run-test-async
+   (re-frame/dispatch-sync [:dapp.core/initialize-db])
+   (testing "Generate wallet, authenticate with SDK and disconnect"
+     (let [generated-wallet (atom {})
+           modal (Web3Modal. (clj->js {:network "testnet"
+                                       :cacheProvider true}))]
+       (.then (lib.wallet.shared/random-wallet)
+              (fn [generated-wallet*]
+                (is (lib.wallet/valid? generated-wallet*))
+                ;; need access to generated-wallet value outside of promise
+                (reset! generated-wallet generated-wallet*)
+                ;; Set the modal & current wallet in re-frame app-db
+                (re-frame/dispatch [:dapp.wallet/set-web3-modal modal])
+                (re-frame/dispatch [:dapp.wallet/set-current-wallet generated-wallet*])))
+
+       ;; Wait for authentication to succeed
+       (rf-test/wait-for
+        [:dapp.wallet/authenticate-success]
+        (let [auth-ctx @(re-frame/subscribe [:dapp.wallet/ctx])
+              {:wallet/keys [address] :as connected-wallet} @(re-frame/subscribe [:dapp.wallet/wallet])]
+          ;; Ensure connected-wallet passes validation
+          (is (lib.wallet/valid? connected-wallet))
+          ;; Ensure connected-wallet address is the same as generated-wallet address
+          (is (= (:wallet/address @generated-wallet) address))
+          ;; Ensure that a session with appropriate JWT token information is stored
+          (is (contains? (get-in auth-ctx [:crypto/session :vault/tokens]) address))
+          (let [jwt-path [:crypto/session :vault/tokens address]]
+            (is (and (some? (get-in auth-ctx (conj jwt-path :header)))
+                     (some? (get-in auth-ctx (conj jwt-path :claims)))
+                     (some? (get-in auth-ctx (conj jwt-path :token)))
+                     (some? (get-in auth-ctx (conj jwt-path :signature)))))))
+
+        ;; Dispatch disconnect event and wait for it to succeed
+        (re-frame/dispatch [:dapp.wallet/disconnect (:wallet/address @generated-wallet)])
+        (rf-test/wait-for
+         [:dapp.wallet/disconnect-success]
+         (let [{:keys [web3-modal] :as _db} @(re-frame/subscribe [:dapp.core/db])
+               disconnected-ctx @(re-frame/subscribe [:dapp.wallet/ctx])]
+           ;; Ensure no modal exists in the app-db
+           (is (nil? web3-modal))
+           ;; Ensure no session information remains in the app-db
+           (is (nil? (get-in disconnected-ctx [:crypto/session :vault/tokens (:wallet/address @generated-wallet)]))))))))))

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -17,7 +17,7 @@
 
  :dependencies
  [;; needed for dapp
-  [binaryage/devtools "1.0.5"]
+  [binaryage/devtools "1.0.6"]
   ;; a Clojure/Script library for word case conversions
   [camel-snake-kebab/camel-snake-kebab "0.4.2"]
   ;; errors as simple, actionable, generic information
@@ -31,7 +31,7 @@
   ;; immutable database and Datalog query engine
   [datascript/datascript "1.3.12"]
   ;; inspection tool for re-frame events & app-db
-  ^:dev [day8.re-frame/re-frame-10x "1.2.5"]
+  ^:dev [day8.re-frame/re-frame-10x "1.2.6"]
   ;; testing for re-frame events & subs
   ^:dev [day8.re-frame/test "0.1.5"]
   ;; tracing for re-frame events

--- a/src/main/com/kubelt/lib/wallet/shared.cljc
+++ b/src/main/com/kubelt/lib/wallet/shared.cljc
@@ -1,0 +1,45 @@
+(ns com.kubelt.lib.wallet.shared
+  (:require
+   [goog.object :as gobj])
+  (:require
+   ["@ethersproject/keccak256" :refer [keccak256]]
+   ["@ethersproject/signing-key" :refer [SigningKey]]
+   ["@ethersproject/wallet" :refer [Wallet]])
+  (:require
+   [com.kubelt.lib.octet :as lib.octet]
+   [com.kubelt.lib.promise :refer [promise]]))
+
+(defn make-sign-fn
+  "Given an Ethereum wallet, return a signing function that uses the
+  wallet's private key to sign the digest of some given data. To match
+  what happens in the browser, the signing function returns a promise
+  that resolves to the signature value."
+  [eth-wallet]
+  (fn [data]
+    (promise
+     (fn [resolve _reject]
+       (let [private-key (.-privateKey eth-wallet)
+             signing-key (SigningKey. private-key)
+
+             data-length (count data)
+             prefix (str "\u0019Ethereum Signed Message:\n" data-length)
+             prefix+data (str prefix data)
+             data-bytes (lib.octet/as-bytes prefix+data)
+
+             digest (keccak256 data-bytes)
+             signature-raw (.signDigest signing-key digest private-key)
+             signature (gobj/get signature-raw "compact")]
+         (resolve signature))))))
+
+(defn random-wallet
+  []
+  (promise
+   (fn [resolve _reject]
+     (let [eth-wallet (.createRandom Wallet)
+           sign-fn (make-sign-fn eth-wallet)]
+       (resolve
+        (.then (.getAddress eth-wallet)
+               (fn [address]
+                 {:com.kubelt/type :kubelt.type/wallet
+                  :wallet/address address
+                  :wallet/sign-fn sign-fn})))))))


### PR DESCRIPTION
# Description

- Bumps some dev dependencies with new versions
- Allows `random-wallet` to be used from `:browser` targets
- Tests generated wallet against ETH `testnet` and authenticates with cloudflare-worker running locally
- Tests disconnecting via the dapp's re-frame event
- Runs on CI with private container from the Kubelt GH Container Registry

Closes https://github.com/kubelt/kubelt/issues/317

## Type of change

- [x] Adding tests + refactoring (no new features in code)

# How Has This Been Tested?

- [x] Re-frame event for auth via dapp with cloudflare worker
- [x] Re-frame event for disconnecting the wallet from dapp

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes