### PR TITLE
Feat/rpc client ddt tasks

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
@@ -65,5 +65,6 @@
                                                                         (println :method rpc-method
                                                                                  :params rpc-params)
                                                                         (println "call result: " r)))))))
-                          (lib.promise/catch (fn [error]
-                                               (println "we got an error" error))))))))))})
+                          (lib.promise/catch (fn [e]
+                                               (println (ex-message e))
+                                               (prn (ex-data e)))))))))))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
@@ -3,13 +3,14 @@
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [clojure.string :as cstr]
+   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
    [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
    [com.kubelt.ddt.util :as ddt.util]
    [com.kubelt.lib.promise :as lib.promise]
+   [com.kubelt.rpc :as rpc]
    [com.kubelt.sdk.v1.core :as sdk.core]
-   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
-   [com.kubelt.rpc :as rpc]))
+   [taoensso.timbre :as log]))
 
 (defonce command
   {:command "call <method>"
@@ -62,8 +63,8 @@
                                                                               rpc-method
                                                                               (into [] (vals rpc-params)))
                                                     (lib.promise/then (fn [r]
-                                                                        (println :method rpc-method
-                                                                                 :params rpc-params)
+                                                                        (log/debug :rpc/call {:method rpc-method
+                                                                                              :params rpc-params})
                                                                         (println "call result: " r)))))))
                           (lib.promise/catch (fn [e]
                                                (println (ex-message e))

--- a/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/call.cljs
@@ -2,15 +2,19 @@
   "Make an RPC call."
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [clojure.string :as cstr])
-  (:require
-   [com.kubelt.ddt.options :as ddt.options]))
+   [clojure.string :as cstr]
+   [com.kubelt.ddt.options :as ddt.options]
+   [com.kubelt.ddt.prompt :as ddt.prompt]
+   [com.kubelt.ddt.util :as ddt.util]
+   [com.kubelt.lib.promise :as lib.promise]
+   [com.kubelt.sdk.v1.core :as sdk.core]
+   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
+   [com.kubelt.rpc :as rpc]))
 
 (defonce command
   {:command "call <method>"
    :desc "Make an RPC call."
    :requiresArg true
-
    :builder (fn [^Yargs yargs]
               ;; Include the common options.
               (ddt.options/options yargs)
@@ -20,10 +24,9 @@
                                 :describe "An RPC parameter (<name>=<value>)"
                                 :requiresArg true
                                 :demandOption "param name and value are required"
-                                :string true
+                                :array true
                                 :nargs 1}]
                 (.option yargs "param" config))
-
               ;; Return a parameter map rather than an array
               ;; of "<name>=<value>" strings.
               (let [param-fn
@@ -37,10 +40,30 @@
 
    :handler (fn [args]
               (let [args-map (ddt.options/to-map args)
-                    method (get args-map :method)
+                    method (->> (cstr/split (get args-map :method) #":")
+                                (filter (complement cstr/blank?))
+                                (mapv keyword))
                     params (get args-map :param)]
-                ;;(prn args-map)
-                ;;(prn params)
-                (println "RPC call:" method)
-                (doseq [[k v] params]
-                  (println "->" (name k) ":" v))))})
+                (ddt.prompt/ask-password!
+                 (fn [err result]
+                   (ddt.util/exit-if err)
+                   (ddt.auth/authenticate
+                    args-map
+                    (.-password result)
+                    (fn [sys]
+                      (-> (sdk.core/rpc-api sys (-> sys :crypto/wallet :wallet/address))
+                          (lib.promise/then (fn [api]
+                                              (let [client (->> (update-in api [:methods 1 :result] assoc :name "pong" :schema {:type "string"})
+                                                                (rpc/init "url"))
+                                                    request (rpc/request* client method params)
+                                                    rpc-method (:method/name (:rpc/method request))
+                                                    rpc-params (:rpc/params request)]
+                                                (-> (sdk.core/call-rpc-method sys (-> sys :crypto/wallet :wallet/address)
+                                                                              rpc-method
+                                                                              (into [] (vals rpc-params)))
+                                                    (lib.promise/then (fn [r]
+                                                                        (println :method rpc-method
+                                                                                 :params rpc-params)
+                                                                        (println "call result: " r)))))))
+                          (lib.promise/catch (fn [error]
+                                               (println "we got an error" error))))))))))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -33,8 +33,6 @@
                         (lib.promise/then (fn [api]
                                             (println (->> (update-in api [:methods 1 :result] assoc :name "pong" :schema {:type "string"})
                                                           (rpc/init "url")
-                                                          :rpc/methods
-                                                          keys
-                                                          vec))))
+                                                          (rpc/methods)))))
                         (lib.promise/catch (fn [error]
                                             (println "we got an error" error)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -2,13 +2,13 @@
   "List available RPC methods."
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
    [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
    [com.kubelt.ddt.util :as ddt.util]
    [com.kubelt.lib.promise :as lib.promise]
-   [com.kubelt.sdk.v1.core :as sdk.core]
-   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
-   [com.kubelt.rpc :as rpc]))
+   [com.kubelt.rpc :as rpc]
+   [com.kubelt.sdk.v1.core :as sdk.core]))
 
 (defonce command
   {:command "list"

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -34,5 +34,6 @@
                                             (println (->> (update-in api [:methods 1 :result] assoc :name "pong" :schema {:type "string"})
                                                           (rpc/init "url")
                                                           (rpc/methods)))))
-                        (lib.promise/catch (fn [error]
-                                            (println "we got an error" error)))))))))})
+                        (lib.promise/catch (fn [e]
+                                               (println (ex-message e))
+                                               (prn (ex-data e))))))))))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -2,17 +2,143 @@
   "List available RPC methods."
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.ddt.options :as ddt.options]))
+   [com.kubelt.ddt.options :as ddt.options]
+   [com.kubelt.ddt.prompt :as ddt.prompt]
+   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.ddt.util :as ddt.util]
+   [com.kubelt.spec.openrpc :as spec.openrpc]
+   [com.kubelt.lib.promise :as lib.promise]
+   [malli.core :as mc]
+   [com.kubelt.sdk.v1.core :as sdk.core]
+   [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
+   [com.kubelt.proto.http :as proto.http]
+   [com.kubelt.lib.json :as lib.json]
+   [com.kubelt.rpc :as rpc]))
 
 (defonce command
-  {:command "list "
+  {:command "list"
    :aliases ["ls"]
    :desc "List available RPC methods."
-   :requiresArg true
-   :builder (fn [yargs]
-              yargs)
+  :requiresArg false
 
-   :handler (fn [args]
-              (let [args-map (ddt.options/to-map args)
-                    app-name (get args-map :app-name)]
-                (println "RPC calls: fixme")))})
+  :builder (fn [^Yargs yargs]
+             ;; Include the common options.
+             (ddt.options/options yargs)
+             yargs)
+
+  :handler (fn [args]
+             (ddt.prompt/ask-password!
+              (fn [err result]
+                (ddt.util/exit-if err)
+                (ddt.auth/authenticate
+                 (ddt.options/to-map args)
+                 (.-password result)
+                 (fn [sys]
+                   (println
+
+                    (-> (sdk.core/rpc-api sys (-> sys :crypto/wallet :wallet/address))
+                        (lib.promise/then (fn [api]
+                                            (->> (lib.json/json-str->edn api lib.json/keyword-mapper)
+                                                 (rpc/init "url" )
+                                                 (println )
+                                                )
+
+
+                                            (println api)))
+                        )
+
+                    )
+                   (prn "joeee" (-> sys :crypto/wallet :wallet/address)  ))))))})
+
+(comment
+
+  (def x (lib.json/json-str->edn
+          "{
+    \"jsonrpc\": \"2.0\",
+    \"id\": 1,
+    \"result\": {
+        \"openrpc\": \"1.2.6\",
+        \"info\": {
+            \"title\": \"Kubelt Core\",
+            \"version\": \"0.0.0\"
+        },
+        \"methods\": [
+            {
+                \"name\": \"kb_ping\",
+                \"params\": [],
+                \"result\": {
+                    \"name\": \"pong\",
+                    \"schema\": {
+                        \"type\": \"string\"
+                    }
+                }
+            },
+            {
+                \"name\": \"kb_pong\",
+                \"params\": [],
+                \"result\": {}
+            },
+            {
+                \"name\": \"kb_auth\",
+                \"params\": [
+                    {
+                        \"name\": \"address\",
+                        \"summary\": \"Account address\",
+                        \"required\": true,
+                        \"schema\": {
+                            \"type\": \"string\"
+                        }
+                    }
+                ],
+                \"result\": {
+                    \"name\": \"nonce\",
+                    \"schema\": {
+                        \"type\": \"string\"
+                    }
+                }
+            },
+            {
+                \"name\": \"kb_auth_verify\",
+                \"params\": [
+                    {
+                        \"name\": \"nonce\",
+                        \"summary\": \"Challenge Nonce\",
+                        \"required\": true,
+                        \"schema\": {
+                            \"type\": \"string\"
+                        }
+                    },
+                    {
+                        \"name\": \"signature\",
+                        \"summary\": \"Nonce Signature\",
+                        \"required\": true,
+                        \"schema\": {
+                            \"type\": \"string\"
+                        }
+                    }
+                ],
+                \"result\": {
+                    \"name\": \"jwt\",
+                    \"schema\": {
+                        \"type\": \"string\"
+                    }
+                }
+            }
+        ]
+    }
+}"
+          lib.json/keyword-mapper))
+  (lib.error/explain (mc/schema spec.openrpc/schema*) (:result x) )
+  (rpc/init "url" (:result x))
+
+  (-> (proto.http/request! (com.kubelt.lib.http.node/->HttpClient.)
+                           {:com.kubelt/type :kubelt.type/http-request
+                            :http/method :get
+                            :uri/scheme :https
+                            :uri/domain "raw.githubusercontent.com"
+                            :uri/path "/kubelt/kubelt/main/fix/openrpc/ethereum.json"})
+
+      (.then (fn [x]
+               (def data-schema (-> x :http/body (lib.json/json-str->edn lib.json/keyword-mapper)))))
+      (.catch (fn [e] (println "error " e))))
+  (def rpc (rpc/init "url" data-schema)))

--- a/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/ls.cljs
@@ -4,141 +4,37 @@
   (:require
    [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
-   [com.kubelt.lib.error :as lib.error]
    [com.kubelt.ddt.util :as ddt.util]
-   [com.kubelt.spec.openrpc :as spec.openrpc]
    [com.kubelt.lib.promise :as lib.promise]
-   [malli.core :as mc]
    [com.kubelt.sdk.v1.core :as sdk.core]
    [com.kubelt.ddt.cmds.sdk.core.authenticate :as ddt.auth]
-   [com.kubelt.proto.http :as proto.http]
-   [com.kubelt.lib.json :as lib.json]
    [com.kubelt.rpc :as rpc]))
 
 (defonce command
   {:command "list"
    :aliases ["ls"]
    :desc "List available RPC methods."
-  :requiresArg false
+   :requiresArg false
 
-  :builder (fn [^Yargs yargs]
+   :builder (fn [^Yargs yargs]
              ;; Include the common options.
-             (ddt.options/options yargs)
-             yargs)
+              (ddt.options/options yargs)
+              yargs)
 
-  :handler (fn [args]
-             (ddt.prompt/ask-password!
-              (fn [err result]
-                (ddt.util/exit-if err)
-                (ddt.auth/authenticate
-                 (ddt.options/to-map args)
-                 (.-password result)
-                 (fn [sys]
-                   (println
-
+   :handler (fn [args]
+              (ddt.prompt/ask-password!
+               (fn [err result]
+                 (ddt.util/exit-if err)
+                 (ddt.auth/authenticate
+                  (ddt.options/to-map args)
+                  (.-password result)
+                  (fn [sys]
                     (-> (sdk.core/rpc-api sys (-> sys :crypto/wallet :wallet/address))
                         (lib.promise/then (fn [api]
-                                            (->> (lib.json/json-str->edn api lib.json/keyword-mapper)
-                                                 (rpc/init "url" )
-                                                 (println )
-                                                )
-
-
-                                            (println api)))
-                        )
-
-                    )
-                   (prn "joeee" (-> sys :crypto/wallet :wallet/address)  ))))))})
-
-(comment
-
-  (def x (lib.json/json-str->edn
-          "{
-    \"jsonrpc\": \"2.0\",
-    \"id\": 1,
-    \"result\": {
-        \"openrpc\": \"1.2.6\",
-        \"info\": {
-            \"title\": \"Kubelt Core\",
-            \"version\": \"0.0.0\"
-        },
-        \"methods\": [
-            {
-                \"name\": \"kb_ping\",
-                \"params\": [],
-                \"result\": {
-                    \"name\": \"pong\",
-                    \"schema\": {
-                        \"type\": \"string\"
-                    }
-                }
-            },
-            {
-                \"name\": \"kb_pong\",
-                \"params\": [],
-                \"result\": {}
-            },
-            {
-                \"name\": \"kb_auth\",
-                \"params\": [
-                    {
-                        \"name\": \"address\",
-                        \"summary\": \"Account address\",
-                        \"required\": true,
-                        \"schema\": {
-                            \"type\": \"string\"
-                        }
-                    }
-                ],
-                \"result\": {
-                    \"name\": \"nonce\",
-                    \"schema\": {
-                        \"type\": \"string\"
-                    }
-                }
-            },
-            {
-                \"name\": \"kb_auth_verify\",
-                \"params\": [
-                    {
-                        \"name\": \"nonce\",
-                        \"summary\": \"Challenge Nonce\",
-                        \"required\": true,
-                        \"schema\": {
-                            \"type\": \"string\"
-                        }
-                    },
-                    {
-                        \"name\": \"signature\",
-                        \"summary\": \"Nonce Signature\",
-                        \"required\": true,
-                        \"schema\": {
-                            \"type\": \"string\"
-                        }
-                    }
-                ],
-                \"result\": {
-                    \"name\": \"jwt\",
-                    \"schema\": {
-                        \"type\": \"string\"
-                    }
-                }
-            }
-        ]
-    }
-}"
-          lib.json/keyword-mapper))
-  (lib.error/explain (mc/schema spec.openrpc/schema*) (:result x) )
-  (rpc/init "url" (:result x))
-
-  (-> (proto.http/request! (com.kubelt.lib.http.node/->HttpClient.)
-                           {:com.kubelt/type :kubelt.type/http-request
-                            :http/method :get
-                            :uri/scheme :https
-                            :uri/domain "raw.githubusercontent.com"
-                            :uri/path "/kubelt/kubelt/main/fix/openrpc/ethereum.json"})
-
-      (.then (fn [x]
-               (def data-schema (-> x :http/body (lib.json/json-str->edn lib.json/keyword-mapper)))))
-      (.catch (fn [e] (println "error " e))))
-  (def rpc (rpc/init "url" data-schema)))
+                                            (println (->> (update-in api [:methods 1 :result] assoc :name "pong" :schema {:type "string"})
+                                                          (rpc/init "url")
+                                                          :rpc/methods
+                                                          keys
+                                                          vec))))
+                        (lib.promise/catch (fn [error]
+                                            (println "we got an error" error)))))))))})

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
@@ -13,6 +13,32 @@
    [com.kubelt.sdk.v1 :as sdk]
    [com.kubelt.sdk.v1.core :as sdk.core]))
 
+(defn authenticate [args-map password on-authenticate]
+ (let [app-name (get args-map :app-name)
+       wallet-name (get args-map :wallet)]
+   (println app-name wallet-name)
+   (-> (lib.wallet/load app-name wallet-name password)
+       (lib.promise/then
+        (fn [wallet]
+          (let [ ;; Transform command line arguments into an SDK options map.
+                options (-> args-map
+                            ddt.options/init-options
+                            (assoc :crypto/wallet wallet))
+                address (:wallet/address wallet)]
+            (-> (sdk/init options)
+                (lib.promise/then
+                 (fn [kbt]
+                   (-> (sdk.core/authenticate! kbt address)
+                       (lib.promise/then
+                        on-authenticate)
+                       (lib.promise/catch
+                           (fn [e]
+                             (println (ex-message e))
+                             (prn (ex-data e))))
+                       (lib.promise/finally
+                         (fn []
+                           (sdk/halt! kbt)))))))))))))
+
 (defonce command
   {:command "authenticate"
    :desc "Authenticate an account"
@@ -27,30 +53,7 @@
               (ddt.prompt/ask-password!
                (fn [err result]
                  (ddt.util/exit-if err)
-                 (let [args-map (ddt.options/to-map args)
-                       ;; Load the wallet.
-                       app-name (get args-map :app-name)
-                       wallet-name (get args-map :wallet)
-                       password (.-password result)]
-                   (-> (lib.wallet/load app-name wallet-name password)
-                       (lib.promise/then
-                        (fn [wallet]
-                          (let [;; Transform command line arguments into an SDK options map.
-                                options (-> args-map
-                                            ddt.options/init-options
-                                            (assoc :crypto/wallet wallet))
-                                address (:wallet/address wallet)]
-                            (-> (sdk/init options)
-                                (lib.promise/then
-                                 (fn [kbt]
-                                   (-> (sdk.core/authenticate! kbt address)
-                                       (lib.promise/then
-                                        (fn [result]
-                                          (prn result)))
-                                       (lib.promise/catch
-                                           (fn [e]
-                                             (println (ex-message e))
-                                             (prn (ex-data e))))
-                                       (lib.promise/finally
-                                         (fn []
-                                           (sdk/halt! kbt)))))))))))))))})
+                 (authenticate
+                  (ddt.options/to-map args)
+                  (.-password result)
+                  (fn [result] (prn result))))))})

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
@@ -16,7 +16,6 @@
 (defn authenticate [args-map password on-authenticate]
  (let [app-name (get args-map :app-name)
        wallet-name (get args-map :wallet)]
-   (println app-name wallet-name)
    (-> (lib.wallet/load app-name wallet-name password)
        (lib.promise/then
         (fn [wallet]

--- a/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/options.cljs
@@ -3,7 +3,6 @@
   {:copyright "©2022 Kubelt, Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.ddt.options :as ddt.options]
-   [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.promise :as lib.promise]
    [com.kubelt.sdk.v1 :as sdk]))
 

--- a/src/main/com/kubelt/lib/p2p.cljs
+++ b/src/main/com/kubelt/lib/p2p.cljs
@@ -61,3 +61,9 @@
 (defn rpc-api [sys core]
   {:pre [(string? core)]}
   (send (json-rpc-provider sys core) "rpc.discover"))
+
+(defn call-rpc-method [sys core method args]
+  {:pre [(string? core) (string? method) (vector? args)]}
+  (send (json-rpc-provider sys core) method args))
+
+

--- a/src/main/com/kubelt/lib/p2p.cljs
+++ b/src/main/com/kubelt/lib/p2p.cljs
@@ -2,6 +2,7 @@
   "Wrapper around the external p2p naming system."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [taoensso.timbre :as log]
    [clojure.string :as cstr])
   (:require
    ["@ethersproject/providers" :refer [JsonRpcProvider]]
@@ -14,9 +15,10 @@
   (let [scheme (get-in sys [:client/p2p :http/scheme])
         host (get-in sys [:client/p2p :http/host])
         port (get-in sys [:client/p2p :http/port])
-        path (cstr/join "" ["/@" core "/jsonrpc"])]
-    (println :uri (str (name scheme) "://" host ":" port path))
-    (str (name scheme) "://" host ":" port path)))
+        path (cstr/join "" ["/@" core "/jsonrpc"])
+        uri (str (name scheme) "://" host ":" port path)]
+    (log/debug {::connection-uri uri})
+    uri))
 
 (defn- json-rpc-provider [sys core]
   (JsonRpcProvider. (connection-uri sys core)))
@@ -25,7 +27,7 @@
   ([provider method]
    (send provider method []))
   ([provider method params]
-   (println :method method :params params)
+   (log/debug {::send {:method method :params params}})
    (-> (.send provider method (clj->js params))
        (lib.promise/then
         (fn [x]

--- a/src/main/com/kubelt/lib/p2p.cljs
+++ b/src/main/com/kubelt/lib/p2p.cljs
@@ -27,6 +27,9 @@
   ([provider method params]
    (println :method method :params params)
    (-> (.send provider method (clj->js params))
+       (lib.promise/then
+        (fn [x]
+          (js->clj x :keywordize-keys true)))
        (lib.promise/catch
         (fn [e]
           (lib.error/from-obj e))))))

--- a/src/main/com/kubelt/sdk/v1/core.cljs
+++ b/src/main/com/kubelt/sdk/v1/core.cljs
@@ -82,6 +82,13 @@
   [sys core]
   (authenticate! sys core))
 
+
+;; TODO test me
+(defn rpc-api [sys core]
+  (lib.p2p/rpc-api sys core))
+
+(defn rpc-api-js [sys core]
+  (rpc-api sys core))
 ;; logged-in?
 ;; -----------------------------------------------------------------------------
 ;; A predicate that returns true when the user has successfully authenticated.

--- a/src/main/com/kubelt/sdk/v1/core.cljs
+++ b/src/main/com/kubelt/sdk/v1/core.cljs
@@ -89,6 +89,15 @@
 
 (defn rpc-api-js [sys core]
   (rpc-api sys core))
+
+;; TODO test me
+(defn call-rpc-method [sys core method args]
+  (lib.p2p/call-rpc-method sys core method args))
+
+(defn call-rpc-api-js [sys core method args]
+  (call-rpc-method sys core method args))
+
+
 ;; logged-in?
 ;; -----------------------------------------------------------------------------
 ;; A predicate that returns true when the user has successfully authenticated.


### PR DESCRIPTION
Relates #376 to be merged in https://github.com/kubelt/kubelt/tree/feat/rpc-client
### `ddt rpc `
- [x] add `call` command for calling provider RPC endpoints
    
```
node ddt.js rpc call :kb:ping  -w default  -x value_1=1 -x value_2=2
Enter your password:  ******

com.kubelt.ddt.js default
:method kb_ping :params {:value_1 1, :value_2 2}
call result: pong
```

- [x] add `list` command for listing available RPC endpoints

```
> node ddt.js rpc list -w default

Enter your password:  ******
#{[:kb :auth] [:kb :ping] [:kb :pong] [:kb :auth :verify]}
```