### PR TITLE
feat(rpc): support OpenRPC schema discovery

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -28,12 +28,14 @@
   hato/hato {:mvn/version "0.8.2"}
   ;; Micro-framework for data-driven architecture
   integrant/integrant {:mvn/version "0.8.0"}
-  ;; Time as a Clojure/Script value
-  tick/tick {:mvn/version "0.4.32"}
+  ;; A pure Clojure/Script URI library
+  lambdaisland/uri {:mvn/version "1.13.95"}
   ;; A Clojure library for fast json encoding and decoding
   metosin/jsonista {:mvn/version "0.3.6"}
   ;; Data-driven schemas for Clojure
   metosin/malli {:mvn/version "0.8.8"}
+  ;; Time as a Clojure/Script value
+  tick/tick {:mvn/version "0.4.32"}
   ;; Expansive Java cryptographic library
   org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
   ;; Facilities for async programming and communication in Clojure

--- a/src/main/com/kubelt/lib/uri.cljc
+++ b/src/main/com/kubelt/lib/uri.cljc
@@ -119,8 +119,8 @@
 
 (defn expand
   "Given a URL template and a map of parameter values, return the expanded
-  URI."
-  [tpl params]
-  {:pre [(string? tpl) (map? params)]}
-  :fixme
-  )
+  URI. If no variables are supplied, the template is returned unchanged."
+  [tpl variables]
+  {:pre [(string? tpl) ((some-fn [nil? map?]) variables)]}
+  ;; TODO actually expand this template
+  tpl)

--- a/src/main/com/kubelt/lib/uri.cljc
+++ b/src/main/com/kubelt/lib/uri.cljc
@@ -1,0 +1,126 @@
+(ns com.kubelt.lib.uri
+  "URI-related utilities."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [clojure.string :as cstr])
+  (:require
+   [camel-snake-kebab.core :as csk]
+   [lambdaisland.uri :as lambda])
+  (:require
+   [com.kubelt.lib.error :as lib.error]))
+
+;; TODO test test test
+
+;; TODO define com.kubelt.spec.uri schema
+
+(def spec-parse-url
+  :string)
+
+(def spec-parse-opts
+  [:map
+   [:query/convert? {:optional true} :boolean]
+   [:query/keywordize? {:optional true} :boolean]
+   [:query/hyphenate? {:optional true} :boolean]])
+
+(def parse-defaults
+  {:query/convert? true
+   :query/keywordize? true
+   :query/hyphenate? true})
+
+(defn- query->map
+  "Convert a query string into a map."
+  [query-str {:keys [query/keywordize? query/hyphenate?]}]
+  {:pre [(string? query-str)]}
+  (into {}
+        (map (fn [s]
+               (let [[k v] (cstr/split s #"=")
+                     k (cond-> k
+                         ;; convert string keys to keywords
+                         keywordize?
+                         keyword
+                         ;; convert keys to kebab case
+                         hyphenate?
+                         csk/->kebab-case)]
+                 [k v]))
+             (cstr/split query-str #"&"))))
+
+(defn- parse-query
+  "Given a query string, process it according to the configured
+  options. With an empty options map, the same query string is
+  returned."
+  [query-str {:keys [query/convert?] :as options}]
+  {:pre [(string? query-str)]}
+  (if convert?
+    (query->map query-str options)
+    query-str))
+
+;; parse
+;; -----------------------------------------------------------------------------
+
+(defn parse
+  "Given a URL string, parse the URL into component parts and return as a
+  map. Available options include:
+  - :query/convert?, convert query string into a map (default: true)
+  - :query/keywordize?, convert query map keys to keywords (default: true)
+  - :query/hyphenate?, convert query map keys to kebab case (default: true)"
+  ([s]
+   (parse s parse-defaults))
+
+  ([s options]
+   (lib.error/conform*
+    [spec-parse-url s]
+    [spec-parse-opts options]
+    (let [options (merge parse-defaults options)
+          uri (lambda/uri s)]
+      (merge {:com.kubelt/type :kubelt.type/uri}
+             ;; :uri/scheme
+             (when-let [scheme (:scheme uri)]
+               (let [scheme (keyword scheme)]
+                 {:uri/scheme scheme}))
+             ;; :uri/domain
+             (when-let [domain (:host uri)]
+               {:uri/domain domain})
+             ;; :uri/port
+             (when-let [port (:port uri)]
+               {:uri/port port})
+             ;; :uri/path
+             (when-let [path (:path uri)]
+               {:uri/path path})
+             ;; :uri/fragment
+             (when-let [fragment (:fragment uri)]
+               {:uri/fragment fragment})
+             ;; :uri/query
+             (when-let [query (:query uri)]
+               (let [query (parse-query query options)]
+                 {:uri/query query}))
+             ;; :uri/user
+             (when-let [user (:user uri)]
+               {:uri/user user})
+             ;; :uri/password
+             (when-let [password (:password uri)]
+               {:uri/password password}))))))
+
+;; unparse
+;; -----------------------------------------------------------------------------
+;; TODO convert a URI map back into a URI string.
+
+(defn unparse
+  ""
+  [m]
+  #_(lib.error/conform*
+     [])
+  :fixme
+  )
+
+;; expand
+;; -----------------------------------------------------------------------------
+;; TODO convert a URL template string and associated parameter values
+;; into a URI string.
+
+(defn expand
+  "Given a URL template and a map of parameter values, return the expanded
+  URI."
+  [tpl params]
+  {:pre [(string? tpl) (map? params)]}
+  :fixme
+  )

--- a/src/main/com/kubelt/rpc.cljc
+++ b/src/main/com/kubelt/rpc.cljc
@@ -8,25 +8,25 @@
   (:require
    [com.kubelt.lib.error :as lib.error :refer [conform*] :refer-macros [conform*]]
    [com.kubelt.lib.http :as lib.http]
-   [com.kubelt.proto.http :as proto.http]
    [com.kubelt.rpc.client :as rpc.client]
+   [com.kubelt.rpc.execute :as rpc.execute]
    [com.kubelt.rpc.http :as rpc.http]
    [com.kubelt.rpc.path :as rpc.path]
    [com.kubelt.rpc.request :as rpc.request]
    [com.kubelt.rpc.schema :as rpc.schema]
-   [com.kubelt.spec :as spec]
-   [com.kubelt.spec.openrpc :as spec.openrpc]
+   [com.kubelt.rpc.schema.util :as rpc.schema.util]
+   [com.kubelt.rpc.server :as rpc.server]
    [com.kubelt.spec.rpc :as spec.rpc]
-   [com.kubelt.spec.rpc.available :as spec.rpc.available]
+   [com.kubelt.spec.rpc.api :as spec.rpc.api]
    [com.kubelt.spec.rpc.call :as spec.rpc.call]
    [com.kubelt.spec.rpc.client :as spec.rpc.client]
-   [com.kubelt.spec.rpc.discover :as spec.rpc.discover]
    [com.kubelt.spec.rpc.doc :as spec.rpc.doc]
    [com.kubelt.spec.rpc.execute :as spec.rpc.execute]
-   [com.kubelt.spec.rpc.inflate :as spec.rpc.inflate]
    [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.prepare :as spec.rpc.prepare]
    [com.kubelt.spec.rpc.request :as spec.rpc.request]
-   [com.kubelt.spec.rpc.schema :as spec.rpc.schema]))
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]
+   [com.kubelt.spec.rpc.servers :as spec.rpc.servers]))
 
 ;; TODO check version of supplied schema to ensure we support it
 
@@ -38,10 +38,6 @@
 ;; TODO add option to provide set of "dividing" characters, e.g. _, .
 ;; - "eth_sync" => [:eth :sync]
 ;; - "rpc.provider" => [:rpc :provider]
-;;
-;; TODO add option for using a prefix, e.g.
-;; {:method/prefix :xxx}
-;; - "eth_sync" => [:xxx :eth :sync]
 ;;
 ;; TODO if user wants to inject an existing HTTP client, should it go
 ;; into the options map (as things are now) or via a separate
@@ -77,7 +73,71 @@
                     (merge defaults $))]
       (rpc.client/init http-client options)))))
 
-;; available
+;; server
+;; -----------------------------------------------------------------------------
+
+(defn server
+  "Update a client by adding a server configuration. This is useful when a
+  schema is loaded that does not specify one or more servers
+  already. The server configuration must conform to the OpenRPC
+  specification for a Server object, suitably edn-ized. At minimum, the
+  following fields are required:
+  - :name, the name of the server configuration
+  - :url, the URL of the server's RPC endpoint
+    The URL may be a URL template as long as any variables in the
+    template have corresponding values defined in the :variables map of
+    the server configuration."
+  ([client config]
+   (let [prefix ::rpc.schema/default]
+     (server client prefix config)))
+
+  ([client prefix config]
+   (conform*
+    [spec.rpc.client/client client]
+    [spec.rpc.client/prefix prefix]
+    [spec.rpc.server/server config]
+    (let [;; Convert the name of the server into an idiomatic keyword.
+          server-name (rpc.schema.util/s->kw (get config :name))
+          ;; Our server map has the shape:
+          ;; {:prefix {:server-name {...}}}
+          path [:rpc/servers prefix server-name]]
+      (assoc-in client path config)))))
+
+;; servers
+;; -----------------------------------------------------------------------------
+
+(defn servers
+  "Return the name(s) of servers that the client knows about. Each schema
+  may have a collection of servers at which the corresponding service
+  may be accessed, and it is possible to select among them when
+  preparing or executing an RPC request. Available options:
+  - :server/name, the name of a server to select
+  - :server/random?, when true, select an available server at random"
+  ([client]
+   (let [path []]
+     (servers client path)))
+
+  ([client path]
+   (let [defaults {}]
+     (servers client path defaults)))
+
+  ([client path options]
+   (conform*
+    [spec.rpc.client/client client]
+    [spec.rpc/path path]
+    [spec.rpc.servers/options options]
+    (let [;; The collection of servers added independently of any schema
+          ;; using (server) function.
+          server-client (get client :rpc/servers {})
+          ;; Returns the collection of available servers in the client
+          ;; for the given path.
+          server-path (rpc.server/select client path options)]
+      ;; TODO merge these two sets of server configurations
+      ;; TODO return a set of vectors that name each server configuration
+      #{}
+      ))))
+
+;; api
 ;; -----------------------------------------------------------------------------
 ;; The intent of this function is to provide a pleasant REPL-driven
 ;; developer experience. A user should be able to instantiate or receive
@@ -88,7 +148,7 @@
 ;; the (doc) function to obtain more detailed documentation as data or
 ;; possibly in a pretty output format.
 
-(defn available
+(defn api
   "Return the collection of operations provided by the API. Each vector of
   keywords in the returned collection represents a call that may be
   performed. If a vector of keywords is provided as the 'path' argument,
@@ -98,17 +158,17 @@
   or transform the data that is returned."
   ([client]
    (let [path []]
-     (available client path)))
+     (api client path)))
 
   ([client path]
    (let [defaults {:methods/sort? true}]
-     (available client path defaults)))
+     (api client path defaults)))
 
   ([client path options]
    (conform*
     [spec.rpc.client/client client]
     [spec.rpc/path path]
-    [spec.rpc.available/options options]
+    [spec.rpc.api/options options]
     (let [sort? (get options :methods/sort?)
           depth (get options :methods/depth)
           search (get options :methods/search)
@@ -163,7 +223,7 @@
     [spec.rpc.client/client client]
     [spec.rpc/path path]
     [spec.rpc.doc/options options]
-    (let [path-set (available client path)
+    (let [path-set (api client path)
           path-count (count path-set)]
       ;; Calling (available) returns a set of paths that match a path
       ;; prefix, i.e. [:foo] will match all paths like [:foo ...]. We
@@ -196,42 +256,55 @@
   "Return a request map describing the RPC call to perform. The supplied
   parameters are validated against the service schema and an error map
   is returned if any issues are detected."
-  [client path params]
-  ;; Use conform* to ensure that each argument matches
-  ;; its schema.
-  (conform*
-   [spec.rpc.client/client client]
-   [spec.rpc/path path]
-   [spec.rpc/params params]
-   ;; TODO add macro for guards, i.e. to check the results of a
-   ;; collection of predicates and return meaningful errors when they
-   ;; fail. Maybe something like: (guards [() () ... ()] (body)).
-   (if-let [method (rpc.client/find-method client path)]
-     (let [options (get client :init/options)
-           ;; If a vector of values was supplied, turn it into a map by
-           ;; associating each positional value with its name in the
-           ;; schema definition. If a map was supplied, it should be
-           ;; from parameter name keyword to parameter value already. In
-           ;; either case, validate that we have the correct number of
-           ;; parameters.
-           ;;
-           ;; NB does not yet validate params using JSON Schema definition.
-           params (if (vector? params)
-                    (rpc.request/from-params-vec method params)
-                    (rpc.request/from-params-map method params))]
-       ;; TODO check if any of the parameter values are error
-       ;; maps. Coalesce into a single error map and return it, if so.
-       (if (lib.error/error? params)
-         params
-         (rpc.request/from-method path method params options)))
-     (lib.error/error {:message "no such RPC method" :method path}))))
+  ([client path params]
+   (let [defaults {}]
+     (prepare client path params defaults)))
+
+  ([client path params options]
+   ;; Use conform* to ensure that each argument matches
+   ;; its schema.
+   (conform*
+    [spec.rpc.client/client client]
+    [spec.rpc/path path]
+    [spec.rpc/params params]
+    [spec.rpc.prepare/options options]
+    ;; TODO add macro for guards, i.e. to check the results of a
+    ;; collection of predicates and return meaningful errors when they
+    ;; fail. Maybe something like: (guards [() () ... ()] (body)).
+    (if-let [method (rpc.client/find-method client path)]
+      (let [options (get client :init/options)
+            ;; Select the server that the prepared request should be
+            ;; executed against. The :server/name option, if present,
+            ;; should be used to look up one of the available server
+            ;; configuration maps.
+            ;; TODO check for a returned error value
+            server (rpc.server/select client path options)
+            ;; If a vector of values was supplied, turn it into a map by
+            ;; associating each positional value with its name in the
+            ;; schema definition. If a map was supplied, it should be
+            ;; from parameter name keyword to parameter value already. In
+            ;; either case, validate that we have the correct number of
+            ;; parameters.
+            ;;
+            ;; NB does not yet validate params using JSON Schema definition.
+            params (if (vector? params)
+                     (rpc.request/from-params-vec method params)
+                     (rpc.request/from-params-map method params))]
+        ;; TODO check if any of the parameter values are error
+        ;; maps. Coalesce into a single error map and return it, if so.
+        (if (lib.error/error? params)
+          params
+          (rpc.request/from-method server method params options)))
+      (lib.error/error {:message "no such RPC method" :method path})))))
 
 ;; execute
 ;; -----------------------------------------------------------------------------
 ;; options:
-;; - explicit request ID
-;; - override provider URL
-;; - request timeout
+;; - TODO explicit request ID (:request/id)
+;; global:
+;; - TODO request timeout (:rpc/timeout)
+;; - TODO JWT (:rpc/jwt)
+;; - user agent
 
 (defn execute
   "Execute a prepared RPC request."
@@ -247,10 +320,7 @@
     (let [http-client (get client :http/client)
           http-request (get request :http/request)]
       (tap> [::execute http-request])
-      ;; TODO validate result
-      ;; :node/browser Returns a promise.
-      ;; :jvm Returns a future.
-      (proto.http/request! http-client http-request)))))
+      (rpc.execute/execute http-client http-request)))))
 
 ;; call
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/rpc/client.cljc
+++ b/src/main/com/kubelt/rpc/client.cljc
@@ -25,6 +25,7 @@
   {:com.kubelt/type :kubelt.type/rpc.client
    :init/options options
    :http/client http-client
+   :rpc/servers {}
    :rpc/schemas {}})
 
 ;; find-method

--- a/src/main/com/kubelt/rpc/execute.cljc
+++ b/src/main/com/kubelt/rpc/execute.cljc
@@ -1,0 +1,17 @@
+(ns com.kubelt.rpc.execute
+  "Execute RPC requests."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.proto.http :as proto.http]))
+
+;; execute
+;; -----------------------------------------------------------------------------
+;; TODO validate result
+
+(defn execute
+  "Execute an RPC call using the given HTTP client and a map describing
+  the HTTP request to perform. Returns:
+  - [clj] a future that may be deref'ed to obtain the result
+  - [cljs] a promise that may be resolved to obtain the result"
+  [http request]
+  (proto.http/request! http request))

--- a/src/main/com/kubelt/rpc/schema.cljc
+++ b/src/main/com/kubelt/rpc/schema.cljc
@@ -1,8 +1,10 @@
 (ns com.kubelt.rpc.schema
   "Tools for working with OpenRPC schemas."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
-   (:require
+  (:require
    [com.kubelt.lib.error :as lib.error :refer [conform*] :refer-macros [conform*]]
+   [com.kubelt.rpc :as rpc]
+   [com.kubelt.rpc.request :as rpc.request]
    [com.kubelt.rpc.schema.fs :as rpc.schema.fs]
    [com.kubelt.rpc.schema.parse :as rpc.schema.parse]
    [com.kubelt.spec.rpc.client :as spec.rpc.client]
@@ -92,8 +94,54 @@
     [spec.rpc.client/prefix prefix]
     [spec.rpc.discover/url url]
     [spec.rpc.discover/options options]
-    :fixme
-    )))
+
+    ;; TODO option :rpc/jwt (to perform rpc.discover call)
+
+    ;; - Save the base URL into client; when referring to URL in a
+    ;;   Server block, it may be defined relative to the base URL (or it
+    ;;   might be absolute)
+
+    ;; prepare an rpc.discover request
+    ;; execute request
+    ;; extract schema from result
+    ;; inject a Server entry (if missing)
+    ;; update client by calling (schema)
+
+    (let [;; TEMP
+          schema-doc {:openrpc "1.2.6", :methods [], :info {:title "", :version "1.0.0"}}
+          ;; Construct a fake server object for now
+          server {:name "localhost"
+                  :url "http://localhost:8787/@0x4d38b2ccaed021d60a6161deac5fbd2641916064/jsonrpc"
+                  ;; Map from string (server variable name) to ServerVariable object
+                  ;; TODO use URL templates to construct final URL
+                  :variables {}}
+          ;; We concoct a description of an rpc.discover call as though
+          ;; it were described in an OpenRPC schema. This lets us use
+          ;; the same machinery for performing the RPC call as used for
+          ;; standard API calls.
+          ;; TODO add description of expected result (a schema).
+          method {:method/name "rpc.discover"
+                  :method/params {}
+                  :method.params/all []
+                  :method.params/required []
+                  :method.params/optional []
+                  :method.params/schemas {}}
+          ;; This call takes takes no parameters.
+          params {}
+          ;;
+          options (merge (get client :init/options {}) options)
+          ;; Prepare a request map for the standard rpc.discover
+          ;; call.
+          request (rpc.request/from-method server method params options)
+          ;;result (rpc/execute client request)
+          ]
+      request
+      ;;(schema client prefix schema-doc options)
+      ))))
+
+(comment
+  (def rpc-url "http://localhost:8787/@0x4d38b2ccaed021d60a6161deac5fbd2641916064/jsonrpc")
+  )
 
 ;; http
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/rpc/schema.cljc
+++ b/src/main/com/kubelt/rpc/schema.cljc
@@ -3,7 +3,6 @@
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.lib.error :as lib.error :refer [conform*] :refer-macros [conform*]]
-   [com.kubelt.rpc :as rpc]
    [com.kubelt.rpc.request :as rpc.request]
    [com.kubelt.rpc.schema.fs :as rpc.schema.fs]
    [com.kubelt.rpc.schema.parse :as rpc.schema.parse]
@@ -107,9 +106,8 @@
     ;; inject a Server entry (if missing)
     ;; update client by calling (schema)
 
-    (let [;; TEMP
-          schema-doc {:openrpc "1.2.6", :methods [], :info {:title "", :version "1.0.0"}}
-          ;; Construct a fake server object for now
+    (let [;; TODO Construct a fake server object for now, but we need to
+          ;; look up the correct server to use.
           server {:name "localhost"
                   :url "http://localhost:8787/@0x4d38b2ccaed021d60a6161deac5fbd2641916064/jsonrpc"
                   ;; Map from string (server variable name) to ServerVariable object
@@ -128,13 +126,18 @@
                   :method.params/schemas {}}
           ;; This call takes takes no parameters.
           params {}
-          ;;
-          options (merge (get client :init/options {}) options)
+          ;; Merge the options used to initialize the client and the
+          ;; options used for this call. Some of the client options
+          ;; apply generally when executing RPC calls, e.g. the user
+          ;; agent to use, or the global request timeout value.
+          client-opts (get client :init/options {})
+          options (merge client-opts options)
           ;; Prepare a request map for the standard rpc.discover
           ;; call.
           request (rpc.request/from-method server method params options)
-          ;;result (rpc/execute client request)
-          ]
+          ;; Perform the HTTP request returning a promise (CLJS) or
+          ;; future (CLJ).
+          #_result #_(rpc.execute/execute client request)]
       request
       ;;(schema client prefix schema-doc options)
       ))))

--- a/src/main/com/kubelt/rpc/schema/expand.cljc
+++ b/src/main/com/kubelt/rpc/schema/expand.cljc
@@ -3,7 +3,6 @@
   by the referred value."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [clojure.string :as cstr]
    [clojure.zip :as zip])
   (:require
    [com.kubelt.rpc.schema.util :as rpc.schema.util]

--- a/src/main/com/kubelt/rpc/schema/parse.cljc
+++ b/src/main/com/kubelt/rpc/schema/parse.cljc
@@ -170,4 +170,5 @@
         {:rpc/version rpc-version
          :rpc/metadata rpc-metadata
          :rpc/servers rpc-servers
-         :rpc/methods rpc-methods}))))
+         :rpc/methods rpc-methods}))
+    (lib.error/error "unable to validate schema")))

--- a/src/main/com/kubelt/rpc/server.cljc
+++ b/src/main/com/kubelt/rpc/server.cljc
@@ -5,7 +5,7 @@
    [malli.core :as malli])
   (:require
    [com.kubelt.lib.uri :as lib.uri]
-   [com.kubelt.rpc.client :as rpc.client]
+   ;;[com.kubelt.rpc.client :as rpc.client]
    [com.kubelt.spec.openrpc.server :as spec.openrpc.server]))
 
 ;; server?
@@ -63,11 +63,15 @@
      (select client path defaults)))
 
   ([client path options]
-   (let [method (rpc.client/find-method client path)]
+   (let [;; TODO fix me; this introduces a cyclic dependency. Move into
+         ;; shared .method namespace and use from both client and this
+         ;; namespace?
+         ;;method (rpc.client/find-method client path)
+         ]
      ;; TODO use the path to select one of the available schemas.
      ;; TODO use the :server/name value to select one of the servers from the schema
      ;; TODO use the :server/random? flag to return an available server at random
      ;; TODO otherwise return only available server
      ;; TODO otherwise return an error (no servers available)
-     method
+     ;;method
      )))

--- a/src/main/com/kubelt/rpc/server.cljc
+++ b/src/main/com/kubelt/rpc/server.cljc
@@ -1,0 +1,45 @@
+(ns com.kubelt.rpc.server
+  "Work with OpenRPC Server objects."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.lib.uri :as lib.uri]
+   [malli.core :as malli])
+  (:require
+   [com.kubelt.spec.openrpc.server :as spec.openrpc.server]))
+
+;; server?
+;; -----------------------------------------------------------------------------
+
+(defn server?
+  "Returns true if the given value has the shape of an OpenRPC server
+  configuration map, and false otherwise."
+  [x]
+  (malli/validate spec.openrpc.server/server x))
+
+;; uri
+;; -----------------------------------------------------------------------------
+
+(defn uri
+  "Convert an OpenRPC server map into a URL. Note that the URL may be
+  supplied as a template, in which case there may be variables supplied
+  in the :variables map that may be used to interpolate those variables
+  when producing the URI."
+  [m]
+  {:pre [(server? m)]}
+  ;; TODO be sure we support relative URLs; a server map :uri might be
+  ;; defined w.r.t. a base URL rather than being absolute. (lib.uri/join)?
+  (let [template (get m :uri)
+        variables (get m :variables)]
+    ;; TODO this currently just returns the template unmodified
+    (lib.uri/expand template variables)))
+
+;; uri-map
+;; -----------------------------------------------------------------------------
+
+(defn uri-map
+  "Given an OpenRPC server map, generate the URL it represents and return
+  a map of URI components."
+  [m]
+  {:pre [(server? m)]}
+  (let [server-url (uri m)]
+    (lib.uri/parse server-url)))

--- a/src/main/com/kubelt/rpc/server.cljc
+++ b/src/main/com/kubelt/rpc/server.cljc
@@ -2,9 +2,10 @@
   "Work with OpenRPC Server objects."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.lib.uri :as lib.uri]
    [malli.core :as malli])
   (:require
+   [com.kubelt.lib.uri :as lib.uri]
+   [com.kubelt.rpc.client :as rpc.client]
    [com.kubelt.spec.openrpc.server :as spec.openrpc.server]))
 
 ;; server?
@@ -21,7 +22,7 @@
 
 (defn uri
   "Convert an OpenRPC server map into a URL. Note that the URL may be
-  supplied as a template, in which case there may be variables supplied
+  supplied as a template, in which case there may be values supplied
   in the :variables map that may be used to interpolate those variables
   when producing the URI."
   [m]
@@ -30,7 +31,10 @@
   ;; defined w.r.t. a base URL rather than being absolute. (lib.uri/join)?
   (let [template (get m :uri)
         variables (get m :variables)]
-    ;; TODO this currently just returns the template unmodified
+    ;; TODO this currently just returns the template unmodified. If no
+    ;; variables are present in the server map (we pass nil as the
+    ;; variables argument to (expand)), this should return the template
+    ;; unchanged.
     (lib.uri/expand template variables)))
 
 ;; uri-map
@@ -43,3 +47,27 @@
   {:pre [(server? m)]}
   (let [server-url (uri m)]
     (lib.uri/parse server-url)))
+
+;; select
+;; -----------------------------------------------------------------------------
+
+(defn select
+  "Return a server configuration map from the client. The path is used to
+  select one of the available schemas within the client. If the options
+  map contains the :server/name key, that name is used to select the
+  corresponding server configuration from within the schema. If no
+  server name is provided, and only one server is available, that is
+  returned. If no servers are configured, an error is returned."
+  ([client path]
+   (let [defaults {}]
+     (select client path defaults)))
+
+  ([client path options]
+   (let [method (rpc.client/find-method client path)]
+     ;; TODO use the path to select one of the available schemas.
+     ;; TODO use the :server/name value to select one of the servers from the schema
+     ;; TODO use the :server/random? flag to return an available server at random
+     ;; TODO otherwise return only available server
+     ;; TODO otherwise return an error (no servers available)
+     method
+     )))

--- a/src/main/com/kubelt/spec/openrpc/component.cljc
+++ b/src/main/com/kubelt/spec/openrpc/component.cljc
@@ -1,5 +1,7 @@
 (ns com.kubelt.spec.openrpc.component
-  ""
+  "Defines the schema for the set of OpenRPC components, which are objects
+  that constitute different aspects of an OpenRPC API that may be
+  referred to from elsewhere in an API definition to allow reuse."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.spec.openrpc.content :as openrpc.content]

--- a/src/main/com/kubelt/spec/openrpc/content.cljc
+++ b/src/main/com/kubelt/spec/openrpc/content.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.content
-  ""
+  "Defines the schema for an OpenRPC Content Descriptor object. These are
+  reusable ways of describing either an RPC parameter or a result."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name])
   (:require

--- a/src/main/com/kubelt/spec/openrpc/example.cljc
+++ b/src/main/com/kubelt/spec/openrpc/example.cljc
@@ -1,4 +1,6 @@
 (ns com.kubelt.spec.openrpc.example
+  "Describes an OpenRPC Example object that is intended to match a Content
+  Descriptor schema."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/info.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info
-  ""
+  "Define the schema for an OpenRPC Info object that provides metadata
+  about an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.spec.openrpc.info.contact :as info.contact]

--- a/src/main/com/kubelt/spec/openrpc/info/contact.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/contact.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info.contact
-  ""
+  "Defines the schema for an OpenRPC Contact object that provides contact
+  information for an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/info/license.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/license.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info.license
-  ""
+  "Defines the schema for an OpenRPC License object that provides the
+  license information for an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/pairing.cljc
+++ b/src/main/com/kubelt/spec/openrpc/pairing.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.pairing
-  ""
+  "Defines the schema for an OpenRPC Example Pairing object that provides
+  a set of example parameters and results."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name])
   (:require

--- a/src/main/com/kubelt/spec/rpc/api.cljc
+++ b/src/main/com/kubelt/spec/rpc/api.cljc
@@ -1,12 +1,12 @@
-(ns com.kubelt.spec.rpc.available
-  "Schemas related to the rpc/methods function."
+(ns com.kubelt.spec.rpc.api
+  "Schemas related to the com.kubelt.rpc/api function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
 
 ;; options
 ;; -----------------------------------------------------------------------------
-;; The options map that can be passed to the (available) function that
-;; is used to explore the collection of API methods available via an RPC
-;; client.
+;; The options map that can be passed to the (com.kubelt.rpc/api)
+;; function that is used to explore the collection of API methods
+;; available via an RPC client.
 
 (def options
   [:map

--- a/src/main/com/kubelt/spec/rpc/client.cljc
+++ b/src/main/com/kubelt/spec/rpc/client.cljc
@@ -3,7 +3,10 @@
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [methods])
   (:require
-   [com.kubelt.spec.rpc.init :as spec.rpc.init]))
+   [com.kubelt.rpc.server :as rpc.server]
+   [com.kubelt.spec.openrpc.server :as spec.openrpc.server]
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
 
 ;; http-client
 ;; -----------------------------------------------------------------------------
@@ -40,6 +43,9 @@
 (def schemas
   [:map-of prefix schema])
 
+(def servers
+  [:map-of prefix [:map-of spec.openrpc.server/name rpc.server/server]])
+
 ;; client
 ;; -----------------------------------------------------------------------------
 ;; An RPC client.
@@ -49,4 +55,5 @@
    [:com.kubelt/type [:enum :kubelt.type/rpc.client]]
    [:init/options spec.rpc.init/options]
    [:http/client http-client]
+   [:rpc/servers servers]
    [:rpc/schemas schemas]])

--- a/src/main/com/kubelt/spec/rpc/client.cljc
+++ b/src/main/com/kubelt/spec/rpc/client.cljc
@@ -3,7 +3,6 @@
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [methods])
   (:require
-   [com.kubelt.rpc.server :as rpc.server]
    [com.kubelt.spec.openrpc.server :as spec.openrpc.server]
    [com.kubelt.spec.rpc.init :as spec.rpc.init]
    [com.kubelt.spec.rpc.server :as spec.rpc.server]))
@@ -28,23 +27,23 @@
 
 ;; TODO flesh these specs out to describe the RPC client map that
 ;; results from the (rpc/init) call.
-(def version :string)
-(def metadata :map)
-(def servers [:vector :any])
-(def methods :map)
+(def schema-version :string)
+(def schema-metadata :map)
+(def schema-servers [:vector :any])
+(def schema-methods :map)
 
 (def schema
   [:map
-   [:rpc/version version]
-   [:rpc/metadata metadata]
-   [:rpc/servers servers]
-   [:rpc/methods methods]])
+   [:rpc/version schema-version]
+   [:rpc/metadata schema-metadata]
+   [:rpc/servers schema-servers]
+   [:rpc/methods schema-methods]])
 
 (def schemas
   [:map-of prefix schema])
 
 (def servers
-  [:map-of prefix [:map-of spec.openrpc.server/name rpc.server/server]])
+  [:map-of prefix [:map-of spec.openrpc.server/name spec.rpc.server/server]])
 
 ;; client
 ;; -----------------------------------------------------------------------------

--- a/src/main/com/kubelt/spec/rpc/discover.cljc
+++ b/src/main/com/kubelt/spec/rpc/discover.cljc
@@ -1,6 +1,8 @@
 (ns com.kubelt.spec.rpc.discover
   "Schemas related to com.kubelt.rpc/discover function."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.jwt :as spec.jwt]))
 
 ;; url
 ;; -----------------------------------------------------------------------------
@@ -16,4 +18,5 @@
 ;; into an RPC client.
 
 (def options
-  :map)
+  [:map
+   [:rpc/jwt {:optional true} spec.jwt/jwt]])

--- a/src/main/com/kubelt/spec/rpc/execute.cljc
+++ b/src/main/com/kubelt/spec/rpc/execute.cljc
@@ -1,11 +1,16 @@
 (ns com.kubelt.spec.rpc.execute
   "Schemas related to the com.kubelt.rpc/execute function."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.request :as spec.rpc.request]))
 
 ;; options
 ;; -----------------------------------------------------------------------------
 ;; The options map that may be passed to RPC client (execute) function.
 
 (def options
-  ;; TODO
-  :map)
+  [:map
+   [:request/id {:optional true} spec.rpc.request/id]
+   [:rpc/jwt {:optional true} spec.rpc.init/jwt]
+   [:rpc/timeout {:optional true} spec.rpc.init/timeout]])

--- a/src/main/com/kubelt/spec/rpc/init.cljc
+++ b/src/main/com/kubelt/spec/rpc/init.cljc
@@ -2,7 +2,8 @@
   "Schemas related to RPC client (init) function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.spec.jwt :as spec.jwt]))
+   [com.kubelt.spec.jwt :as spec.jwt]
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]))
 
 ;; http-client
 ;; -----------------------------------------------------------------------------
@@ -10,6 +11,16 @@
 ;; TODO re-use existing HTTP client definition
 (def http-client
   :map)
+
+;; jwt
+;; -----------------------------------------------------------------------------
+;; Defines a JWT credential supplied along with an RPC request.
+
+;; TODO flip :rpc/jwt to spec.jwt/jwt once we use/expect decrypted jwt
+;; value (in BE too).
+(def jwt
+  ;;spec.jwt/jwt
+  :string)
 
 ;; user-agent
 ;; -----------------------------------------------------------------------------
@@ -20,6 +31,13 @@
 (def user-agent
   :string)
 
+;; timeout
+;; -----------------------------------------------------------------------------
+;; The amount of time to wait for an RPC request to complete.
+
+(def timeout
+  nat-int?)
+
 ;; options
 ;; -----------------------------------------------------------------------------
 ;; The options map that may be passed to RPC client (init) function.
@@ -28,5 +46,5 @@
   [:map
    [:http/client {:optional true} http-client]
    [:http/user-agent {:optional true} user-agent]
-   ;; TODO flip :rpc/jwt to spec.jwt/jwt once we use/expect decrypted jwt value (in BE too)
-   [:rpc/jwt {:optional true} :string]])
+   [:rpc/jwt {:optional true} jwt]
+   [:rpc/timeout {:optional true} timeout]])

--- a/src/main/com/kubelt/spec/rpc/init.cljc
+++ b/src/main/com/kubelt/spec/rpc/init.cljc
@@ -2,7 +2,7 @@
   "Schemas related to RPC client (init) function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.spec.jwt :as spec.jwt]
+   ;;[com.kubelt.spec.jwt :as spec.jwt]
    [com.kubelt.spec.rpc.init :as spec.rpc.init]))
 
 ;; http-client

--- a/src/main/com/kubelt/spec/rpc/prepare.cljc
+++ b/src/main/com/kubelt/spec/rpc/prepare.cljc
@@ -1,0 +1,17 @@
+(ns com.kubelt.spec.rpc.prepare
+  "Schemas related to the com.kubelt.rpc/prepare function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.request :as spec.rpc.request]
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to RPC client
+;; com.kubelt.rpc/prepare function.
+
+(def options
+  [:map
+   [:request/id {:optional true} spec.rpc.request/id]
+   spec.rpc.server/name-entry
+   spec.rpc.server/random?-entry])

--- a/src/main/com/kubelt/spec/rpc/request.cljc
+++ b/src/main/com/kubelt/spec/rpc/request.cljc
@@ -4,20 +4,25 @@
   (:require
    [com.kubelt.spec.http :as spec.http]))
 
-;; options
+;; id
 ;; -----------------------------------------------------------------------------
-;; The options map that may be passed to RPC client (request) function.
+;; Every RPC request must have a unique identifier.
 
-(def options
-  ;; TODO
-  :map)
+(def id
+  :string)
 
 ;; request
 ;; -----------------------------------------------------------------------------
 ;; An RPC request map.
-
+;;
 ;; NB: we re-use the HTTP request map schema.
+
 (def request
   [:map
    [:com.kubelt/type [:enum :kubelt.type/rpc.request]]
-   [:http/request   spec.http/request]])
+   [:request/id id]
+   ;; TODO
+   ;;[:rpc/method method]
+   ;;[:rpc/params params]
+   ;;[:rpc/server server]
+   [:http/request spec.http/request]])

--- a/src/main/com/kubelt/spec/rpc/server.cljc
+++ b/src/main/com/kubelt/spec/rpc/server.cljc
@@ -1,0 +1,35 @@
+(ns com.kubelt.spec.rpc.server
+  "Common options for specifying a server to execute an RPC against."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.server :as spec.openrpc.server]))
+
+;; name
+;; -----------------------------------------------------------------------------
+;; This is the name of a Server configuration map in an OpenRPC schema.
+;; When preparing an RPC request for execution, one of the available
+;; server backends must be selected (if there is more than one) by name.
+
+(def name
+  spec.openrpc.server/name)
+
+(def name-entry
+  [:server/name {:optional true} name])
+
+;; random?
+;; -----------------------------------------------------------------------------
+;; Rather than picking a specific server, set this flag to enable the
+;; selection of one of the available servers at random.
+
+(def random?
+  :boolean)
+
+(def random?-entry
+  [:server/random? {:optional true} random?])
+
+;; server
+;; -----------------------------------------------------------------------------
+
+(def server
+  spec.openrpc.server/server)

--- a/src/main/com/kubelt/spec/rpc/servers.cljc
+++ b/src/main/com/kubelt/spec/rpc/servers.cljc
@@ -1,0 +1,14 @@
+(ns com.kubelt.spec.rpc.servers
+  "Schemas related to the (com.kubelt.rpc/servers) function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to the (com.kubelt.rpc/servers) function.
+
+(def options
+  [:map
+   spec.rpc.server/name-entry
+   spec.rpc.server/random?-entry])


### PR DESCRIPTION
# Description

OpenRPC supports a method for discovering the schema that defines a compliant API. Our backend is supporting that mechanism, enabling us to dynamically discover what calls are available. This adds initial support for this discovery mechanism.

- add `com.kubelt.lib.uri` namespace for cross-platform URI utilities
  - contains capabilities required to work with OpenRPC Server configuration
  - [x] `parse` URI string into our map format
  - [ ] tests for `parse` fn
  - [ ] `unparse` our map format into URI string
  - [ ] tests for `unparse` fn
  - [ ] `expand` a [URL template](https://datatracker.ietf.org/doc/html/rfc6570) into a string using supplied parameters
  - [ ] tests for `expand` fn
- add `com.kubelt.rpc.server` namespace for working with OpenRPC `Server`

## Type of change

- [x] New feature (non-breaking change which adds functionality)