### PR TITLE
Fix shadow-cljs warnings

### DIFF
--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -84,7 +84,7 @@
                         (if (lib.error/error? result)
                           [param-kw result]
                           pair))
-                      [param-kw (lib.error/error "no such parameter" :parameter param-kw)]))
+                      [param-kw (lib.error/error ["no such parameter" :parameter param-kw])]))
                   params))))
 
 ;; from-params-vec

--- a/src/main/com/kubelt/rpc/schema/zip.cljc
+++ b/src/main/com/kubelt/rpc/schema/zip.cljc
@@ -35,7 +35,7 @@
 
 (defn- map-entry
   [k v]
-  (clojure.lang.MapEntry/create k v))
+  #?(:clj (clojure.lang.MapEntry/create k v)))
 
 ;; branch?
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/spec/openrpc.cljc
+++ b/src/main/com/kubelt/spec/openrpc.cljc
@@ -16,7 +16,7 @@
 ;; Root
 ;; -----------------------------------------------------------------------------
 
-(def schema
+(def schemata
   [:map
    {:closed true
     :description "The root object of an OpenRPC document."}


### PR DESCRIPTION
# Description

Relates and closes https://github.com/kubelt/kubelt/pull/392

Caused by cljs compilation bug https://github.com/thheller/shadow-cljs/issues/874... so renaming a def https://github.com/kubelt/kubelt/compare/fix-shadow-warnings?expand=1#diff-b862c75b84e447a6ed4ced02513a37f7a0884c1151b0f1a31de8c00e9e77d3b1R19
