### PR TITLE
chore(all-modules): Run dapp integration tests on each PR

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -169,8 +169,6 @@ jobs:
   #     - run: npm run test:sdk-web:develop
 
   test-dapp:
-    needs: changes
-    if: needs.changes.outputs.dapp == 'true'
     runs-on: ubuntu-latest
     permissions:
       packages: read


### PR DESCRIPTION
# Description

Since the `dapp` tests are essentially integration tests now, they should run on each PR to `main` before merging.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Run workflow even though `dapp` hasn't changed on this PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
