### PR TITLE
chore: add project.clj to .gitignore

### DIFF
--- a/packages/sdk-clj/.gitignore
+++ b/packages/sdk-clj/.gitignore
@@ -14,3 +14,6 @@ target/
 
 # Maven pom
 pom.xml*
+
+# Generated Leiningen configuration file used to publish artifact
+project.clj

--- a/packages/sdk-cljs/.gitignore
+++ b/packages/sdk-cljs/.gitignore
@@ -14,3 +14,6 @@ target/
 
 # Maven pom
 pom.xml*
+
+# Generated Leiningen configuration file used to publish artifact
+project.clj


### PR DESCRIPTION
# Description

We have some utility scripts in our package directories for generating `project.clj` files as an aid to publishing artifacts; `shadow-cljs` user guide recommends using `lein` to that end. This just updates a couple of `.gitignore` files to ignore those generated files.