### PR TITLE
chore(sdk): refactor and add error checking in conform*

### DIFF
--- a/src/main/com/kubelt/spec/error.cljc
+++ b/src/main/com/kubelt/spec/error.cljc
@@ -16,3 +16,15 @@
     :description "An error map"
     :example {}}
    error])
+
+;; conform*
+;; -----------------------------------------------------------------------------
+
+(def guard
+  [:tuple :vector :any])
+
+(def guards
+  [:+ guard])
+
+(def body
+  :any)


### PR DESCRIPTION
# Description

Rework `conform*` to avoid nested let, avoid capture, and add error checking.

## Type of change

- [x] Refactoring and cleanup