### PR TITLE
feat(rpc): memoize $ref lookup fn

### DIFF
--- a/src/main/com/kubelt/rpc/schema/util.cljc
+++ b/src/main/com/kubelt/rpc/schema/util.cljc
@@ -49,19 +49,24 @@
 ;; lookup
 ;; -----------------------------------------------------------------------------
 ;; NB We memoize the lookup function to avoid repeating the work
-;; of (possibly recursively) looking up the definition of a $ref.
+;; of (possibly recursively) looking up the definition of a $ref. This
+;; is done via alter-var-root, which atomically alters the root binding
+;; of a var by applying a function and any arguments. The advantage is
+;; that it leaves the original fn available for development and testing,
+;; without needing to account for the complications in these areas that
+;; arise from memoization.
 
-(def lookup
+(defn lookup
   "Given a schema and a reference map (containing a :$ref key), return the
   value being referred to by the reference string. References can refer
   to other references so it's necessary to recursively look them up."
-  (memoize
-   (fn
-     [$ref schema]
-     {:pre [(string? $ref) (map? schema)]}
-     (loop [components (get schema :components)
-            ref-path (ref->path $ref)
-            ref-val (get-in schema ref-path)]
-       (if-not (contains? ref-val :$ref)
-         ref-val
-         (recur components ref-path ref-val))))))
+  [$ref schema]
+  {:pre [(string? $ref) (map? schema)]}
+  (loop [components (get schema :components)
+         ref-path (ref->path $ref)
+         ref-val (get-in schema ref-path)]
+    (if-not (contains? ref-val :$ref)
+      ref-val
+      (recur components ref-path ref-val))))
+
+(alter-var-root #'lookup memoize)


### PR DESCRIPTION
# Description

Memoizes the `rpc.schema.util/lookup` fn that takes a `$ref` and an edn schema and (possibly recursively) looks up the referenced definition.