### PR TITLE
Ignore roam folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ pom.xml
 
 # dapp
 /dapp/cypress/videos/
+/roam/


### PR DESCRIPTION
simple folder git ignore

I use to set a [roam](https://www.orgroam.com/) system inside clojure repos thus using org-mode + babel i can do literate programming (using same CIDER repl connection/session to eval repo code) there with personal documentation purposes ... so this PR change is to don't track personal dev settings 