### PR TITLE
fix(rpc): only use alter-var-root in CLJ

### DIFF
--- a/src/main/com/kubelt/rpc/schema/util.cljc
+++ b/src/main/com/kubelt/rpc/schema/util.cljc
@@ -69,4 +69,5 @@
       ref-val
       (recur components ref-path ref-val))))
 
-(alter-var-root #'lookup memoize)
+#?(:clj (alter-var-root #'lookup memoize)
+   :cljs (def lookup (memoize lookup) ))


### PR DESCRIPTION
# Description

Turns out that `alter-var-root` doesn't exist in CLJS (oops). Hide it away using conditional reader.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)