### PR TITLE
Fix :redef-in-file

### DIFF
--- a/src/main/com/kubelt/rpc/schema/util.cljc
+++ b/src/main/com/kubelt/rpc/schema/util.cljc
@@ -70,4 +70,4 @@
       (recur components ref-path ref-val))))
 
 #?(:clj (alter-var-root #'lookup memoize)
-   :cljs (def lookup (memoize lookup) ))
+   :cljs (set! lookup (memoize lookup)))


### PR DESCRIPTION



Following this answer https://stackoverflow.com/a/57023111

``` 

------ WARNING #1 - :redef-in-file ---------------------------------------------
 File: /home/runner/work/kubelt/kubelt/src/main/com/kubelt/rpc/schema/util.cljc:73:10
--------------------------------------------------------------------------------
  70 |       (recur components ref-path ref-val))))
  71 |
  72 | #?(:clj (alter-var-root #'lookup memoize)
  73 |    :cljs (def lookup (memoize lookup) ))
----------------^---------------------------------------------------------------
 lookup at line 59 is being replaced

```