### PR TITLE
Fix warning: ns-var-clash

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,6 +8,8 @@
   commons-codec/commons-codec {:mvn/version "1.15"}
   ;; A data format and set of libraries for conveying values
   com.cognitect/transit-clj {:mvn/version "1.0.329"}
+  ;; Navigator-based query and transformation of Clojure data
+  com.rpl/specter {:mvn/version "1.1.4"}
   ;; Pure Clojure/Script logging library
   com.taoensso/timbre {:mvn/version "5.2.1"}
   ;; An http client for Clojure wrapping jdk 11's HttpClient
@@ -30,7 +32,7 @@
 
  :aliases
  {:dev {:extra-paths ["src/dev"]
-        :extra-deps {fipp/fipp {:mvn/version "0.6.25"}}}
+        :extra-deps {fipp/fipp {:mvn/version "0.6.26"}}}
 
   ;; Generate literate docs from the source code using sidenote (a fork
   ;; of marginalia).
@@ -43,13 +45,13 @@
   ;; Execute the tests configured in tests.edn:
   ;; $ clojure -M:kaocha
   :test {:extra-paths ["src/test"]
-         :extra-deps {lambdaisland/kaocha {:mvn/version "1.65.1029"}
+         :extra-deps {lambdaisland/kaocha {:mvn/version "1.66.1034"}
                       org.clojure/test.check {:mvn/version "1.1.1"}
                       org.clojure/test.generative {:mvn/version "1.0.0"}
-                      org.clojure/tools.namespace {:mvn/version "1.2.0"}
+                      org.clojure/tools.namespace {:mvn/version "1.3.0"}
                       org.clojure/tools.trace {:mvn/version "0.7.11"}}
          :main-opts ["-m" "kaocha.runner"]}
 
   ;; $ clojure -M:lint --lint src/
-  :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.04.08"}}
+  :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2022.04.25"}}
          :main-opts ["-m" "clj-kondo.main"]}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -24,12 +24,14 @@
   [com.cognitect/anomalies "0.1.12"]
   ;; data format for conveying values between applications
   [com.cognitect/transit-cljs "0.8.269"]
+  ;; Navigator-based query and transformation of Clojure data
+  [com.rpl/specter "1.1.4"]
   ;; a pure Clojure/Script logging library
   [com.taoensso/timbre "5.2.1"]
   ;; tailwind components for dapp
   [com.github.mainej/headlessui-reagent "1.5.0.47"]
   ;; immutable database and Datalog query engine
-  [datascript/datascript "1.3.12"]
+  [datascript/datascript "1.3.13"]
   ;; inspection tool for re-frame events & app-db
   ^:dev [day8.re-frame/re-frame-10x "1.2.6"]
   ;; testing for re-frame events & subs
@@ -37,7 +39,7 @@
   ;; tracing for re-frame events
   ^:dev [day8.re-frame/tracing "0.6.2"]
   ;; fast, idiomatic pretty-printer
-  [fipp/fipp "0.6.25"]
+  [fipp/fipp "0.6.26"]
   ;; a micro-framework for building data-driven applications
   [integrant/integrant "0.8.0"]
   ;; fast JSON encoding and decoding

--- a/src/main/com/kubelt/ddt/cmds.cljs
+++ b/src/main/com/kubelt/ddt/cmds.cljs
@@ -9,6 +9,7 @@
    [com.kubelt.ddt.cmds.jwt :as ddt.jwt]
    [com.kubelt.ddt.cmds.path :as ddt.path]
    [com.kubelt.ddt.cmds.rdf :as ddt.rdf]
+   [com.kubelt.ddt.cmds.rpc :as ddt.rpc]
    [com.kubelt.ddt.cmds.sdk :as ddt.sdk]
    [com.kubelt.ddt.cmds.wallet :as ddt.wallet]))
 
@@ -32,6 +33,8 @@
       (.command (clj->js ddt.path/command))
       ;; $DDT rdf <command>
       (.command (clj->js ddt.rdf/command))
+      ;; $DDT rpc <command>
+      (.command (clj->js ddt.rpc/command))
       ;; $DDT sdk <command>
       (.command (clj->js ddt.sdk/command))
       ;; $DDT wallet <command>

--- a/src/main/com/kubelt/ddt/cmds/rpc.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc.cljs
@@ -1,0 +1,15 @@
+(ns com.kubelt.ddt.cmds.rpc
+  "CLI setup for 'rpc' sub-command."
+  {:author "Proof Zero Inc."}
+  (:require
+   [com.kubelt.ddt.cmds.rpc.call :as rpc.call]
+   [com.kubelt.ddt.cmds.rpc.ls :as rpc.ls]))
+
+(defonce command
+  {:command "rpc <command>"
+   :desc "Work with RPC APIs"
+   :builder (fn [^js yargs]
+              (-> yargs
+                  (.command (clj->js rpc.call/command))
+                  (.command (clj->js rpc.ls/command))
+                  (.demandCommand)))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
@@ -1,0 +1,46 @@
+(ns com.kubelt.ddt.cmds.rpc.call
+  "Make an RPC call."
+  {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [clojure.string :as cstr])
+  (:require
+   [com.kubelt.ddt.options :as ddt.options]))
+
+(defonce command
+  {:command "call <method>"
+   :desc "Make an RPC call."
+   :requiresArg true
+
+   :builder (fn [^Yargs yargs]
+              ;; Include the common options.
+              (ddt.options/options yargs)
+              ;; A generic --param option is used to collection RPC call
+              ;; parameters.
+              (let [config #js {:alias "x"
+                                :describe "An RPC parameter (<name>=<value>)"
+                                :requiresArg true
+                                :demandOption "param name and value are required"
+                                :string true
+                                :nargs 1}]
+                (.option yargs "param" config))
+
+              ;; Return a parameter map rather than an array
+              ;; of "<name>=<value>" strings.
+              (let [param-fn
+                    (fn [m s]
+                      (let [[k v] (cstr/split s #"=")
+                            kw (keyword k)]
+                        (assoc m kw v)))]
+                (.coerce yargs "param"
+                         (fn [params]
+                           (js->clj (reduce param-fn {} params))))))
+
+   :handler (fn [args]
+              (let [args-map (ddt.options/to-map args)
+                    method (get args-map :method)
+                    params (get args-map :param)]
+                ;;(prn args-map)
+                ;;(prn params)
+                (println "RPC call:" method)
+                (doseq [[k v] params]
+                  (println "->" (name k) ":" v))))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -1,0 +1,18 @@
+(ns com.kubelt.ddt.cmds.rpc.ls
+  "List available RPC methods."
+  {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.ddt.options :as ddt.options]))
+
+(defonce command
+  {:command "list "
+   :aliases ["ls"]
+   :desc "List available RPC methods."
+   :requiresArg true
+   :builder (fn [yargs]
+              yargs)
+
+   :handler (fn [args]
+              (let [args-map (ddt.options/to-map args)
+                    app-name (get args-map :app-name)]
+                (println "RPC calls: fixme")))})

--- a/src/main/com/kubelt/ipfs/client.cljc
+++ b/src/main/com/kubelt/ipfs/client.cljc
@@ -203,6 +203,7 @@
 ;; Public
 ;; -----------------------------------------------------------------------------
 
+;; TODO validate with malli.
 (defn client?
   "Return true if x is an IPFS client returned from calling (init), and
   false otherwise."
@@ -211,6 +212,8 @@
    (map? x)
    (= :kubelt.type/ipfs-client (get x :com.kubelt/type))))
 
+;; TODO validate with malli.
+;; TODO move to lib.error.
 (defn error?
   "Return true if x is a Kubelt error map, and false otherwise."
   [x]
@@ -232,7 +235,7 @@
 ;;  [:dag :get]
 ;;  [:dag :import]]
 (defn ops
-  "Return the collection of oeprations provided by the API. Each vector of
+  "Return the collection of operations provided by the API. Each vector of
   keywords in the returned collection represents a call that may be
   performed. Use the (doc) command to get a description of the API
   resource."

--- a/src/main/com/kubelt/rpc.cljc
+++ b/src/main/com/kubelt/rpc.cljc
@@ -1,0 +1,187 @@
+(ns com.kubelt.rpc
+  "Entry point for a JSON-RPC client."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [methods])
+  (:require
+   [malli.core :as malli])
+  (:require
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.rpc.schema :as rpc.schema]
+   [com.kubelt.spec :as spec]
+   [com.kubelt.spec.openrpc :as spec.openrpc]
+   [com.kubelt.spec.rpc :as spec.rpc]
+   [com.kubelt.spec.rpc.call :as spec.rpc.call]
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.methods :as spec.rpc.methods]
+   [com.kubelt.spec.rpc.request :as spec.rpc.request]))
+
+;; Public
+;; -----------------------------------------------------------------------------
+;; TODO check version of supplied schema to ensure we support it
+;; TODO support dynamic extension of client to add another schema (with prefix)
+
+(defn client?
+  [x]
+  (malli/validate spec.rpc/client x))
+
+(defn path?
+  [x]
+  (malli/validate spec.rpc/path x))
+
+;; TODO add option to provide set of "dividing" characters, e.g. _, .
+;; - "eth_sync" => [:eth :sync]
+;; - "rpc.provider" => [:rpc :provider]
+;; TODO add option for using a prefix, e.g.
+;; {:method/prefix :xxx}
+;; - "eth_sync" => [:xxx :eth :sync]
+(defn init
+  "Create a JSON-RPC client."
+  ([url schema]
+   (let [defaults {}]
+     (init url schema defaults)))
+  ([url schema options]
+   (lib.error/conform*
+    [spec.rpc/url url]
+    [spec.openrpc/schema schema]
+    [spec.rpc.init/options options]
+    (let [;; Returns the schema, if valid, or an error map indicating
+          ;; the detected errors.
+          schema (rpc.schema/validate schema)]
+      (if (lib.error/error? schema)
+        schema
+        ;; Analyze schema and convert to client map.
+        (let [client (rpc.schema/build url schema options)]
+          (merge {:com.kubelt/type :kubelt.type/rpc.client} client)))))))
+
+;; The intent of this function is to provide a pleasant REPL-driven
+;; developer experience. A user should be able to instantiate or receive
+;; a client, and use this method to discover what calls it supports by
+;; listing everything, searching/filtering based on various
+;; attributes (initially the API call name or "path"), and sorting the
+;; output to obtain a single API method name that can be passed to
+;; the (doc) function to obtain more detailed documentation as data or
+;; possibly in a pretty output format.
+(defn methods
+  "Return the collection of operations provided by the API. Each vector of
+  keywords in the returned collection represents a call that may be
+  performed. If a vector of keywords is provided as the 'path' argument,
+  it is used as a prefix to filter the set of methods that are
+  returned. Use the (doc) function to get a more detailed description of
+  a single API resource. The options parameter can be supplied to filter
+  or transform the data that is returned."
+  ([client]
+   (let [path []]
+     (methods client path)))
+  ([client path]
+   (let [defaults {:methods/sort? true}]
+     (methods client path defaults)))
+  ([client path options]
+   (lib.error/conform*
+    [spec.rpc/client client]
+    [spec.rpc/path path]
+    [spec.rpc.methods/options options]
+    (let [method-map (get client :rpc/methods [])
+          sort? (get options :methods/sort?)
+          depth (get options :methods/depth)
+          search (get options :methods/search)
+          paths (cond-> (keys method-map)
+                  ;; depth
+                  (and (integer? depth) (>= depth 0))
+                  (rpc.schema/filter-depth depth)
+                  ;; search
+                  (string? search)
+                  (rpc.schema/filter-search search)
+                  ;; path
+                  (not-empty path)
+                  (rpc.schema/filter-path path))]
+      (if sort?
+        (apply sorted-set paths)
+        (into #{} paths))))))
+
+(defn doc
+  "Given a method path (a vector of keywords) return a map that describes
+  it."
+  [client path]
+  (lib.error/conform*
+   [spec.rpc/client client]
+   [spec.rpc/path path]
+   (let [methods (get client :rpc/methods)]
+     (if-not (contains? methods path)
+       (let [message {:message "missing method"
+                      :method path}]
+         (lib.error/error message))
+       ;; TODO optionally provide a better formatted version of documentation
+       (get methods path)))))
+
+;; WIP
+(defn request
+  "Return a request map describing the RPC call to perform. The supplied
+  parameters are validated against the service schema and an error map
+  is returned if any issues are detected."
+  [client path params]
+  ;; Use lib.error/conform* to ensure that each argument matches
+  ;; its schema.
+  (lib.error/conform*
+   [spec.rpc/client client]
+   [spec.rpc/path path]
+   [spec.rpc/params params]
+   ;; TODO add macro for guards, i.e. to check the results of a
+   ;; collection of predicates and return meaningful errors when they
+   ;; fail. Maybe something like: (guards [() () ... ()] (body)).
+   (if-let [method (get-in client [:rpc/methods path])]
+     method
+     ;; TODO confirm that path/method exists
+     ;; TODO pull method description
+     ;; TODO validate params
+     (lib.error/error {:message "no such method" :method path}))))
+
+(comment
+  (let [resource-desc]
+       {:com.kubelt/type :kubelt.type/api-resource
+        :resource/description resource-desc
+        :resource/methods resource-methods
+        :resource/path request-path
+        :resource/params request-params
+        :resource/conflicts request-conflicts
+        :resource/body request-body
+        :response/types response-types
+        :response/spec response-spec
+        :parameter/spec parameter-spec
+        :parameter/data options
+        :http/request request}))
+
+;; options:
+;; - explicit request ID
+;; - override provider URL
+(defn call
+  "Call an RPC method."
+  ([client request]
+    (let [defaults {}]
+      (call client request defaults)))
+  ([client request options]
+   (lib.error/conform*
+    [spec.rpc/client client]
+    [spec.rpc.request/request request]
+    [spec.rpc.call/options options]
+    ;; Do eeet
+   )))
+
+;; TODO is this useful for developers?
+(defn rpc-fn
+  "Return a function that implements the given RPC call and which accepts
+  the expected parameters and returns the expected result."
+  [client path]
+  (lib.error/conform*
+   [spec.rpc/client client]
+   [spec.rpc/path path]
+   ;; The returned function should invoke the RPC method named by the
+   ;; path argument, assuming that it exists on the client.
+   ;; - should we require a single parameter map, or allow the user to
+   ;;   supply arguments as varargs? [params] vs. [& params]
+   (fn [params]
+     (let [;; This validates the parameters and returns an error map if
+           ;; any issue(s) were detected.
+           req-map (request client path params)]
+       (if (lib.error/error? req-map)
+         req-map
+         (call client req-map))))))

--- a/src/main/com/kubelt/rpc.cljc
+++ b/src/main/com/kubelt/rpc.cljc
@@ -8,7 +8,6 @@
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.rpc.path :as rpc.path]
    [com.kubelt.rpc.schema :as rpc.schema]
-   [com.kubelt.spec :as spec]
    [com.kubelt.spec.openrpc :as spec.openrpc]
    [com.kubelt.spec.rpc :as spec.rpc]
    [com.kubelt.spec.rpc.call :as spec.rpc.call]
@@ -49,7 +48,7 @@
   ([url schema options]
    (lib.error/conform*
     [spec.rpc.init/url url]
-    [spec.openrpc/schema schema]
+    [spec.openrpc/schema* schema]
     [spec.rpc.init/options options]
     ;; Analyze schema and convert to client map.
     (let [client (rpc.schema/build url schema options)]

--- a/src/main/com/kubelt/rpc.cljc
+++ b/src/main/com/kubelt/rpc.cljc
@@ -11,6 +11,7 @@
    [com.kubelt.spec.openrpc :as spec.openrpc]
    [com.kubelt.spec.rpc :as spec.rpc]
    [com.kubelt.spec.rpc.call :as spec.rpc.call]
+   [com.kubelt.spec.rpc.client :as spec.rpc.client]
    [com.kubelt.spec.rpc.init :as spec.rpc.init]
    [com.kubelt.spec.rpc.methods :as spec.rpc.methods]
    [com.kubelt.spec.rpc.request :as spec.rpc.request]))
@@ -18,11 +19,20 @@
 ;; Public
 ;; -----------------------------------------------------------------------------
 ;; TODO check version of supplied schema to ensure we support it
+;;
 ;; TODO support dynamic extension of client to add another schema (with prefix)
+;;
+;; TODO support taking a map of schemas, with the map keys serving as
+;; the prefixes. If the schema map has an :openrpc key it's a schema
+;; itself; otherwise we can try assuming that the map is a collection of
+;; schemas.
+;;
+;; TODO rather than injecting a provider URL, use the server URL
+;; template feature defined in the OpenRPC spec.
 
 (defn client?
   [x]
-  (malli/validate spec.rpc/client x))
+  (malli/validate spec.rpc.client/client x))
 
 (defn path?
   [x]
@@ -41,7 +51,7 @@
      (init url schema defaults)))
   ([url schema options]
    (lib.error/conform*
-    [spec.rpc/url url]
+    [spec.rpc.init/url url]
     [spec.openrpc/schema schema]
     [spec.rpc.init/options options]
     (let [;; Returns the schema, if valid, or an error map indicating
@@ -77,7 +87,7 @@
      (methods client path defaults)))
   ([client path options]
    (lib.error/conform*
-    [spec.rpc/client client]
+    [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc.methods/options options]
     (let [method-map (get client :rpc/methods [])
@@ -103,7 +113,7 @@
   it."
   [client path]
   (lib.error/conform*
-   [spec.rpc/client client]
+   [spec.rpc.client/client client]
    [spec.rpc/path path]
    (let [methods (get client :rpc/methods)]
      (if-not (contains? methods path)
@@ -122,7 +132,7 @@
   ;; Use lib.error/conform* to ensure that each argument matches
   ;; its schema.
   (lib.error/conform*
-   [spec.rpc/client client]
+   [spec.rpc.client/client client]
    [spec.rpc/path path]
    [spec.rpc/params params]
    ;; TODO add macro for guards, i.e. to check the results of a
@@ -160,7 +170,7 @@
       (call client request defaults)))
   ([client request options]
    (lib.error/conform*
-    [spec.rpc/client client]
+    [spec.rpc.client/client client]
     [spec.rpc.request/request request]
     [spec.rpc.call/options options]
     ;; Do eeet
@@ -172,7 +182,7 @@
   the expected parameters and returns the expected result."
   [client path]
   (lib.error/conform*
-   [spec.rpc/client client]
+   [spec.rpc.client/client client]
    [spec.rpc/path path]
    ;; The returned function should invoke the RPC method named by the
    ;; path argument, assuming that it exists on the client.

--- a/src/main/com/kubelt/rpc/path.cljc
+++ b/src/main/com/kubelt/rpc/path.cljc
@@ -1,0 +1,71 @@
+(ns com.kubelt.rpc.path
+  "Path-related utilities."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [malli.core :as malli])
+  (:require
+   [com.kubelt.spec.rpc :as spec.rpc]))
+
+;; path?
+;; -----------------------------------------------------------------------------
+
+(defn path?
+  "Return true if the argument is an RPC path, i.e. a method name that has
+  been converted into structured data (a vector of keywords), and false
+  otherwise."
+  [x]
+  (malli/validate spec.rpc/path x))
+
+;; filter-depth
+;; -----------------------------------------------------------------------------
+
+(defn filter-depth
+  "Take a sequence of paths and trim each path be of the given
+  length. Returns a set."
+  [paths depth]
+  (letfn [(trim-depth [v path]
+            ;; If depth is greater than the length of the path, we
+            ;; include the path without any further processing.
+            (if (> depth (count path))
+              (conj v path)
+              (let [path (vec (first (partition depth path)))]
+                (conj v path))))]
+    (reduce trim-depth #{} paths)))
+
+;; filter-search
+;; -----------------------------------------------------------------------------
+
+(defn filter-search
+  "Filter a sequence of paths to include only those containing a given
+  search string. Returns a set."
+  [paths search]
+  {:pre [(string? search)]}
+  (let [pattern (re-pattern (str ".*" search ".*"))]
+    (letfn [(match-kw [kw]
+              (re-matches pattern (name kw)))
+            (matches? [path]
+              (not-empty (filter match-kw path)))
+            (match-search [a-set path]
+              (if (matches? path)
+                (conj a-set path)
+                a-set))]
+      (reduce match-search #{} paths))))
+
+;; filter-prefix
+;; -----------------------------------------------------------------------------
+
+(defn filter-prefix
+  "Return only those paths that have the given path prefix. For example,
+  if path contains [:foo :bar], only paths that begin with that sequence
+  of keywords will be returned, e.g. [:foo :bar :baz]."
+  [paths prefix]
+  (letfn [(pair= [[a b]]
+            (= a b))
+          (has-prefix? [prefix path]
+            (let [pairs (partition 2 (interleave prefix path))]
+              (every? pair= pairs)))
+          (match-path [a-set path]
+            (if (has-prefix? prefix path)
+              (conj a-set path)
+              a-set))]
+    (reduce match-path #{} paths)))

--- a/src/main/com/kubelt/rpc/schema.cljc
+++ b/src/main/com/kubelt/rpc/schema.cljc
@@ -100,9 +100,9 @@
            tf (mt/transformer mt/strip-extra-keys-transformer
                               mt/string-transformer
                               mt/json-transformer)
-           clean-edn (mc/decode spec.openrpc/schema edn tf)]
-       (if-not (mc/validate spec.openrpc/schema clean-edn)
-         (lib.error/explain spec.openrpc/schema clean-edn)
+           clean-edn (mc/decode spec.openrpc/schema* edn tf)]
+       (if-not (mc/validate spec.openrpc/schema* clean-edn)
+         (lib.error/explain spec.openrpc/schema* clean-edn)
          clean-edn))))
 
 ;; TODO make fn private

--- a/src/main/com/kubelt/rpc/schema.cljc
+++ b/src/main/com/kubelt/rpc/schema.cljc
@@ -1,0 +1,243 @@
+(ns com.kubelt.rpc.schema
+  "Tools for working with OpenRPC schemas."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [load methods])
+  (:require
+   [clojure.set :as cset]
+   [clojure.string :as cstr]
+   [clojure.walk :as walk])
+  (:require
+   #?@(:clj [[clojure.java.io :as io]]))
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [malli.core :as mc]
+   [malli.transform :as mt]
+   [com.rpl.specter :as sp])
+  (:require
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.json :as lib.json]
+   [com.kubelt.spec.openrpc :as spec.openrpc]))
+
+;; TODO consider malli transformers for JSON to edn transformation
+
+(defn version
+  [schema]
+  {:pre [(map? schema)]}
+  (get schema :openrpc))
+
+(defn metadata
+  [schema]
+  {:pre [(map? schema)]}
+  (get schema :info))
+
+(defn servers
+  [schema]
+  {:pre [(map? schema)]}
+  (get schema :servers []))
+
+(defn methods
+  "Extract the method descriptions from an Open RPC schema supplied as
+  edn. Note that underscores in the method names are used to namespace
+  the methods, i.e. a method named foo_getBar will be mapped
+  into [:foo :get-bar]."
+  [schema]
+  {:pre [(map? schema)]}
+  (letfn [(extract-method [m]
+            (dissoc m :name))
+          (s->kw [s]
+            (-> s keyword csk/->kebab-case))
+          (name->path [s]
+            (let [v (cstr/split s #"_")]
+              (mapv s->kw v)))
+          (f [m method]
+            (let [method-name (get method :name)
+                  path (name->path method-name)
+                  method (extract-method method)]
+              (assoc m path method)))]
+    (let [methods (get schema :methods [])]
+      (reduce f {} methods))))
+
+;; Take a sequence of paths and trim each path be of the given
+;; length. Returns a set.
+(defn filter-depth
+  [paths depth]
+  (letfn [(trim-depth [v path]
+            ;; If depth is greater than the length of the path, we
+            ;; include the path without any further processing.
+            (if (> depth (count path))
+              (conj v path)
+              (let [path (vec (first (partition depth path)))]
+                (conj v path))))]
+    (reduce trim-depth #{} paths)))
+
+;; Filter a sequence of paths to include only those containing a given
+;; search string.
+(defn filter-search
+  [paths search]
+  {:pre [(string? search)]}
+  (let [pattern (re-pattern (str ".*" search ".*"))]
+    (letfn [(match-kw [kw]
+              (re-matches pattern (name kw)))
+            (matches? [path]
+              (not-empty (filter match-kw path)))
+            (match-search [a-set path]
+              (if (matches? path)
+                (conj a-set path)
+                a-set))]
+      (reduce match-search #{} paths))))
+
+;; Return only those paths that have the given path prefix. For example,
+;; if path contains [:foo :bar], only paths that begin with that
+;; sequence of keywords will be returned, e.g. [:foo :bar :baz].
+(defn filter-path
+  [paths prefix]
+  (letfn [(pair= [[a b]]
+            (= a b))
+          (has-prefix? [prefix path]
+            (let [pairs (partition 2 (interleave prefix path))]
+              (every? pair= pairs)))
+          (match-path [a-set path]
+            (if (has-prefix? prefix path)
+              (conj a-set path)
+              a-set))]
+    (reduce match-path #{} paths)))
+
+;; Development
+;; -----------------------------------------------------------------------------
+
+(comment
+  ;; TODO :params
+  (defn params->schema
+    [{:keys [params] :as method}]
+    (let [params []]
+      (-> method
+          (assoc :params params)
+          (cset/rename-keys {:name :param/name
+                             :description :param/description
+                             :schema :param/schema}))))
+
+  ;; TODO :result
+  (defn extract-method
+    [m]
+    (-> m
+        (dissoc :name)
+        (params->schema)
+        (cset/rename-keys {:description :method/description
+                           :summary :method/summary
+                           :params :method/params
+                           :result :method/result
+                           :examples :method/examples})))
+  )
+
+;; Public
+;; -----------------------------------------------------------------------------
+
+#?(:clj
+   (defn load
+     "Load an OpenRPC schema from a file. Validates the OpenRPC schema and
+     returns an error map if any issues were detected. Otherwise, returns
+     the schema as a map whose keys have been keywordized and converted to
+     kebab case."
+     [filename]
+     (let [json-str (slurp filename)
+           keywordize? true
+           edn (lib.json/from-json json-str keywordize?)
+           tf (mt/transformer mt/strip-extra-keys-transformer
+                              mt/string-transformer
+                              mt/json-transformer)
+           clean-edn (mc/decode spec.openrpc/schema edn tf)]
+       (if-not (mc/validate spec.openrpc/schema clean-edn)
+         (lib.error/explain spec.openrpc/schema clean-edn)
+         clean-edn))))
+
+;; TODO make fn private
+#_(defn refs
+  "Return a set of all references ($ref) found in the schema."
+  [schema]
+  (let [;; Get all the references used in method parameters.
+        param-set (into #{}
+                        (sp/select
+                         [:methods sp/ALL :params sp/ALL #(get % :$ref) :$ref]
+                         schema))
+        ;; Get all the references used in method results.
+        result-set (into #{}
+                         (sp/select
+                          [:methods sp/ALL :result :schema #(get % :$ref) :$ref]
+                          schema))]
+    (cset/union param result)))
+
+;; TODO experiment will query using specter
+;; NB probably easiest to use clojure.walk, but specter liable to be useful
+;; for more interesting cases later on
+#_(defn refs
+  "Return a set of all references ($ref) found in the schema."
+  [schema]
+  (let [schema-walker
+        (sp/recursive-path
+         [k] p
+         [(sp/walker k)
+          (sp/stay-then-continue
+           [(sp/filterer #(not= k (key %)))
+            (sp/walker k)
+            p])])]
+    (sp/select (schema-walker :$ref) {:$ref "xxx" :foo "bar" :biz "baz"})))
+
+(defn refs
+  "Return a set of all references ($ref) found in the schema."
+  [schema]
+  (let [inner (fn [x]
+                (if (and (map? x) (contains? x :$ref))
+                  (do
+                    (prn x)
+                    (get x :$ref))
+                  x))
+        outer identity]
+    (walk/walk inner outer schema)))
+
+;; TODO make fn private
+(defn missing-refs
+  "Find all $ref and look them up to confirm that they're provided in the
+  schema. Return a vector of just the missing refs."
+  [schema]
+  (let [ref-set (refs schema)]
+    ;; TODO convert each ref path to [keywords]
+    ;; TODO look up each ref to confirm that it exists
+    ;; TODO return only the missing items
+    ))
+
+;; Error checking
+;; - check that all referenced ($ref) values exist
+(defn validate
+  "Check that the schema is well-formed as well as being syntactically
+  valid. Returns the unmodified schema if no issues were detected, or an
+  error map describing any issues that were found."
+  [schema]
+  ;; TODO use guards
+  (let [missing (missing-refs schema)]
+    (if-not (empty? missing)
+      (lib.error/error {:message "missing $refs" :missing missing})
+      schema)))
+
+;; TODO convert result names to kebab keywords
+;; e.g. "hashesPerSecond" -> :hashes-per-second
+;; - use original string names *and* kebab keywords
+;; TODO replace $ref with the referenced values
+;; - method > params
+;; - method > result
+(defn build
+  "Given a provider URL and an OpenRPC schema (converted to edn),
+  transform the schema into a client map. The options map is the same as
+  that provided to the client init function."
+  [url schema options]
+  {:pre [(string? url) (map? schema) (map? options)]}
+  (let [version (version schema)
+        metadata (metadata schema)
+        servers (servers schema)
+        ;; Generate a map from "path" (a vector of keywords representing
+        ;; an available RPC call) to a descriptive map.
+        methods (methods schema)]
+    {:rpc/version version
+     :rpc/metadata metadata
+     :rpc/servers servers
+     :rpc/methods methods
+     :rpc/url url}))

--- a/src/main/com/kubelt/sdk.cljs
+++ b/src/main/com/kubelt/sdk.cljs
@@ -57,4 +57,9 @@
        :resource #js {:add sdk.v1.resource/add-js!}
 
        ;; workspace
-       :workspace #js {:available sdk.v1.workspace/available-js!}})
+       :workspace #js {:available sdk.v1.workspace/available-js!}
+
+       ;; development (removed from production builds)
+       ;; TODO
+       ;;:develop #js {:rpc #js {:call sdk.v1.develop.rpc/call-js!}}
+       })

--- a/src/main/com/kubelt/spec/openrpc.cljc
+++ b/src/main/com/kubelt/spec/openrpc.cljc
@@ -16,7 +16,7 @@
 ;; Root
 ;; -----------------------------------------------------------------------------
 
-(def schema
+(def schema*
   [:map
    {:closed true
     :description "The root object of an OpenRPC document."}

--- a/src/main/com/kubelt/spec/openrpc.cljc
+++ b/src/main/com/kubelt/spec/openrpc.cljc
@@ -1,0 +1,61 @@
+(ns com.kubelt.spec.openrpc
+  "A schema for OpenRPC documents. We use it to validate a schema provided
+  to initialize an RPC client."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.openrpc.method :as openrpc.method]
+   [com.kubelt.spec.openrpc.server :as openrpc.server]
+   [com.kubelt.spec.openrpc.component :as openrpc.component]
+   [com.kubelt.spec.openrpc.info :as openrpc.info]
+   [com.kubelt.spec.openrpc.external :as openrpc.external]))
+
+
+(def version
+  :string)
+
+;; Root
+;; -----------------------------------------------------------------------------
+
+(def schema
+  [:map
+   {:closed true
+    :description "The root object of an OpenRPC document."}
+
+   [:openrpc
+    {:description "This string MUST be the semantic version number of
+the OpenRPC Specification version that the OpenRPC document uses. This
+field SHOULD be used by tooling specifications and clients to interpret
+the OpenRPC document. This is *not* related to the API info.version
+string."}
+    version]
+
+   [:info
+    {:description "Provides metadata about the API. The metadata MAY be
+used by tooling as required."}
+    openrpc.info/info]
+
+   [:methods
+    {:description "The available methods for the API. While it is
+required, the array may be empty (to handle security filtering, for
+example)."}
+    openrpc.method/methods]
+
+   [:components
+    {:optional true
+     :description "Holds a set of reusable objects for different aspects
+of the OpenRPC spec. All objects defined within the components object
+will have no effect on the API unless they are explicitly referenced
+from properties outside the components object."}
+    openrpc.component/components]
+
+   [:servers
+    {:optional true
+     :description "An array of Server objects, which provide connectivity
+information to a target server. If the servers property is not provided,
+or is an empty array, the default value would be a Server Object with a
+url value of 'localhost'."}
+    openrpc.server/servers]
+
+   [:external-docs
+    {:optional true}
+    openrpc.external/docs]])

--- a/src/main/com/kubelt/spec/openrpc/component.cljc
+++ b/src/main/com/kubelt/spec/openrpc/component.cljc
@@ -1,0 +1,75 @@
+(ns com.kubelt.spec.openrpc.component
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.openrpc.error :as openrpc.error]
+   [com.kubelt.spec.openrpc.example :as openrpc.example]
+   [com.kubelt.spec.openrpc.link :as openrpc.link]
+   [com.kubelt.spec.openrpc.pairing :as openrpc.pairing]
+   [com.kubelt.spec.openrpc.schema :as openrpc.schema]
+   [com.kubelt.spec.openrpc.tag :as openrpc.tag]
+   [com.kubelt.spec.openrpc.content :as openrpc.content]))
+
+
+(def errors
+  [:map-of :string openrpc.error/error])
+
+(def pairing
+  [:map-of :string openrpc.pairing/example])
+
+(def tags
+  [:map-of :string openrpc.tag/tag])
+
+(def links
+  [:map-of :string openrpc.link/link])
+
+(def schemas
+  [:map-of :keyword openrpc.schema/schema])
+
+(def examples
+  [:map-of :string openrpc.example/example])
+
+;; Components
+;; -----------------------------------------------------------------------------
+
+(def components
+  [:map
+   {:closed true
+    :description "An element to hold various schemas for the
+specification."}
+
+   [:content-descriptors
+    {:optional true
+     :description "An object to hold reusable Content Descriptor
+objects."}
+    openrpc.content/descriptors]
+
+   [:schemas
+    {:optional true
+     :description "An object to hold reusable Schema objects."}
+    schemas]
+
+   [:examples
+    {:optional true
+     :description "An object to hold reusable Example objects."}
+    examples]
+
+   [:links
+    {:optional true
+     :description "An object to hold reusable Link objects."}
+    links]
+
+   [:errors
+    {:optional true
+     :description "An object to hold reusable Error objects."}
+    errors]
+
+   [:example-pairing-objects
+    {:optional true
+     :description "An object to hold reusable Example Pairing objects."}
+    pairing]
+
+   [:tags
+    {:optional true
+     :description "An object to hold reusable Tag objects."}
+    tags]])

--- a/src/main/com/kubelt/spec/openrpc/content.cljc
+++ b/src/main/com/kubelt/spec/openrpc/content.cljc
@@ -1,0 +1,72 @@
+(ns com.kubelt.spec.openrpc.content
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.schema :as openrpc.schema]))
+
+
+(def name
+  :string)
+
+(def summary
+  :string)
+
+(def description
+  :string)
+
+(def required
+  :boolean)
+
+(def deprecated
+  :boolean)
+
+;; Content Descriptor
+;; -----------------------------------------------------------------------------
+
+(def descriptor
+  [:map
+   {:closed true
+    :description "A Content Descriptor is a reusable way of describing
+either parameters or a result. They MUST have a schema."}
+
+   [:name
+    {:description "Name of the content that is being described. If the
+content described is a method parameter assignable 'by-name', this field
+SHALL define the parameter's key (i.e. name)."}
+    name]
+
+   [:schema openrpc.schema/schema]
+
+   [:summary
+    {:optional true
+     :description "A short summary of the content that is being
+ described."}
+    summary]
+
+   [:description
+    {:optional true
+     :description "A verbose explanation of the content descriptor
+behaviour."}
+    description]
+
+   [:required
+    {:optional true
+     :description "Determines if the content is a required field. Default
+value is false."}
+    required]
+
+   [:deprecated
+    {:optional true
+     :description "Specifies that the content is deprecated and SHOULD be
+   transitioned out of usage. Default value is false."
+     :default false}
+    deprecated]])
+
+;; [Content Descriptor]
+;; -----------------------------------------------------------------------------
+
+(def descriptors
+  [:and
+   {:description "An object to hold reusable Content Descriptor objects."}
+   [:map-of :keyword descriptor]])

--- a/src/main/com/kubelt/spec/openrpc/error.cljc
+++ b/src/main/com/kubelt/spec/openrpc/error.cljc
@@ -1,0 +1,49 @@
+(ns com.kubelt.spec.openrpc.error
+  "A schema for an OpenRPC Error object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]))
+
+
+(def code
+  :int)
+
+(def message
+  :string)
+
+(def data
+  :any)
+
+;; Error
+;; -----------------------------------------------------------------------------
+
+(def error
+  [:map
+   {:closed true
+    :description "Defines an application level error."}
+
+   [:code
+    {:description "A Number that indicates the error type that
+occurred. This MUST be an integer. The error codes from and including
+-32768 to -32000 are reserved for pre-defined errors. These pre-defined
+errors SHOULD be assumed to be returned from any JSON-RPC API."}
+    code]
+
+   [:message
+    {:description "A short description of the error. The message SHOULD
+be limited to a concise single sentence."}
+    message]
+
+   [:data
+    {:optional true
+     :description "A primitive or structured value that contains
+additional information about the error. This may be omitted. The value
+of this member is defined by the server, e.g. detailed error
+information, nested errors, etc."}
+    data]])
+
+;; [Error]
+;; -----------------------------------------------------------------------------
+
+(def errors
+  [:vector [:or openrpc.reference/reference error]])

--- a/src/main/com/kubelt/spec/openrpc/example.cljc
+++ b/src/main/com/kubelt/spec/openrpc/example.cljc
@@ -1,0 +1,61 @@
+(ns com.kubelt.spec.openrpc.example
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name]))
+
+
+(def name
+  :string)
+
+(def summary
+  :string)
+
+(def description
+  :string)
+
+(def value
+  :any)
+
+(def external-value
+  :string)
+
+;; Example
+;; -----------------------------------------------------------------------------
+
+(def example
+  [:map
+   {:closed true
+    :description "Defines an example that is intended to match a Content
+Descriptor Schema. If the the Content Descriptor Schema includes
+'examples', the value from *this* Example object supercedes the value of
+the schema example."}
+
+   [:name
+    {:optional true
+     :description "Canonical name of the example."}
+    name]
+
+   [:summary
+    {:optional true
+     :description "Short description for the example."}
+    summary]
+
+   [:description
+    {:optional true
+     :description "A verbose explanation of the example."}
+    description]
+
+   [:value
+    {:optional true
+     :description "Embedded literal example. The 'value' field and
+'externalValue' field are mutually exclusive. To represent examples of
+media types that cannot naturally be represented in JSON, use a string
+value to contain the example, escaping where necessary."}
+    value]
+
+   [:external-value
+    {:optional true
+     :description "A URL that points to the literal example. This
+provides the capability to reference examples that cannot easily be
+included in JSON documents. The 'value' and 'externalValue' fields are
+mutually exclusive."}
+    external-value]])

--- a/src/main/com/kubelt/spec/openrpc/external.cljc
+++ b/src/main/com/kubelt/spec/openrpc/external.cljc
@@ -1,0 +1,28 @@
+(ns com.kubelt.spec.openrpc.external
+  "A schema for the OpenRPC External Documentation object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+
+(def url
+  :string)
+
+(def description
+  :string)
+
+;; External Docs
+;; -----------------------------------------------------------------------------
+
+(def docs
+  [:map
+   {:closed true
+    :description "Allows referencing an external resource for extended
+documentation."}
+
+   [:url
+    {:description "The URL for the target documentation. Value MUST be
+in the format of a URL."}
+    url]
+
+   [:description
+    {:description "A verbose explanation of the target documentation."}
+    description]])

--- a/src/main/com/kubelt/spec/openrpc/info.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info.cljc
@@ -1,0 +1,55 @@
+(ns com.kubelt.spec.openrpc.info
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.openrpc.info.contact :as info.contact]
+   [com.kubelt.spec.openrpc.info.license :as info.license]))
+
+
+(def version
+  :string)
+
+(def title
+  :string)
+
+(def description
+  :string)
+
+(def terms
+  :string)
+
+;; Info
+;; -----------------------------------------------------------------------------
+
+(def info
+  [:map
+   {:closed true}
+
+   [:version
+    {:description "The version of the OpenRPC document (which is
+distinct from the OpenRPC Specification version or the API
+implementation version."}
+    version]
+
+   [:title
+    {:description "The title of the application."}
+    title]
+
+   [:description
+    {:optional true
+     :description "A verbose description of the application."}
+    description]
+
+   [:terms-of-service
+    {:optional true
+     :description "A URL to the Terms of Service for the API. MUST be in
+the format of a URL."}
+    terms]
+
+   [:contact
+    {:optional true}
+    info.contact/contact]
+
+   [:license
+    {:optional true}
+    info.license/license]])

--- a/src/main/com/kubelt/spec/openrpc/info/contact.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/contact.cljc
@@ -1,0 +1,32 @@
+(ns com.kubelt.spec.openrpc.info.contact
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name]))
+
+
+(def name
+  [:and
+   {:description "The identifying name of the contact
+person/organization."}
+   :string])
+
+(def url
+  [:and
+   {:description "The URL pointing to the contact information. MUST be
+in the format of a URL."}
+   :string])
+
+(def email
+  [:and
+   {:description "The e-mail address of the contact
+person/organization. MUST be in the format of an e-mail address."}
+   :string])
+
+;; Contact
+;; -----------------------------------------------------------------------------
+
+(def contact
+  [:map
+   [:name {:optional true} name]
+   [:url {:optional true} url]
+   [:email {:optional true} email]])

--- a/src/main/com/kubelt/spec/openrpc/info/license.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/license.cljc
@@ -1,0 +1,24 @@
+(ns com.kubelt.spec.openrpc.info.license
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name]))
+
+
+(def name
+  [:and
+   {:description "The license name for the API."}
+   :string])
+
+(def url
+  [:and
+   {:description "A URL to the license used for the API. MUST be in the
+format of a URL."}
+   :string])
+
+;; License
+;; -----------------------------------------------------------------------------
+
+(def license
+  [:map
+   [:name name]
+   [:url {:optional true} url]])

--- a/src/main/com/kubelt/spec/openrpc/link.cljc
+++ b/src/main/com/kubelt/spec/openrpc/link.cljc
@@ -1,0 +1,84 @@
+(ns com.kubelt.spec.openrpc.link
+  "A schema for an OpenRPC Link object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]
+   [com.kubelt.spec.openrpc.runtime :as openrpc.runtime]
+   [com.kubelt.spec.openrpc.server :as openrpc.server]))
+
+
+(def name
+  :string)
+
+(def description
+  :string)
+
+(def summary
+  :string)
+
+(def method
+  :string)
+
+(def params
+  [:map-of :string [:or openrpc.runtime/expression :any]])
+
+;; Link
+;; -----------------------------------------------------------------------------
+
+(def link
+  [:map
+   {:closed true
+    :description "A Link object represents a possible design-time link
+for a result. The presence of a link does not guarantee the caller's
+ability to successfully invoke it, rather it provides a known
+relationship and traversal mechanism between results and other methods.
+
+Unlike *dynamic* links (i.e. links provided in the result payload), the
+OpenRPC linking mechanism does not require link information in the
+runtime result.
+
+For computing links, and providing instructions to execute them, a
+runtime expression is used for accessing values in a method and useing
+them as parameters while invoking the linked method."}
+
+   [:name
+    {:description "Canonical name of the link."}
+    name]
+
+   [:description
+    {:optional true
+     :description "A description of the link."}
+    description]
+
+   [:summary
+    {:optional true
+     :description "Short description for the link."}
+    summary]
+
+   [:method
+    {:optional true
+     :description "The name of an *existing*, resolvable OpenRPC method,
+as defined with a unique 'method'. This field MUST resolve to a unique
+Method object. As opposed to OpenAPI, relative 'method' values ARE NOT
+permitted."}
+    method]
+
+   [:params
+    {:optional true
+     :description "A map representing parameters to pass to a method as
+specified with 'method'. The key is the parameter name to be used,
+whereas the value can be a constant or a runtime expression to be
+evaluated and passed to the linked method."}
+    params]
+
+   [:server
+    {:optional true
+     :description "A Server object to be used by the target method."}
+    openrpc.server/server]])
+
+;; [Link]
+;; -----------------------------------------------------------------------------
+
+(def links
+  [:vector [:or openrpc.reference/reference link]])

--- a/src/main/com/kubelt/spec/openrpc/method.cljc
+++ b/src/main/com/kubelt/spec/openrpc/method.cljc
@@ -1,0 +1,135 @@
+(ns com.kubelt.spec.openrpc.method
+  "A schema for an OpenRPC Method object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [methods name])
+  (:require
+   [com.kubelt.spec.openrpc.content :as openrpc.content]
+   [com.kubelt.spec.openrpc.error :as openrpc.error]
+   [com.kubelt.spec.openrpc.external :as openrpc.external]
+   [com.kubelt.spec.openrpc.link :as openrpc.link]
+   [com.kubelt.spec.openrpc.pairing :as openrpc.pairing]
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]
+   [com.kubelt.spec.openrpc.server :as openrpc.server]
+   [com.kubelt.spec.openrpc.tag :as openrpc.tag]))
+
+
+(def name
+  :string)
+
+(def summary
+  :string)
+
+(def description
+  :string)
+
+(def deprecated
+  :boolean)
+
+(def params
+  [:vector [:or openrpc.reference/reference openrpc.content/descriptor]])
+
+(def result
+  [:or openrpc.reference/reference openrpc.content/descriptor])
+
+(def param-structure
+  [:enum "by-name" "by-position" "either"])
+
+;; Method
+;; -----------------------------------------------------------------------------
+
+(def method
+  [:map
+   {:closed true
+    :description "Describes the interface for the given method name. The
+method name is used as the 'method' field of the JSON-RPC body. It
+therefore MUST be unique."}
+
+   [:name
+    {:description "The canonical name for the method. The name MUST be
+ unique within the methods array."}
+    name]
+
+   [:params
+    {:description "A list of parameters that are applicable for this
+method. The list MUST NOT include duplicated parameters and therefore
+require 'name' to be unique. The list can use the Reference object to
+link to parameters that are defined by the Content Descriptor
+object. All optional params MUST be positioned after all required params
+in the list."}
+    params]
+
+   [:result
+    {:description "The description of the result returned by the
+method. It MUST be a Content Descriptor."}
+    result]
+
+   [:summary
+    {:optional true
+     :description "A short summary of what the method does."}
+    summary]
+
+   [:description
+    {:optional true
+     :description "A verbose explanation of the method behaviour."}
+    description]
+
+   [:deprecated
+    {:optional true
+     :description "Declares this method to be deprecated. Consumers
+SHOULD refrain from usage of the declared method. Default value is
+false."}
+    deprecated]
+
+   [:external-docs
+    {:optional true
+     :description "Additional external documentation for this method."}
+    openrpc.external/docs]
+
+   [:tags
+    {:optional true
+     :description "A list of tags for API documentation control. Tags can
+be used for logical grouping of methods by resources or any other
+qualifier."}
+    openrpc.tag/tags]
+
+   [:servers
+    {:optional true
+     :description "An alternative 'servers' array to service this
+method. If an alternative 'servers' array is specified at the root
+level, it will be overridden by this value."}
+    openrpc.server/servers]
+
+   [:errors
+    {:optional true
+     :description "A list of custom application defined errors that MAY
+be returned. The errors MUST have unique error codes."}
+    openrpc.error/errors]
+
+   [:links
+    {:optional true
+     :description "A list of possible links from this method call."}
+    openrpc.link/links]
+
+   [:param-structure
+    {:optional true
+     :description "The expected format of the parameters. As per the
+JSON-RPC 2.0 specification, the params of a JSON-RPC request object may
+be an array, object, or either (represented as 'by-position', 'by-name',
+and 'either' respectively). When a method has a 'paramStructure' value
+of 'by-name', callers of the method MUST send a JSON-RPC request object
+whose 'params' field is an object. Further, the key names of the
+'params' object MUST be the same as the 'contentDescriptor.name's for
+the given method. Defaults to 'either'."}
+    param-structure]
+
+   [:examples
+    {:optional true
+     :description "Array of Example Pairing object where each example
+includes a valid params-to-result Content Descriptor pairing."}
+    openrpc.pairing/examples]])
+
+;; [Method]
+;; -----------------------------------------------------------------------------
+
+(def methods
+  [:vector [:or openrpc.reference/reference method]])

--- a/src/main/com/kubelt/spec/openrpc/pairing.cljc
+++ b/src/main/com/kubelt/spec/openrpc/pairing.cljc
@@ -1,0 +1,64 @@
+(ns com.kubelt.spec.openrpc.pairing
+  ""
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.example :as openrpc.example]
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]))
+
+
+(def name
+  :string)
+
+(def description
+  :string)
+
+(def summary
+  :string)
+
+(def params
+  [:vector [:or openrpc.example/example openrpc.reference/reference]])
+
+(def results
+  [:or openrpc.example/example openrpc.reference/reference])
+
+;; Example Pairing
+;; -----------------------------------------------------------------------------
+
+(def example
+  [:map
+   {:closed true
+    :description "The Example Pairing object consists of a set of
+example params and result. The result is what you can expect from the
+JSON-RPC service given the exact params."}
+
+   [:name
+    {:optional true
+     :description "Name for the example pairing."}
+    name]
+
+   [:description
+    {:optional true
+     :description "A verbose explanation of the example pairing."}
+    description]
+
+   [:summary
+    {:optional true
+     :description "Short description for the example pairing"}
+    summary]
+
+   [:params
+    {:optional true
+     :description "Example parameters."}
+    params]
+
+   [:result
+    {:optional true
+     :description "Example result."}
+    results]])
+
+;; [Example Pairing]
+;; -----------------------------------------------------------------------------
+
+(def examples
+  [:vector example])

--- a/src/main/com/kubelt/spec/openrpc/reference.cljc
+++ b/src/main/com/kubelt/spec/openrpc/reference.cljc
@@ -1,0 +1,17 @@
+(ns com.kubelt.spec.openrpc.reference
+  "A schema for an OpenRPC Reference object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+(def $ref
+  :string)
+
+;; Reference
+;; -----------------------------------------------------------------------------
+
+(def reference
+  [:map
+   {:closed true
+    :description "A simple object to allow referencing other components
+in the specification, internally and externally."}
+
+   [:$ref $ref]])

--- a/src/main/com/kubelt/spec/openrpc/runtime.cljc
+++ b/src/main/com/kubelt/spec/openrpc/runtime.cljc
@@ -1,0 +1,15 @@
+(ns com.kubelt.spec.openrpc.runtime
+  "A schema for an OpenRPC Runtime Expression object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; Runtime Expression
+;; -----------------------------------------------------------------------------
+
+(def expression
+  [:and
+   {:description "Runtime expressions allow the user to define an
+expression which will evaluate to a string once the desired value(s) are
+known. The are used when the desired value of a link or server can only
+be constructed at run time. This mechanism is used by Link objects and
+Server Variables."}
+   :string])

--- a/src/main/com/kubelt/spec/openrpc/schema.cljc
+++ b/src/main/com/kubelt/spec/openrpc/schema.cljc
@@ -1,0 +1,23 @@
+(ns com.kubelt.spec.openrpc.schema
+  "A schema for an OpenRPC Schema object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]))
+
+
+;; TODO
+(def json-schema
+  :any)
+
+;; Schema
+;; -----------------------------------------------------------------------------
+
+(def schema
+  [:or
+   {:description "Defines the input and output data types. Schema
+Objects MUST follow the specifications outlined in the JSON Schema
+Specification v7. Alternately, any time a Schema Object can be used, a
+Reference Object can be used in its place. This allows referencing
+definitions instead of defining them inline."}
+   openrpc.reference/reference
+   json-schema])

--- a/src/main/com/kubelt/spec/openrpc/server.cljc
+++ b/src/main/com/kubelt/spec/openrpc/server.cljc
@@ -1,0 +1,63 @@
+(ns com.kubelt.spec.openrpc.server
+  "A schema for an OpenRPC Server object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.runtime :as openrpc.runtime]
+   [com.kubelt.spec.openrpc.server.variable :as openrpc.server.variable]))
+
+
+(def name
+  :string)
+
+(def url
+  openrpc.runtime/expression)
+
+(def summary
+  :string)
+
+(def description
+  :string)
+
+;; Server
+;; -----------------------------------------------------------------------------
+
+(def server
+  [:map
+   {:closed true
+    :description "An object representing a Server."}
+
+   [:name
+    {:description "A name to be used as the canonical name for the
+server."}
+    name]
+
+   [:url
+    {:description "A URL to the target host. This URL supports Server
+Variables and MAY be relative, to indicate that the host location is
+relative to the location where the OpenRPC document is being
+served. Server Variables are passed into the Runtime Expression to
+produce a server URL."}
+    url]
+
+   [:summary
+    {:optional true
+     :description "A short summary of what the server is."}
+    summary]
+
+   [:description
+    {:optional true
+     :description "A description of the host described by the URL."}
+    description]
+
+   [:variables
+    {:optional true
+     :description "A map between a variable name and its value. The
+value is passed into the Runtime Expression to produce a server URL."}
+    openrpc.server.variable/variables]])
+
+;; [Server]
+;; -----------------------------------------------------------------------------
+
+(def servers
+  [:vector server])

--- a/src/main/com/kubelt/spec/openrpc/server/variable.cljc
+++ b/src/main/com/kubelt/spec/openrpc/server/variable.cljc
@@ -1,0 +1,46 @@
+(ns com.kubelt.spec.openrpc.server.variable
+  "A schema for an OpenRPC Server Variable object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+
+(def default
+  :string)
+
+(def description
+  :string)
+
+(def enum
+  [:vector :string])
+
+;; Server Variable
+;; -----------------------------------------------------------------------------
+
+(def variable
+  [:map
+   {:closed true
+    :description "An object representing a Server Variable for server
+URL template substitution."}
+
+   [:default
+    {:description "The default value to use for the substitution, which
+SHALL be sent if an alternate value is *not* supplied. Note that this
+behaviour is different than the Schema Object's treatment of default
+values, because in those cases parameter values are optional."}
+    default]
+
+   [:description
+    {:optional true
+     :description "An optional description for the server variable."}
+    description]
+
+   [:enum
+    {:optional true
+     :description "An enumeration of string values to be used if the
+substitution options are from a limited set."}
+    enum]])
+
+;; [Server Variable]
+;; -----------------------------------------------------------------------------
+
+(def variables
+  [:map-of :string variable])

--- a/src/main/com/kubelt/spec/openrpc/tag.cljc
+++ b/src/main/com/kubelt/spec/openrpc/tag.cljc
@@ -1,0 +1,49 @@
+(ns com.kubelt.spec.openrpc.tag
+  "A schema for an OpenRPC Tag object."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.external :as openrpc.external]
+   [com.kubelt.spec.openrpc.reference :as openrpc.reference]))
+
+
+(def name
+  :string)
+
+(def summary
+  :string)
+
+(def description
+  :string)
+
+;; Tag
+;; -----------------------------------------------------------------------------
+
+(def tag
+  [:map
+   {:closed true
+    :description "Adds metadata to a single tag that is used by the
+Method object. It is not mandatory to have a Tag object per tag defined
+in the Method object instances."}
+
+   [:name
+    {:description "The name of the tag."}
+    name]
+
+   [:summary
+    {:optional true
+     :description "A short summary of the tag."}
+    summary]
+
+   [:description
+    {:optional true
+     :description "A verbose explanation for the tag."}
+    description]
+
+   [:external-docs {:optional true} openrpc.external/docs]])
+
+;; [Tag]
+;; -----------------------------------------------------------------------------
+
+(def tags
+  [:or openrpc.reference/reference tag])

--- a/src/main/com/kubelt/spec/rpc.cljc
+++ b/src/main/com/kubelt/spec/rpc.cljc
@@ -1,42 +1,25 @@
 (ns com.kubelt.spec.rpc
   "A schema for RPC client configuration."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
-  (:refer-clojure :exclude [methods]))
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
 
 ;; path
 ;; -----------------------------------------------------------------------------
 ;; RPC calls as defined in an OpenRPC schema are strings. We prefer to
 ;; use a vector of keywords, which we get by breaking apart the call
 ;; name at each underscore and converting the resulting strings to
-;; keywords.
+;; keywords. Converting to structured data makes them nicer to
+;; manipulate when we want to do things like adding a prefix.
 
 (def path
   [:vector :keyword])
 
 ;; params
 ;; -----------------------------------------------------------------------------
+;; This is the definition of the parameter map for an RPC request. This
+;; is a basic check, but a more detailed parameter map schema for a
+;; specific call lives inside the client as part of the transformed
+;; schema.
 
 (def params
   ;; TODO
   :map)
-
-;; client
-;; -----------------------------------------------------------------------------
-;; An RPC client.
-
-;; TODO flesh these specs out to describe the RPC client map that
-;; results from the (rpc/init) call.
-(def version :string)
-(def metadata :map)
-(def servers [:vector :any])
-(def methods :map)
-(def url :string)
-
-(def client
-  [:map
-   [:com.kubelt/type [:enum :kubelt.type/rpc.client]]
-   [:rpc/version version]
-   [:rpc/metadata metadata]
-   [:rpc/servers servers]
-   [:rpc/methods methods]
-   [:rpc/url url]])

--- a/src/main/com/kubelt/spec/rpc.cljc
+++ b/src/main/com/kubelt/spec/rpc.cljc
@@ -1,0 +1,48 @@
+(ns com.kubelt.spec.rpc
+  "A schema for RPC client configuration."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [methods]))
+
+;; url
+;; -----------------------------------------------------------------------------
+
+(def url
+  :string)
+
+;; path
+;; -----------------------------------------------------------------------------
+;; RPC calls as defined in an OpenRPC schema are strings. We prefer to
+;; use a vector of keywords, which we get by breaking apart the call
+;; name at each underscore and converting the resulting strings to
+;; keywords.
+
+(def path
+  [:vector :keyword])
+
+;; params
+;; -----------------------------------------------------------------------------
+
+(def params
+  ;; TODO
+  :map)
+
+;; client
+;; -----------------------------------------------------------------------------
+;; An RPC client.
+
+;; TODO flesh these specs out to describe the RPC client map that
+;; results from the (rpc/init) call.
+(def version :string)
+(def metadata :map)
+(def servers [:vector :any])
+(def methods :map)
+(def url :string)
+
+(def client
+  [:map
+   [:com.kubelt/type [:enum :kubelt.type/rpc.client]]
+   [:rpc/version version]
+   [:rpc/metadata metadata]
+   [:rpc/servers servers]
+   [:rpc/methods methods]
+   [:rpc/url url]])

--- a/src/main/com/kubelt/spec/rpc.cljc
+++ b/src/main/com/kubelt/spec/rpc.cljc
@@ -3,12 +3,6 @@
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [methods]))
 
-;; url
-;; -----------------------------------------------------------------------------
-
-(def url
-  :string)
-
 ;; path
 ;; -----------------------------------------------------------------------------
 ;; RPC calls as defined in an OpenRPC schema are strings. We prefer to

--- a/src/main/com/kubelt/spec/rpc/call.cljc
+++ b/src/main/com/kubelt/spec/rpc/call.cljc
@@ -1,0 +1,11 @@
+(ns com.kubelt.spec.rpc.call
+  "Schemas related to RPC requests."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to RPC client (call) function.
+
+(def options
+  ;; TODO
+  :map)

--- a/src/main/com/kubelt/spec/rpc/client.cljc
+++ b/src/main/com/kubelt/spec/rpc/client.cljc
@@ -1,0 +1,25 @@
+(ns com.kubelt.spec.rpc.client
+  "An RPC client map."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [methods]))
+
+;; client
+;; -----------------------------------------------------------------------------
+;; An RPC client.
+
+;; TODO flesh these specs out to describe the RPC client map that
+;; results from the (rpc/init) call.
+(def version :string)
+(def metadata :map)
+(def servers [:vector :any])
+(def methods :map)
+(def url :string)
+
+(def client
+  [:map
+   [:com.kubelt/type [:enum :kubelt.type/rpc.client]]
+   [:rpc/version version]
+   [:rpc/metadata metadata]
+   [:rpc/servers servers]
+   [:rpc/methods methods]
+   [:rpc/url url]])

--- a/src/main/com/kubelt/spec/rpc/init.cljc
+++ b/src/main/com/kubelt/spec/rpc/init.cljc
@@ -2,6 +2,16 @@
   "Schemas related to RPC client (init) function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
 
+;; url
+;; -----------------------------------------------------------------------------
+;; The init call takes a provider URL (RPC endpoint) as a parameter.
+
+(def url
+  :string)
+
+;; http-client
+;; -----------------------------------------------------------------------------
+
 ;; TODO re-use existing HTTP client definition
 (def http-client
   :map)
@@ -10,7 +20,6 @@
 ;; -----------------------------------------------------------------------------
 ;; The options map that may be passed to RPC client (init) function.
 
-;; TODO
 (def options
   [:map
    [:http/client {:optional true} http-client]])

--- a/src/main/com/kubelt/spec/rpc/init.cljc
+++ b/src/main/com/kubelt/spec/rpc/init.cljc
@@ -1,0 +1,16 @@
+(ns com.kubelt.spec.rpc.init
+  "Schemas related to RPC client (init) function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; TODO re-use existing HTTP client definition
+(def http-client
+  :map)
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to RPC client (init) function.
+
+;; TODO
+(def options
+  [:map
+   [:http/client {:optional true} http-client]])

--- a/src/main/com/kubelt/spec/rpc/methods.cljc
+++ b/src/main/com/kubelt/spec/rpc/methods.cljc
@@ -1,0 +1,13 @@
+(ns com.kubelt.spec.rpc.methods
+  "Schemas related to the rpc/methods function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that can be passed to the RPC client (methods) function.
+
+(def options
+  [:map
+   [:methods/sort? {:optional true} :boolean]
+   [:methods/depth {:optional true} nat-int?]
+   [:methods/search {:optional true} :string]])

--- a/src/main/com/kubelt/spec/rpc/request.cljc
+++ b/src/main/com/kubelt/spec/rpc/request.cljc
@@ -1,0 +1,21 @@
+(ns com.kubelt.spec.rpc.request
+  "Schemas related to RPC requests."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to RPC client (request) function.
+
+(def options
+  ;; TODO
+  :map)
+
+;; request
+;; -----------------------------------------------------------------------------
+;; An RPC request map.
+;;
+;; TODO re-use the HTTP request map schema.
+
+(def request
+  ;; TODO
+  :map)


### PR DESCRIPTION
Fix following warning 

```
------ WARNING - :ns-var-clash -------------------------------------------------
 File: /Users/tangrammer/git/kubelt/kubelt/src/main/com/kubelt/spec/openrpc.cljc:19:1
 Namespace com.kubelt.spec.openrpc.schema clashes with var com.kubelt.spec.openrpc/schema
--------------------------------------------------------------------------------
````

the problem also prevents code evaluation in dev local env, so fixing it enable normal dev REPL flow