### PR TITLE
chore(spec): add OpenRPC specs

### DIFF
--- a/src/main/com/kubelt/spec/openrpc/component.cljc
+++ b/src/main/com/kubelt/spec/openrpc/component.cljc
@@ -1,5 +1,7 @@
 (ns com.kubelt.spec.openrpc.component
-  ""
+  "Defines the schema for the set of OpenRPC components, which are objects
+  that constitute different aspects of an OpenRPC API that may be
+  referred to from elsewhere in an API definition to allow reuse."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.spec.openrpc.content :as openrpc.content]

--- a/src/main/com/kubelt/spec/openrpc/content.cljc
+++ b/src/main/com/kubelt/spec/openrpc/content.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.content
-  ""
+  "Defines the schema for an OpenRPC Content Descriptor object. These are
+  reusable ways of describing either an RPC parameter or a result."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name])
   (:require

--- a/src/main/com/kubelt/spec/openrpc/example.cljc
+++ b/src/main/com/kubelt/spec/openrpc/example.cljc
@@ -1,4 +1,6 @@
 (ns com.kubelt.spec.openrpc.example
+  "Describes an OpenRPC Example object that is intended to match a Content
+  Descriptor schema."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/info.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info
-  ""
+  "Define the schema for an OpenRPC Info object that provides metadata
+  about an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.spec.openrpc.info.contact :as info.contact]

--- a/src/main/com/kubelt/spec/openrpc/info/contact.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/contact.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info.contact
-  ""
+  "Defines the schema for an OpenRPC Contact object that provides contact
+  information for an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/info/license.cljc
+++ b/src/main/com/kubelt/spec/openrpc/info/license.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.info.license
-  ""
+  "Defines the schema for an OpenRPC License object that provides the
+  license information for an API."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name]))
 

--- a/src/main/com/kubelt/spec/openrpc/pairing.cljc
+++ b/src/main/com/kubelt/spec/openrpc/pairing.cljc
@@ -1,5 +1,6 @@
 (ns com.kubelt.spec.openrpc.pairing
-  ""
+  "Defines the schema for an OpenRPC Example Pairing object that provides
+  a set of example parameters and results."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [name])
   (:require

--- a/src/main/com/kubelt/spec/rpc/api.cljc
+++ b/src/main/com/kubelt/spec/rpc/api.cljc
@@ -1,0 +1,15 @@
+(ns com.kubelt.spec.rpc.api
+  "Schemas related to the com.kubelt.rpc/api function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that can be passed to the (com.kubelt.rpc/api)
+;; function that is used to explore the collection of API methods
+;; available via an RPC client.
+
+(def options
+  [:map
+   [:methods/sort? {:optional true} :boolean]
+   [:methods/depth {:optional true} nat-int?]
+   [:methods/search {:optional true} :string]])

--- a/src/main/com/kubelt/spec/rpc/client.cljc
+++ b/src/main/com/kubelt/spec/rpc/client.cljc
@@ -3,7 +3,9 @@
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:refer-clojure :exclude [methods])
   (:require
-   [com.kubelt.spec.rpc.init :as spec.rpc.init]))
+   [com.kubelt.spec.openrpc.server :as spec.openrpc.server]
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
 
 ;; http-client
 ;; -----------------------------------------------------------------------------
@@ -25,20 +27,23 @@
 
 ;; TODO flesh these specs out to describe the RPC client map that
 ;; results from the (rpc/init) call.
-(def version :string)
-(def metadata :map)
-(def servers [:vector :any])
-(def methods :map)
+(def schema-version :string)
+(def schema-metadata :map)
+(def schema-servers [:vector :any])
+(def schema-methods :map)
 
 (def schema
   [:map
-   [:rpc/version version]
-   [:rpc/metadata metadata]
-   [:rpc/servers servers]
-   [:rpc/methods methods]])
+   [:rpc/version schema-version]
+   [:rpc/metadata schema-metadata]
+   [:rpc/servers schema-servers]
+   [:rpc/methods schema-methods]])
 
 (def schemas
   [:map-of prefix schema])
+
+(def servers
+  [:map-of prefix [:map-of spec.openrpc.server/name spec.rpc.server/server]])
 
 ;; client
 ;; -----------------------------------------------------------------------------
@@ -49,4 +54,5 @@
    [:com.kubelt/type [:enum :kubelt.type/rpc.client]]
    [:init/options spec.rpc.init/options]
    [:http/client http-client]
+   [:rpc/servers servers]
    [:rpc/schemas schemas]])

--- a/src/main/com/kubelt/spec/rpc/discover.cljc
+++ b/src/main/com/kubelt/spec/rpc/discover.cljc
@@ -1,6 +1,8 @@
 (ns com.kubelt.spec.rpc.discover
   "Schemas related to com.kubelt.rpc/discover function."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.jwt :as spec.jwt]))
 
 ;; url
 ;; -----------------------------------------------------------------------------
@@ -16,4 +18,5 @@
 ;; into an RPC client.
 
 (def options
-  :map)
+  [:map
+   [:rpc/jwt {:optional true} spec.jwt/jwt]])

--- a/src/main/com/kubelt/spec/rpc/execute.cljc
+++ b/src/main/com/kubelt/spec/rpc/execute.cljc
@@ -1,11 +1,16 @@
 (ns com.kubelt.spec.rpc.execute
   "Schemas related to the com.kubelt.rpc/execute function."
-  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.init :as spec.rpc.init]
+   [com.kubelt.spec.rpc.request :as spec.rpc.request]))
 
 ;; options
 ;; -----------------------------------------------------------------------------
 ;; The options map that may be passed to RPC client (execute) function.
 
 (def options
-  ;; TODO
-  :map)
+  [:map
+   [:request/id {:optional true} spec.rpc.request/id]
+   [:rpc/jwt {:optional true} spec.rpc.init/jwt]
+   [:rpc/timeout {:optional true} spec.rpc.init/timeout]])

--- a/src/main/com/kubelt/spec/rpc/init.cljc
+++ b/src/main/com/kubelt/spec/rpc/init.cljc
@@ -2,7 +2,7 @@
   "Schemas related to RPC client (init) function."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.spec.jwt :as spec.jwt]))
+   #_[com.kubelt.spec.jwt :as spec.jwt]))
 
 ;; http-client
 ;; -----------------------------------------------------------------------------
@@ -10,6 +10,16 @@
 ;; TODO re-use existing HTTP client definition
 (def http-client
   :map)
+
+;; jwt
+;; -----------------------------------------------------------------------------
+;; Defines a JWT credential supplied along with an RPC request.
+
+;; TODO flip :rpc/jwt to spec.jwt/jwt once we use/expect decrypted jwt
+;; value (in BE too).
+(def jwt
+  ;;spec.jwt/jwt
+  :string)
 
 ;; user-agent
 ;; -----------------------------------------------------------------------------
@@ -20,6 +30,13 @@
 (def user-agent
   :string)
 
+;; timeout
+;; -----------------------------------------------------------------------------
+;; The amount of time to wait for an RPC request to complete.
+
+(def timeout
+  nat-int?)
+
 ;; options
 ;; -----------------------------------------------------------------------------
 ;; The options map that may be passed to RPC client (init) function.
@@ -28,5 +45,5 @@
   [:map
    [:http/client {:optional true} http-client]
    [:http/user-agent {:optional true} user-agent]
-   ;; TODO flip :rpc/jwt to spec.jwt/jwt once we use/expect decrypted jwt value (in BE too)
-   [:rpc/jwt {:optional true} :string]])
+   [:rpc/jwt {:optional true} jwt]
+   [:rpc/timeout {:optional true} timeout]])

--- a/src/main/com/kubelt/spec/rpc/prepare.cljc
+++ b/src/main/com/kubelt/spec/rpc/prepare.cljc
@@ -1,0 +1,17 @@
+(ns com.kubelt.spec.rpc.prepare
+  "Schemas related to the com.kubelt.rpc/prepare function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.request :as spec.rpc.request]
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to RPC client
+;; com.kubelt.rpc/prepare function.
+
+(def options
+  [:map
+   [:request/id {:optional true} spec.rpc.request/id]
+   spec.rpc.server/name-entry
+   spec.rpc.server/random?-entry])

--- a/src/main/com/kubelt/spec/rpc/request.cljc
+++ b/src/main/com/kubelt/spec/rpc/request.cljc
@@ -4,20 +4,25 @@
   (:require
    [com.kubelt.spec.http :as spec.http]))
 
-;; options
+;; id
 ;; -----------------------------------------------------------------------------
-;; The options map that may be passed to RPC client (request) function.
+;; Every RPC request must have a unique identifier.
 
-(def options
-  ;; TODO
-  :map)
+(def id
+  :string)
 
 ;; request
 ;; -----------------------------------------------------------------------------
 ;; An RPC request map.
-
+;;
 ;; NB: we re-use the HTTP request map schema.
+
 (def request
   [:map
    [:com.kubelt/type [:enum :kubelt.type/rpc.request]]
-   [:http/request   spec.http/request]])
+   [:request/id id]
+   ;; TODO
+   ;;[:rpc/method method]
+   ;;[:rpc/params params]
+   ;;[:rpc/server server]
+   [:http/request spec.http/request]])

--- a/src/main/com/kubelt/spec/rpc/server.cljc
+++ b/src/main/com/kubelt/spec/rpc/server.cljc
@@ -1,0 +1,35 @@
+(ns com.kubelt.spec.rpc.server
+  "Common options for specifying a server to execute an RPC against."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:refer-clojure :exclude [name])
+  (:require
+   [com.kubelt.spec.openrpc.server :as spec.openrpc.server]))
+
+;; name
+;; -----------------------------------------------------------------------------
+;; This is the name of a Server configuration map in an OpenRPC schema.
+;; When preparing an RPC request for execution, one of the available
+;; server backends must be selected (if there is more than one) by name.
+
+(def name
+  spec.openrpc.server/name)
+
+(def name-entry
+  [:server/name {:optional true} name])
+
+;; random?
+;; -----------------------------------------------------------------------------
+;; Rather than picking a specific server, set this flag to enable the
+;; selection of one of the available servers at random.
+
+(def random?
+  :boolean)
+
+(def random?-entry
+  [:server/random? {:optional true} random?])
+
+;; server
+;; -----------------------------------------------------------------------------
+
+(def server
+  spec.openrpc.server/server)

--- a/src/main/com/kubelt/spec/rpc/servers.cljc
+++ b/src/main/com/kubelt/spec/rpc/servers.cljc
@@ -1,0 +1,14 @@
+(ns com.kubelt.spec.rpc.servers
+  "Schemas related to the (com.kubelt.rpc/servers) function."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.spec.rpc.server :as spec.rpc.server]))
+
+;; options
+;; -----------------------------------------------------------------------------
+;; The options map that may be passed to the (com.kubelt.rpc/servers) function.
+
+(def options
+  [:map
+   spec.rpc.server/name-entry
+   spec.rpc.server/random?-entry])

--- a/src/main/com/kubelt/spec/wallet.cljc
+++ b/src/main/com/kubelt/spec/wallet.cljc
@@ -3,9 +3,8 @@
   cross-platform key management and crypto facilities."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.spec.common :as spec.common]
    [com.kubelt.spec.core :as spec.core]
-   [com.kubelt.spec.crypto :as spec.crypto]
+   ;;[com.kubelt.spec.crypto :as spec.crypto]
    [com.kubelt.spec.jwt :as spec.jwt]))
 
 (def wallet-address

--- a/src/test/com/kubelt/rpc/schema_test.cljs
+++ b/src/test/com/kubelt/rpc/schema_test.cljs
@@ -1,19 +1,21 @@
 (ns com.kubelt.rpc.schema-test
   "Test rpc schema"
   (:require
-   ["fs" :refer [promises] :rename {promises fs-promises} :as fs]
    [cljs.core.async :refer [go]]
    [cljs.core.async.interop :refer-macros [<p!]]
    [cljs.reader :refer [read-string]]
-   [cljs.test :as t :refer [deftest is testing async]]
+   [cljs.test :as t :refer [deftest is testing async]])
+  (:require
+   ["fs" :refer [promises] :rename {promises fs-promises} :as fs])
+  (:require
+   [malli.core :as malli])
+  (:require
    [com.kubelt.lib.promise :as lib.promise]
    [com.kubelt.lib.util :as lib.util :refer [node-env]]
    [com.kubelt.rpc :as rpc]
    [com.kubelt.rpc.schema :as rpc.schema]
    [com.kubelt.rpc.schema.fs :as s.fs]
-   [com.kubelt.rpc.schema.parse :as rpc.schema.parse]
-   [malli.core :as malli]))
-
+   [com.kubelt.rpc.schema.parse :as rpc.schema.parse]))
 
 
 
@@ -43,7 +45,7 @@
 
 
 (deftest parse-be-schema-test
-  (testing "checks on be.edn "
+  (testing "checks on oort.edn"
     (async done
            (go
              (try


### PR DESCRIPTION
# Description

Introduces some of the OpenRPC-related schemas from the in-flight branch in case they're useful sooner for other work. Also fixes some lint issues in the perennial quest to become lint-clean.

## Type of change

- [x] New feature (non-breaking change which adds functionality)