### PR TITLE
Compilation and test fixes

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -169,7 +169,8 @@
 
   test:sdk:cljs:develop
   {:doc "Build and run development version of sdk tests"
-   :task (shell "npx shadow-cljs compile sdk-test")}
+   :task (do (shell "npx shadow-cljs compile sdk-test ")
+             (shell "node target/sdk-test.js"))}
 
   test:sdk:cljs:release
   {:doc "Build and run release version of sdk tests"

--- a/bb.edn
+++ b/bb.edn
@@ -110,7 +110,7 @@
    :task (shell "npx shadow-cljs compile sdk-test ")}
 
   build:sdk:watch
-  {:doc "Build development version of the sdk for node"
+  {:doc "Watch and rebuild when changed development version of the sdk for node"
    :task (shell "npx shadow-cljs watch sdk")}
 
   build:sdk:release

--- a/bb.edn
+++ b/bb.edn
@@ -105,6 +105,14 @@
   {:doc "Build development version of the sdk for node"
    :task (shell "npx shadow-cljs compile sdk")}
 
+  build:sdk-test:develop
+  {:doc "Build development version of the sdk-test for node"
+   :task (shell "npx shadow-cljs compile sdk-test ")}
+
+  build:sdk:watch
+  {:doc "Build development version of the sdk for node"
+   :task (shell "npx shadow-cljs watch sdk")}
+
   build:sdk:release
   {:doc "Build release version of the sdk for node"
    :task (shell "npx shadow-cljs release sdk")}
@@ -169,8 +177,8 @@
 
   test:sdk:cljs:develop
   {:doc "Build and run development version of sdk tests"
-   :task (do (shell "npx shadow-cljs compile sdk-test ")
-             (shell "node target/sdk-test.js"))}
+   :depends [build:sdk-test:develop]
+   :task (shell "node target/sdk-test.js")}
 
   test:sdk:cljs:release
   {:doc "Build and run release version of sdk tests"

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -170,7 +170,7 @@
    :compiler-options {:reader-features #{:node}}
    :output-to "target/sdk-test.js"
    :ns-regexp "(lib|sdk|com\\.kubelt\\.rpc)\\..*-test$"
-   :autorun true}
+   :autorun false}
 
   ;; Generate an HTML version of the SDK tests that can be manually checked by:
   ;; $ cd target/web-test/ && npx http-server

--- a/src/main/com/kubelt/rpc.cljc
+++ b/src/main/com/kubelt/rpc.cljc
@@ -6,7 +6,7 @@
   (:require
    [malli.core :as malli])
   (:require
-   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.error :as lib.error :refer-macros [conform*]]
    [com.kubelt.lib.http :as lib.http]
    [com.kubelt.proto.http :as proto.http]
    [com.kubelt.rpc.client :as rpc.client]
@@ -60,7 +60,7 @@
      (init defaults)))
 
   ([options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.init/options options]
     ;; TODO Use the OpenRPC "Server" block to configure RPC endpoints
     ;; using URL templates.
@@ -105,7 +105,7 @@
      (available client path defaults)))
 
   ([client path options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc.available/options options]
@@ -159,7 +159,7 @@
      (doc client path defaults)))
 
   ([client path options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc.doc/options options]
@@ -197,9 +197,9 @@
   parameters are validated against the service schema and an error map
   is returned if any issues are detected."
   [client path params]
-  ;; Use lib.error/conform* to ensure that each argument matches
+  ;; Use conform* to ensure that each argument matches
   ;; its schema.
-  (lib.error/conform*
+  (conform*
    [spec.rpc.client/client client]
    [spec.rpc/path path]
    [spec.rpc/params params]
@@ -240,7 +240,7 @@
       (execute client request defaults)))
 
   ([client request options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.request/request request]
     [spec.rpc.execute/options options]
@@ -264,7 +264,7 @@
      (call client path params defaults)))
 
   ([client path params options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc/params params]
@@ -286,7 +286,7 @@
      (rpc-fn client path defaults)))
 
   ([client path options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc.call/options options]

--- a/src/main/com/kubelt/rpc/schema.cljc
+++ b/src/main/com/kubelt/rpc/schema.cljc
@@ -2,7 +2,7 @@
   "Tools for working with OpenRPC schemas."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.error :as lib.error :refer-macros [conform*]]
    [com.kubelt.rpc.schema.fs :as rpc.schema.fs]
    [com.kubelt.rpc.schema.parse :as rpc.schema.parse]
    [com.kubelt.rpc.schema.util :as rpc.schema.util]
@@ -27,7 +27,7 @@
      (schema client prefix schema-doc defaults)))
 
   ([client prefix schema-doc options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.client/prefix prefix]
     [spec.rpc.schema/schema schema-doc]
@@ -58,7 +58,7 @@
      (inflate client prefix filename defaults)))
 
   ([client prefix filename options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.client/prefix prefix]
     [spec.rpc.inflate/filename filename]
@@ -88,7 +88,7 @@
      (discover client prefix url defaults)))
 
   ([client prefix url options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.client/prefix prefix]
     [spec.rpc.discover/url url]
@@ -111,7 +111,7 @@
      (http client prefix url defaults)))
 
   ([client prefix url options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.client/prefix prefix]
     [spec.rpc.http/url url]
@@ -134,7 +134,7 @@
      (github client prefix repo defaults)))
 
   ([client prefix repo options]
-   (lib.error/conform*
+   (conform*
     [spec.rpc.client/client client]
     [spec.rpc.client/prefix prefix]
     [spec.rpc.github/repo repo]

--- a/src/test/com/kubelt/rpc/schema_test.cljs
+++ b/src/test/com/kubelt/rpc/schema_test.cljs
@@ -54,19 +54,22 @@
                    (is (= #{[:kb :auth] [:kb :ping] [:kb :pong]
                             [:kb :auth :verify] [:kb :core :create]
                             [:kb :core :add :signer]}
-                          (rpc/available client)))
-                   (is (= {:com.kubelt/type :kubelt.type/rpc.request,
-                           :rpc/path [:kb :ping],
-                           :rpc/method
-                           #:method{:name "kb_ping",
-                                    :summary nil,
-                                    :params [],
-                                    :raw
-                                    {:name "kb_ping",
-                                     :params [],
-                                     :result {:name "pong", :schema {:type "string"}}}}}
-                          (-> (rpc/prepare client [:kb :ping] {})
-                              (select-keys   [:com.kubelt/type :rpc/path :rpc/method]))))))
+                          (rpc/available client))
+                       "failing methods")
+                   (is (=
+                        {:com.kubelt/type :kubelt.type/rpc.request,
+                         :rpc/path [:kb :ping],
+                         :rpc/method
+                         {:method/name "kb_ping",
+                          :method/summary nil,
+                          :method/params {},
+                          :method.params/all [],
+                          :method.params/required [],
+                          :method.params/optional [],
+                          :method.params/schemas {}}}
+                        (-> (rpc/prepare client [:kb :ping] {})
+                            (select-keys   [:com.kubelt/type :rpc/path :rpc/method])))
+                       "failing ping prepare expectations")))
                (catch js/Error err (js/console.log err))
                (finally (done)))))))
 


### PR DESCRIPTION
- [FIX: Use of undeclared Var com.kubelt.lib.error/conform*](https://github.com/kubelt/kubelt/runs/6600348899?check_suite_focus=true#step:8:379)

```
------ WARNING #1 - :undeclared-var --------------------------------------------
 File: /home/runner/work/kubelt/kubelt/src/main/com/kubelt/rpc/schema.cljc:30:5
--------------------------------------------------------------------------------
  27 |      (schema client prefix schema-doc defaults)))
  28 | 
  29 |   ([client prefix schema-doc options]
  30 |    (lib.error/conform*
-----------^--------------------------------------------------------------------
 Use of undeclared Var com.kubelt.lib.error/conform*
--------------------------------------------------------------------------------
  .....
```

- [Fix node test output error](https://github.com/kubelt/kubelt/pull/426/commits/10c0ce563bc2dc4ca54a2f92c65452d6f983a83c) ====> [expected failing build](https://github.com/kubelt/kubelt/runs/6609836975?check_suite_focus=true#step:8:399)
- [Fix schema-test](https://github.com/kubelt/kubelt/pull/426/commits/5017acbedc845509e30249946bfbfffb10d1e499)