### PR TITLE
chore(sdk): Add cljs target for external cljs projects

### DIFF
--- a/src/main/com/kubelt/lib/init.cljc
+++ b/src/main/com/kubelt/lib/init.cljc
@@ -15,8 +15,9 @@
    [com.kubelt.proto.http :as proto.http])
   (:require
    #?@(:browser [[com.kubelt.lib.http.browser :as http.browser]]
-       :node [[com.kubelt.lib.http.node :as http.node]]
-       :clj [[com.kubelt.lib.http.jvm :as http.jvm]])))
+       :clj [[com.kubelt.lib.http.jvm :as http.jvm]]
+       :cljs [[com.kubelt.lib.http.browser :as http.browser]]
+       :node [[com.kubelt.lib.http.node :as http.node]])))
 
 ;; System
 ;; -----------------------------------------------------------------------------
@@ -117,8 +118,9 @@
   {:post [(not (nil? %))]}
   (log/debug {:log/msg "init HTTP client"})
   #?(:browser (http.browser/->HttpClient)
-     :node (http.node/->HttpClient)
-     :clj (http.jvm/->HttpClient)))
+     :clj (http.jvm/->HttpClient)
+     :cljs (http.browser/->HttpClient)
+     :node (http.node/->HttpClient)))
 
 (defmethod ig/halt-key! :client/http [_ client]
   {:pre [(satisfies? proto.http/HttpClient client)]}


### PR DESCRIPTION
# Description

When trying to authenticate via `three-id`, we are generating a JAR with `lein install` that is not aware of the `:browser` reader conditional. Without this, the HTTP client cannot be instantiated.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Locally try to connect wallet with `three-id` with and without these changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
