### PR TITLE
feat(ddt): add support for importing wallets

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/wallet.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet.cljs
@@ -2,6 +2,7 @@
   "CLI setup for 'wallet' sub-command."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.cmds.wallet.import :as wallet.import]
    [com.kubelt.ddt.cmds.wallet.init :as wallet.init]
    [com.kubelt.ddt.cmds.wallet.ls :as wallet.ls]
    [com.kubelt.ddt.cmds.wallet.rm :as wallet.rm]
@@ -13,6 +14,7 @@
    :builder (fn [^js yargs]
               (-> yargs
                   (.command (clj->js wallet.init/command))
+                  (.command (clj->js wallet.import/command))
                   (.command (clj->js wallet.ls/command))
                   (.command (clj->js wallet.rm/command))
                   (.command (clj->js wallet.sign/command))

--- a/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
@@ -31,7 +31,12 @@
                       (fn [err result]
                         (when err
                           (ddt.util/exit-if err))
-                        (let [password (.-password result)]
-                          (lib.wallet/import (fn [res]
-                                               (println res))
-                                             app-name wallet-name mnemonic password)))))))))})
+                        (let [password (.-password result)
+                              result& (lib.wallet/import app-name wallet-name mnemonic password)]
+                          (-> result&
+                              (.then (fn [{:keys [wallet/name wallet/path]}]
+                                       (let [message (str "wallet '" name "' successfully imported")]
+                                         (println message))))
+                              (.catch (fn [error]
+                                        (let [message (:error error)]
+                                          (println message)))))))))))))})

--- a/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
@@ -33,5 +33,5 @@
                           (ddt.util/exit-if err))
                         (let [password (.-password result)]
                           (lib.wallet/import (fn [res]
-                                               (println "successfully imported wallet:" res))
+                                               (println res))
                                              app-name wallet-name mnemonic password)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
@@ -21,17 +21,17 @@
 
                 ;; Check to see if named wallet already exists. Wallets
                 ;; can't be overwritten so throw an error if so.
-                (if (lib.wallet/has-wallet? app-name wallet-name)
+                (when (lib.wallet/has-wallet? app-name wallet-name)
                   (let [message (str "wallet '" wallet-name "' already exists")]
-                    (ddt.util/exit-if message))
-                  (println "good! no other wallet exists with this name"))
-                (ddt.prompt/ask-mnemonic! (fn [err result]
-                                            (let [mnemonic (.-mnemonic result)]
-                                              (ddt.prompt/confirm-password!
-                                               (fn [err result]
-                                                 (when err
-                                                   (ddt.util/exit-if err))
-                                                 (let [password (.-password result)]
-                                                   (lib.wallet/import (fn [res]
-                                                                        (println "imported wallet:" res))
-                                                                      app-name wallet-name mnemonic password)))))))))})
+                    (ddt.util/exit-if message)))
+                (ddt.prompt/ask-mnemonic!
+                 (fn [err result]
+                   (let [mnemonic (.-mnemonic result)]
+                     (ddt.prompt/confirm-password!
+                      (fn [err result]
+                        (when err
+                          (ddt.util/exit-if err))
+                        (let [password (.-password result)]
+                          (lib.wallet/import (fn [res]
+                                               (println "successfully imported wallet:" res))
+                                             app-name wallet-name mnemonic password)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
@@ -1,0 +1,38 @@
+(ns com.kubelt.ddt.cmds.wallet.import
+  "Invoke the wallet (import) method."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.ddt.options :as ddt.options]
+   [com.kubelt.ddt.prompt :as ddt.prompt]
+   [com.kubelt.ddt.util :as ddt.util]
+   [com.kubelt.lib.wallet :as lib.wallet]))
+
+(defonce command
+  {:command "import <name>"
+   :desc "Import wallet providing a name, mnemonic phrase and password"
+   :requiresArg false
+   :builder (fn [^Yargs yargs]
+              yargs)
+   :handler (fn [args]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)
+                    wallet-name (get args-map :name)]
+                ;; TODO check to see if wallet name is valid (using yargs)
+
+                ;; Check to see if named wallet already exists. Wallets
+                ;; can't be overwritten so throw an error if so.
+                (if (lib.wallet/has-wallet? app-name wallet-name)
+                  (let [message (str "wallet '" wallet-name "' already exists")]
+                    (ddt.util/exit-if message))
+                  (println "good! no other wallet exists with this name"))
+                (ddt.prompt/ask-pnemonic! (fn [err result]
+                                            (let [mnemonic (.-mnemonic result)]
+                                              (ddt.prompt/confirm-password!
+                                               (fn [err result]
+                                                 (when err
+                                                   (ddt.util/exit-if err))
+                                                 (let [password (.-password result)]
+                                                   (println {:mnemonic mnemonic
+                                                             :password password})
+                                                   #_(let [wallet-path (lib.wallet/init app-name wallet-name password)]
+                                                       (println "initialized wallet:" wallet-name))))))))))})

--- a/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/import.cljs
@@ -25,14 +25,13 @@
                   (let [message (str "wallet '" wallet-name "' already exists")]
                     (ddt.util/exit-if message))
                   (println "good! no other wallet exists with this name"))
-                (ddt.prompt/ask-pnemonic! (fn [err result]
+                (ddt.prompt/ask-mnemonic! (fn [err result]
                                             (let [mnemonic (.-mnemonic result)]
                                               (ddt.prompt/confirm-password!
                                                (fn [err result]
                                                  (when err
                                                    (ddt.util/exit-if err))
                                                  (let [password (.-password result)]
-                                                   (println {:mnemonic mnemonic
-                                                             :password password})
-                                                   #_(let [wallet-path (lib.wallet/init app-name wallet-name password)]
-                                                       (println "initialized wallet:" wallet-name))))))))))})
+                                                   (lib.wallet/import (fn [res]
+                                                                        (println "imported wallet:" res))
+                                                                      app-name wallet-name mnemonic password)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
@@ -2,10 +2,7 @@
   "Invoke the wallet (init) method."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   ["path" :as path])
-  (:require
-   [clojure.string :as cstr])
-  (:require
+   [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
    [com.kubelt.ddt.util :as ddt.util]
    [com.kubelt.lib.wallet :as lib.wallet]))
@@ -19,9 +16,8 @@
               yargs)
 
    :handler (fn [args]
-              (let [args-map (js->clj args :keywordize-keys true)
-                    base-name (.basename path (get args-map :$0))
-                    app-name (cstr/join "." ["com" "kubelt" base-name])
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)
                     wallet-name (get args-map :name)]
                 ;; TODO check to see if wallet name is valid (using yargs)
 

--- a/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
+++ b/src/main/com/kubelt/ddt/cmds/wallet/init.cljs
@@ -18,9 +18,8 @@
    :handler (fn [args]
               (let [args-map (ddt.options/to-map args)
                     app-name (get args-map :app-name)
+                    ;; TODO check to see if wallet name is valid (using yargs)
                     wallet-name (get args-map :name)]
-                ;; TODO check to see if wallet name is valid (using yargs)
-
                 ;; Check to see if named wallet already exists. Wallets
                 ;; can't be overwritten so throw an error if so.
                 (if (lib.wallet/has-wallet? app-name wallet-name)
@@ -31,5 +30,9 @@
                    (when err
                      (ddt.util/exit-if err))
                    (let [password (.-password result)]
-                     (let [wallet-path (lib.wallet/init app-name wallet-name password)]
-                       (println "initialized wallet:" wallet-name)))))))})
+                     (let [wallet (lib.wallet/init app-name wallet-name password)
+                           wallet-name (get wallet :wallet/name)
+                           ;; NB: Also available are the mnemonic path, locale.
+                           mnemonic (get wallet :wallet.mnemonic/phrase)]
+                       (println "initialized wallet:" wallet-name)
+                       (println "-> mnemonic:" mnemonic)))))))})

--- a/src/main/com/kubelt/ddt/prompt.cljs
+++ b/src/main/com/kubelt/ddt/prompt.cljs
@@ -15,6 +15,16 @@
 (def pw-regex
   #"^\w+$")
 
+(def pnemonic-config
+  {:pnemonic
+   {:description "Enter your pnmemonic phrase"
+    :type "string"
+    :message "Password must be 12 words"
+    :hidden true
+    :replace "*"
+    :required true
+    :before pw-clean}})
+
 (def password-config
   {:password
    {:description "Enter your password"
@@ -45,9 +55,13 @@
 ;; The prompt schema determines what is asked for from the user.
 ;; NB: "before" fn is run before callbacks and can modify user's input.
 
-(def ask-schema
+(def ask-pw-schema
   (clj->js
    {:properties password-config}))
+
+(def ask-pnemonic-schema
+  (clj->js
+   {:properties pnemonic-config}))
 
 (def confirm-schema
   (clj->js
@@ -82,16 +96,30 @@
 ;; Public
 ;; -----------------------------------------------------------------------------
 
-(defn ask-password!
+(defn ask!
   "Prompt the user for their password. Expects a callback function that
   accepts an error and a result parameter: (fn [err result] ...)."
-  [callback]
+  [callback ask-schema]
   {:pre [(fn? callback)]}
   ;; Remove the preliminary prompt set by default in "prompt" library.
   (set! (.-message prompt) "")
   ;; Prompt the user for their wallet password.
   (.start prompt)
   (.get prompt ask-schema callback))
+
+(defn ask-pnemonic!
+  "Prompt the user for their password. Expects a callback function that
+  accepts an error and a result parameter: (fn [err result] ...)."
+  [callback]
+  {:pre [(fn? callback)]}
+  (ask! callback ask-pnemonic-schema))
+
+(defn ask-password!
+  "Prompt the user for their password. Expects a callback function that
+  accepts an error and a result parameter: (fn [err result] ...)."
+  [callback]
+  {:pre [(fn? callback)]}
+  (ask! callback ask-pw-schema))
 
 (defn confirm-password!
   "Prompt the user for their password twice and passes along an error

--- a/src/main/com/kubelt/ddt/prompt.cljs
+++ b/src/main/com/kubelt/ddt/prompt.cljs
@@ -15,9 +15,9 @@
 (def pw-regex
   #"^\w+$")
 
-(def pnemonic-config
-  {:pnemonic
-   {:description "Enter your pnmemonic phrase"
+(def mnemonic-config
+  {:mnemonic
+   {:description "Enter your mnemonic phrase"
     :type "string"
     :message "Password must be 12 words"
     :hidden true
@@ -59,9 +59,9 @@
   (clj->js
    {:properties password-config}))
 
-(def ask-pnemonic-schema
+(def ask-mnemonic-schema
   (clj->js
-   {:properties pnemonic-config}))
+   {:properties mnemonic-config}))
 
 (def confirm-schema
   (clj->js
@@ -107,12 +107,12 @@
   (.start prompt)
   (.get prompt ask-schema callback))
 
-(defn ask-pnemonic!
+(defn ask-mnemonic!
   "Prompt the user for their password. Expects a callback function that
   accepts an error and a result parameter: (fn [err result] ...)."
   [callback]
   {:pre [(fn? callback)]}
-  (ask! callback ask-pnemonic-schema))
+  (ask! callback ask-mnemonic-schema))
 
 (defn ask-password!
   "Prompt the user for their password. Expects a callback function that

--- a/src/main/com/kubelt/lib/error.cljc
+++ b/src/main/com/kubelt/lib/error.cljc
@@ -35,3 +35,10 @@
      (when (:title (mc/properties schema))
        {:title (:title (mc/properties schema))})
      {:error explain})))
+
+#?(:cljs
+  (defn from-obj
+    "Return an error map from a js/Error object."
+    [o]
+    (let [message (.-message o)]
+      (error message))))

--- a/src/main/com/kubelt/lib/promise.cljs
+++ b/src/main/com/kubelt/lib/promise.cljs
@@ -95,7 +95,7 @@
 ;;   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 (defn all-map
   "Resolves when all promise values in the map resolve. The resolved value
-  will e a map with the same keys as the input map, but with the
+  will be a map with the same keys as the input map, but with the
   resolved values of the promises. Rejects with first error if any
   promise rejects. Like Promise.all() but for Maps."
   [js-map]

--- a/src/main/com/kubelt/lib/wallet.cljc
+++ b/src/main/com/kubelt/lib/wallet.cljc
@@ -116,9 +116,10 @@
   #?(:node (wallet.node/create)))
 
 (defn import
-  "Import a wallet and store it encrypted"
-  [callback app-name wallet-name mnemonic password]
-  {:pre [(string? app-name) (string? wallet-name) (string? mnemonic) (string? password)
-         (fn? callback)]}
+  "Import a wallet and store it encrypted. Returns a promise that rejects
+  with an error map if a problem occurs, or resolves to the name of the
+  newly imported wallet on success."
+  [app-name wallet-name mnemonic password]
+  {:pre [(string? app-name) (string? wallet-name) (string? mnemonic) (string? password)]}
   #?(:node
-       (wallet.node/import callback app-name wallet-name mnemonic password)))
+     (wallet.node/import app-name wallet-name mnemonic password)))

--- a/src/main/com/kubelt/lib/wallet.cljc
+++ b/src/main/com/kubelt/lib/wallet.cljc
@@ -9,6 +9,7 @@
   (:require
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.spec.wallet :as spec.wallet])
+  (:refer-clojure :exclude [import])
   #?(:node
      (:require
       [com.kubelt.lib.wallet.node :as wallet.node])))
@@ -113,3 +114,11 @@
   "Create a platform-appropriate wallet."
   []
   #?(:node (wallet.node/create)))
+
+(defn import
+  "Import a wallet and store it encrypted"
+  [callback app-name wallet-name mnemonic password]
+  {:pre [(string? app-name) (string? wallet-name) (string? mnemonic) (string? password)
+         (fn? callback)]}
+  #?(:node
+       (wallet.node/import callback app-name wallet-name mnemonic password)))

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -145,7 +145,13 @@
 (defn import
   "Import a wallet and store it encrypted"
   [callback app-name wallet-name mnemonic password]
-  (go
-    (println ::processing app-name wallet-name )
-    (let [w  (.fromMnemonic Wallet mnemonic)]
-      (callback [wallet-name (.-address w)]))))
+  (let [wallet-dirp (ensure-wallet-dir app-name)]
+    (when (has-wallet? app-name wallet-name)
+      (let [message (str "wallet " wallet-name " already exists")]
+        (lib.error/error message)))
+    (go
+      (let [wallet-path (.join path wallet-dirp wallet-name)
+            w  (.fromMnemonic Wallet mnemonic)
+            wallet-js (<p! (.encrypt w password))]
+        (.writeFileSync fs wallet-path wallet-js)
+        (callback wallet-name)))))

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -9,6 +9,7 @@
   (:require
    [cljs.core.async :as async :refer [go]]
    [cljs.core.async.interop :refer-macros [<p!]])
+  (:refer-clojure :exclude [import])
   (:require
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.path :as lib.path]
@@ -140,3 +141,11 @@
   #_(let [sign-fn (lib.wallet/make-sign-fn eth-wallet)]
     {:wallet/address :fixme
      :wallet/sign-fn sign-fn}))
+
+(defn import
+  "Import a wallet and store it encrypted"
+  [callback app-name wallet-name mnemonic password]
+  (go
+    (println ::processing app-name wallet-name )
+    (let [w  (.fromMnemonic Wallet mnemonic)]
+      (callback [wallet-name (.-address w)]))))

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -149,8 +149,10 @@
     (when (has-wallet? app-name wallet-name)
       (callback (str "wallet " wallet-name " already exists")))
     (go
-      (let [wallet-path (.join path wallet-dirp wallet-name)
-            w  (.fromMnemonic Wallet mnemonic)
-            wallet-js (<p! (.encrypt w password))]
-        (.writeFileSync fs wallet-path wallet-js)
-        (callback wallet-name)))))
+      (try
+        (let [wallet-path (.join path wallet-dirp wallet-name)
+              w  (.fromMnemonic Wallet mnemonic)
+              wallet-js (<p! (.encrypt w password))]
+          (.writeFileSync fs wallet-path wallet-js)
+          (callback (str "successfully imported wallet:" wallet-name)))
+        (catch js/Error e (callback (str e)))))))

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -1,6 +1,7 @@
 (ns com.kubelt.lib.wallet.node
   "The Node.js implementation of a crypto wallet wrapper."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [import])
   (:require
    ["fs" :as fs]
    ["path" :as path])
@@ -9,10 +10,10 @@
   (:require
    [cljs.core.async :as async :refer [go]]
    [cljs.core.async.interop :refer-macros [<p!]])
-  (:refer-clojure :exclude [import])
   (:require
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.path :as lib.path]
+   [com.kubelt.lib.promise :as lib.promise]
    [com.kubelt.lib.wallet.shared :as lib.wallet]))
 
 (defn- wallet-dir
@@ -85,7 +86,11 @@
     false))
 
 (defn init
-  ""
+  "Create and store an encrypted wallet. The encrypted wallet file is
+  stored in an XDG compliant location based on the application name. It
+  is also named using the supplied wallet name and encrypted with the
+  supplied password. A map describing the created wallet is returned if
+  successful. An error map is returned otherwise."
   [app-name wallet-name password]
   (let [;; Create the wallet directory if it doesn't already exist.
         wallet-dirp (ensure-wallet-dir app-name)]
@@ -94,13 +99,18 @@
       (let [message (str "wallet " wallet-name " already exists")]
         (lib.error/error message)))
     ;; Wallet doesn't yet exist, so create it!
-    (let [wallet-path (.join path wallet-dirp wallet-name)]
+    (let [wallet-path (.join path wallet-dirp wallet-name)
+          eth-wallet (.createRandom Wallet)
+          mnemonic (.-mnemonic eth-wallet)]
       (go
-        (let [eth-wallet (.createRandom Wallet)
-              wallet-js (<p! (.encrypt eth-wallet password))]
+        (let [wallet-js (<p! (.encrypt eth-wallet password))]
           (.writeFileSync fs wallet-path wallet-js)))
-      ;; TODO return a map
-      wallet-path)))
+      (let [{:keys [phrase path locale]} (js->clj mnemonic :keywordize-keys true)]
+        {:wallet/path wallet-path
+         :wallet/name wallet-name
+         :wallet.mnemonic/phrase phrase
+         :wallet.mnemonic/path path
+         :wallet.mnemonic/locale locale}))))
 
 (defn load
   ""
@@ -143,16 +153,45 @@
      :wallet/sign-fn sign-fn}))
 
 (defn import
-  "Import a wallet and store it encrypted"
-  [callback app-name wallet-name mnemonic password]
-  (let [wallet-dirp (ensure-wallet-dir app-name)]
-    (when (has-wallet? app-name wallet-name)
-      (callback (str "wallet " wallet-name " already exists")))
-    (go
-      (try
-        (let [wallet-path (.join path wallet-dirp wallet-name)
-              w  (.fromMnemonic Wallet mnemonic)
-              wallet-js (<p! (.encrypt w password))]
-          (.writeFileSync fs wallet-path wallet-js)
-          (callback (str "successfully imported wallet:" wallet-name)))
-        (catch js/Error e (callback (str e)))))))
+  "Import a wallet and store it encrypted. Returns a promise that resolves
+  to the path to the imported wallet, or if an error occurs rejects with
+  a standard error map."
+  [app-name wallet-name mnemonic password]
+  (lib.promise/promise
+   (fn [resolve reject]
+     (when (has-wallet? app-name wallet-name)
+       (let [msg (str "wallet " wallet-name " already exists")
+             error (lib.error/error msg)]
+         (reject error)))
+     ;; The wallet with the given name doesn't yet exist, we can import
+     ;; from the mnemonic and create a wallet with that name.
+     (letfn [;; Returns a promise that resolves to the wallet
+             ;; JSON. Throws if the mnemonic is invalid.
+             (from-mnemonic [mnemonic]
+               (try
+                 (let [w (.fromMnemonic Wallet mnemonic)]
+                   ;; Returns a promise.
+                   (.encrypt w password))
+                 (catch js/Error e
+                   (let [error (lib.error/from-obj e)]
+                     (reject error)))))
+             ;; Returns the path of the wallet file to write.
+             (wallet-path []
+               (let [wallet-dir (ensure-wallet-dir app-name)
+                     wallet-file (.join path wallet-dir wallet-name)]
+                 (lib.promise/resolved wallet-file)))]
+       (let [path& (wallet-path)
+             wallet& (from-mnemonic mnemonic)]
+         (-> (lib.promise/all [path& wallet&])
+             (.then (fn [[wallet-dirp wallet-js]]
+                      (try
+                        (.writeFileSync fs wallet-dirp wallet-js)
+                        (let [result {:wallet/name wallet-name
+                                      :wallet/path wallet-path}]
+                          (resolve result))
+                        (catch js/Error e
+                          (let [error (lib.error/from-obj e)]
+                            (reject error))))))
+             (.catch (fn [e]
+                       (let [error (lib.error/from-obj e)]
+                         (reject error))))))))))

--- a/src/main/com/kubelt/lib/wallet/node.cljs
+++ b/src/main/com/kubelt/lib/wallet/node.cljs
@@ -147,8 +147,7 @@
   [callback app-name wallet-name mnemonic password]
   (let [wallet-dirp (ensure-wallet-dir app-name)]
     (when (has-wallet? app-name wallet-name)
-      (let [message (str "wallet " wallet-name " already exists")]
-        (lib.error/error message)))
+      (callback (str "wallet " wallet-name " already exists")))
     (go
       (let [wallet-path (.join path wallet-dirp wallet-name)
             w  (.fromMnemonic Wallet mnemonic)


### PR DESCRIPTION
# Description

Use @ethersproject/wallet and https://docs.ethers.io/v5/api/signer/#Wallet.fromMnemonic to retrieve wallet, then we store it encrypted following current `com.kubelt.lib.wallet.node/init` approach

### `ddt wallet import <name>`
we are adding to ddt this new `wallet import` command, being `<name>` the name of the local wallet-id imported

Closes #353

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. generate ddt executable script with   `bb build:ddt:develop`
2. try new command with `node ddt.js wallet import example`  
3. `node ddt.js sdk wallet ls` returns the new wallet on the list 
```
-> default
-> example
-> juan
```
4. then using the wallet imported  `node ddt.js sdk core authenticate -w example` ... returns the sdk initialised 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
