### PR TITLE
Adapt camel case rpc method names

### DIFF
--- a/src/main/com/kubelt/ddt/util.cljs
+++ b/src/main/com/kubelt/ddt/util.cljs
@@ -2,6 +2,7 @@
   "Misc utilities."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [camel-snake-kebab.core :as csk]
    [clojure.string :as cstr])
   (:require
    ["process" :as process]))
@@ -28,4 +29,4 @@
   {:pre [(string? s)]}
   (->> (cstr/split s #":")
        (filter (complement cstr/blank?))
-       (mapv keyword)))
+       (mapv csk/->kebab-case-keyword)))


### PR DESCRIPTION
Minor ddt adaptation to work with camel case rpc method names
eg: `:kb:getConfig` 

before these changes path was `[:kb :getConfig]` but we needed `[:kb :get-config]`
