### PR TITLE
feat(sdk): improve SDK schema expansion

### DIFF
--- a/src/dev/.gitignore
+++ b/src/dev/.gitignore
@@ -1,0 +1,3 @@
+# src/dev/.gitignore
+
+robert/

--- a/src/dev/user.cljc
+++ b/src/dev/user.cljc
@@ -1,0 +1,9 @@
+(ns user
+  "Shared development utilities."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; development
+;; -----------------------------------------------------------------------------
+;; Shared development utilities go here. The user namespace can be
+;; referred from a developer-specific namespace to include these
+;; utilities while adding one's own.

--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -3,6 +3,7 @@
   request map."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.json :as lib.json]
    [com.kubelt.lib.uuid :as lib.uuid]
    [com.kubelt.rpc.path :as rpc.path]))
@@ -40,8 +41,8 @@
   (lib.uuid/random))
 
 (defn- make-body
-  [path method]
-  {:pre [(rpc.path/path? path) (map? method)]}
+  [path method params]
+  {:pre [(rpc.path/path? path) (every? map? [method params])]}
   (let [;; Every RPC request must have a unique identifier.
         request-id (make-request-id)
         ;; The version of the JSON-RPC spec that we conform to.
@@ -49,12 +50,56 @@
         ;; The original name of the RPC method to call is stored in the
         ;; method map.
         method-name (get method :method/name)
-        params []]
+        ;; Get the list of keywords representing every parameter
+        ;; supported by this RPC method.
+        all-params (get method :method.params/all)
+        ;; Collect parameters from the supplied parameter map, removing
+        ;; any nil entries.
+        params (filter some? (map #(get params %) all-params))]
     (lib.json/edn->json-str
      {:id request-id
       :jsonrpc rpc-version
       :method method-name
       :params params})))
+
+;; from-params-map
+;; -----------------------------------------------------------------------------
+;; Given a map of parameters from keyword parameter name to parameter
+;; value, validate that the map has the required parameters and return
+;; it if so. Otherwise, return an error map.
+
+(defn from-params-map
+  [method params]
+  {:pre [(every? map? [method params])]}
+  ;; TODO check that all required params were supplied
+  ;; TODO Check for extraneous parameters (only if :strict? option enabled)
+  (let [;; TODO validate parameter value against schema.
+        param-valid? (constantly true)]
+    (into {} (map (fn [[param-kw param-val :as pair]]
+                    (if-let [param (get-in method [:method/params param-kw])]
+                      (let [result (param-valid? param param-val)]
+                        (if (lib.error/error? result)
+                          [param-kw result]
+                          pair))
+                      [param-kw (lib.error/error "no such parameter" :parameter param-kw)]))
+                  params))))
+
+;; from-params-vec
+;; -----------------------------------------------------------------------------
+;; Given a vector of parameter values for a method, and a map describing
+;; the method, return a map from parameter name to parameter
+;; value. E.g. if the method has parameters [:a :b], and we are given
+;; the parameters [:x :y], return {:a :x, :b :y}, or an error map if
+;; some error occurred.
+
+(defn from-params-vec
+  [method params]
+  {:pre [(map? method) (vector? params)]}
+  (let [;; A vector of parameter names (as keywords).
+        params-kw (get method :method.params/all)
+        ;; A map from parameter name to parameter value.
+        params-map (zipmap params-kw params)]
+    (from-params-map method params-map)))
 
 ;; from-method
 ;; -----------------------------------------------------------------------------
@@ -74,14 +119,10 @@
 
   ([path method params options]
    {:pre [(vector? path) (every? map? [method params options])]}
-   ;; TODO allow specification of parameters as a sequence, in which
-   ;; case the position of the parameter aligns with the parameter
-   ;; definition list in the schema
-   ;; TODO allow specification of parameters as a map, in which case the
-   ;; map keys correspondond to the method parameter names.
-   ;; TODO validate parameters
-   (let [body (make-body path method)
+   (let [body (make-body path method params)
          request (http-request body options)]
+     ;; TODO should we merge the method map into the result, rather than
+     ;; storing it as the value of the :rpc/method key?
      {:com.kubelt/type :kubelt.type/rpc.request
       ;; TODO add a :rpc.param/<name> for each param that includes metadata,
       ;; schema, etc.

--- a/src/main/com/kubelt/rpc/schema/expand.cljc
+++ b/src/main/com/kubelt/rpc/schema/expand.cljc
@@ -9,17 +9,6 @@
    [com.kubelt.rpc.schema.util :as rpc.schema.util]
    [com.kubelt.rpc.schema.zip :as rpc.schema.zip]))
 
-;; ref-loc?
-;; -----------------------------------------------------------------------------
-;; A reference is a map with a :$ref key, whose value is a string
-;; reference to another location in the schema, e.g.
-;; {:$ref "#/components/examples/fooBar"}.
-
-(defn- ref-loc?
-  [loc]
-  (let [node (zip/node loc)]
-    (and (map? node) (contains? node :$ref))))
-
 ;; replace-ref
 ;; -----------------------------------------------------------------------------
 ;; NB: must return a loc that is *just before* the next loc of
@@ -57,6 +46,6 @@
   (loop [loc (rpc.schema.zip/schema-zip schema)]
     (if (zip/end? loc)
       (zip/root loc)
-      (recur (zip/next (if (ref-loc? loc)
+      (recur (zip/next (if (rpc.schema.zip/ref-loc? loc)
                          (replace-ref loc schema)
                          loc))))))

--- a/src/main/com/kubelt/rpc/schema/fs.cljc
+++ b/src/main/com/kubelt/rpc/schema/fs.cljc
@@ -74,5 +74,6 @@
                   (lib.promise/catch reject))))
      :clj
      (let [json-str (read-file& filename)
-           keywordize? true]
-       (conform (lib.json/from-json json-str keywordize?)))))
+           keywordize? true
+           edn (lib.json/from-json json-str keywordize?)]
+       (conform edn))))

--- a/src/main/com/kubelt/rpc/schema/zip.cljc
+++ b/src/main/com/kubelt/rpc/schema/zip.cljc
@@ -99,6 +99,17 @@
     (or (map? node) (vector? node) (set? node))
     (into (empty node) children)))
 
+;; ref-loc?
+;; -----------------------------------------------------------------------------
+;; A reference is a map with a :$ref key, whose value is a string
+;; reference to another location in the schema, e.g.
+;; {:$ref "#/components/examples/fooBar"}.
+
+(defn ref-loc?
+  [loc]
+  (let [node (zip/node loc)]
+    (and (map? node) (contains? node :$ref))))
+
 ;; schema-zip
 ;; -----------------------------------------------------------------------------
 

--- a/src/main/com/kubelt/spec/core/config.cljc
+++ b/src/main/com/kubelt/spec/core/config.cljc
@@ -1,7 +1,8 @@
 (ns com.kubelt.spec.core.config
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
-  (:require [com.kubelt.spec.core.config.general :as general]
-            [com.kubelt.spec.core.config.security :as security]))
+  (:require
+   [com.kubelt.spec.core.config.general :as general]
+   [com.kubelt.spec.core.config.security :as security]))
 
 (def general-config
   [:map

--- a/src/main/com/kubelt/spec/core/config/general.cljc
+++ b/src/main/com/kubelt/spec/core/config/general.cljc
@@ -1,27 +1,31 @@
 (ns com.kubelt.spec.core.config.general
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [alias])
-  (:require [com.kubelt.spec.core.config.security :as security]))
+  (:require
+   [com.kubelt.spec.core.config.security :as security]))
 
 (def alias :string)
 
-(def id [:map
-         [:alias alias]])
+(def id
+  [:map
+   [:alias alias]])
 
+(def media-type
+  [:enum "application/json"])
 
-(def media-type [:enum "application/json"])
-
-(def client [:map
-             [:ttl security/ttl]
-             [:media-type media-type]])
+(def client
+  [:map
+   [:ttl security/ttl]
+   [:media-type media-type]])
 
 ;; "libp2p://provider_address/rpc"
 (def provider :string)
 
-(def aliases [:vector
-              [:map
-               [:alias alias]
-               [:provider provider]]])
+(def aliases
+  [:vector
+   [:map
+    [:alias alias]
+    [:provider provider]]])
 
 ;; eg: "2022-05-23"
 (def version

--- a/src/main/com/kubelt/spec/core/config/security.cljc
+++ b/src/main/com/kubelt/spec/core/config/security.cljc
@@ -48,6 +48,8 @@
    [:policy-id :string]
    [:capabilities [:vector capability]]])
 
-(def policies [:vector policy])
+(def policies
+  [:vector policy])
 
-(def capabilities [:vector capability])
+(def capabilities
+  [:vector capability])

--- a/src/main/com/kubelt/spec/openrpc/component.cljc
+++ b/src/main/com/kubelt/spec/openrpc/component.cljc
@@ -2,32 +2,32 @@
   ""
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [com.kubelt.spec.openrpc.content :as openrpc.content]
    [com.kubelt.spec.openrpc.error :as openrpc.error]
    [com.kubelt.spec.openrpc.example :as openrpc.example]
    [com.kubelt.spec.openrpc.link :as openrpc.link]
    [com.kubelt.spec.openrpc.pairing :as openrpc.pairing]
    [com.kubelt.spec.openrpc.schema :as openrpc.schema]
-   [com.kubelt.spec.openrpc.tag :as openrpc.tag]
-   [com.kubelt.spec.openrpc.content :as openrpc.content]))
+   [com.kubelt.spec.openrpc.tag :as openrpc.tag]))
 
 
 (def errors
-  [:map-of :string openrpc.error/error])
+  [:map-of :keyword openrpc.error/error])
 
 (def pairing
-  [:map-of :string openrpc.pairing/example])
+  [:map-of :keyword openrpc.pairing/example])
 
 (def tags
-  [:map-of :string openrpc.tag/tag])
+  [:map-of :keyword openrpc.tag/tag])
 
 (def links
-  [:map-of :string openrpc.link/link])
+  [:map-of :keyword openrpc.link/link])
 
 (def schemas
   [:map-of :keyword openrpc.schema/schema])
 
 (def examples
-  [:map-of :string openrpc.example/example])
+  [:map-of :keyword openrpc.example/example])
 
 ;; Components
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/spec/rpc.cljc
+++ b/src/main/com/kubelt/spec/rpc.cljc
@@ -15,11 +15,17 @@
 
 ;; params
 ;; -----------------------------------------------------------------------------
-;; This is the definition of the parameter map for an RPC request. This
-;; is a basic check, but a more detailed parameter map schema for a
-;; specific call lives inside the client as part of the transformed
-;; schema.
+;; This is the definition of the collection of parameters supplied for
+;; an RPC request. If a vector of values is supplied, the values are
+;; assumed to be in the order defined by the schema's parameter list for
+;; the method. If a map of parameters is supplied, the keys are assumed
+;; to be the parameter names and the corresponding values are the
+;; parameter values.
+;;
+;; NB: a schema for each parameter may be specified, in which it case it
+;; will (eventually) be used to validate the supplied parameter value.
 
 (def params
-  ;; TODO
-  :map)
+  [:or
+   [:map-of :keyword :any]
+   [:vector :any]])

--- a/src/main/com/kubelt/spec/rpc/schema.cljc
+++ b/src/main/com/kubelt/spec/rpc/schema.cljc
@@ -2,7 +2,7 @@
   "Schemas related to the com.kubelt.rpc/schema function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.spec.openrpc :as spec.openrpc]))
+   [com.kubelt.spec.openrpc.schema :as spec.openrpc.schema]))
 
 ;; schema
 ;; -----------------------------------------------------------------------------
@@ -10,7 +10,7 @@
 ;; JSON and parsed into edn data.
 
 (def schema
-  spec.openrpc/schema)
+  spec.openrpc.schema/schema)
 
 ;; options
 ;; -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

When loading a schema for use by the client, references are now expanded inline to make later processing easier.

Other changes:
- [x] initial validation; checking for missing refs
- [x] `prepare` accepts RPC params as either vector or map
  - when vector is supplied, parameters are matched positionally
  - when map is supplied, keys are parameter name and map to corresponding value
- [x] further processing of schema method definition
- [x] work on request body generation
- [x] small style tweaks to specs

## Type of change

- [x] New feature (non-breaking change which adds functionality)