### PR TITLE
feat(sdk): Use project.clj to build JAR for CLJ/CLJS apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,10 +166,7 @@ dist
 # Leiningen
 /.lein-*
 /.nrepl-port
-# We use the leiningen project file only to aid in packing up a CLJS
-# library (as a JAR). The project.clj is generated from shadow-cljs.edn
-# so no need to check it in.
-project.clj
+pom.xml
 
 # clj-kondo cache
 /.clj-kondo/.cache

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,30 @@
+(defproject kubelt/sdk "0.0.1"
+  :description "Kubelt SDK"
+  :url "https://kubelt.com/"
+
+  :source-paths
+  ["src/main"]
+
+  :dependencies
+  [;; always use "provided" for Clojure(Script)
+   [org.clojure/clojure "1.11.1" :scope "provided"]
+   [org.clojure/clojurescript "1.11.51" :scope "provided"]
+   [thheller/shadow-cljs "2.19.0" :scope "provided"]
+   ;; a Clojure/Script library for word case conversions
+   [camel-snake-kebab/camel-snake-kebab "0.4.2"]
+   ;; errors as simple, actionable, generic information
+   [com.cognitect/anomalies "0.1.12"]
+   ;; data format for conveying values between applications
+   [com.cognitect/transit-cljs "0.8.269"]
+   ;; a pure Clojure/Script logging library
+   [com.taoensso/timbre "5.2.1"]
+   ;; fast, idiomatic pretty-printer
+   [fipp/fipp "0.6.25"]
+   ;; a micro-framework for building data-driven applications
+   [integrant/integrant "0.8.0"]
+   ;; fast JSON encoding and decoding
+   [metosin/jsonista "0.3.5"]
+   ;; data-driven schemas for Clojure/Script
+   [metosin/malli "0.8.4"]
+   ;; tools for working with command line arguments
+   [org.clojure/tools.cli "1.0.206"]])


### PR DESCRIPTION
# Description

In order to use the SDK as a dependency via `shadow-cljs`, it is simpler to call `lein install` and build against it.

For CLJS browser apps, they would need to all the following in their compiler options map to have the SDK work as intended:

```
{:compiler-options
  {:reader-features #{:browser}
   ...}}
```

Eventually this JAR can be used as an artifact to build and test other products that are created.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Built JAR locally and used in `three-id` repo 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
