### PR TITLE
RPC core get/set profile support

### DIFF
--- a/src/main/com/kubelt/ddt/cmds/rpc/core.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core.cljs
@@ -2,7 +2,8 @@
   "RPC core options"
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.ddt.cmds.rpc.core.config :as core.config]))
+   [com.kubelt.ddt.cmds.rpc.core.config :as core.config]
+   [com.kubelt.ddt.cmds.rpc.core.profile :as core.profile]))
 
 (defonce command
   {:command "core <command>"
@@ -10,4 +11,5 @@
    :builder (fn [^js yargs]
               (-> yargs
                   (.command (clj->js core.config/command))
+                  (.command (clj->js core.profile/command))
                   (.demandCommand)))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/config/get.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/config/get.cljs
@@ -19,8 +19,7 @@
               (.option yargs rpc.call/ethers-rpc-name rpc.call/ethers-rpc-config))
    :handler (fn [args]
               (aset args "method" ":kb:get:config")
-              (let [args (rpc.call/rpc-args args)
-                    path (ddt.util/rpc-name->path (get args :path ""))]
+              (let [args (rpc.call/rpc-args args)]
                 (ddt.prompt/ask-password!
                  (fn [err result]
                    (ddt.util/exit-if err)

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/config/set.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/config/set.cljs
@@ -5,6 +5,7 @@
    [cljs.reader :as r])
   (:require
    [com.kubelt.ddt.auth :as ddt.auth]
+   [com.kubelt.lib.rpc :as lib.rpc ]
    [com.kubelt.ddt.cmds.rpc.call :as rpc.call ]
    [com.kubelt.ddt.options :as ddt.options]
    [com.kubelt.ddt.prompt :as ddt.prompt]
@@ -51,7 +52,7 @@
                       (-> (sdk.core/rpc-api sys (-> sys :crypto/wallet :wallet/address))
                           (lib.promise/then
                            (fn [api]
-                             (-> (rpc.call/rpc-call& sys api args)
+                             (-> (lib.rpc/rpc-call& sys api args)
                                  (lib.promise/then
                                   (fn [response]
                                     (println "CURRENT CONFIG-> " response)
@@ -59,7 +60,7 @@
                                     (let [args (assoc args
                                                       :method  (ddt.util/rpc-name->path ":kb:set:config")
                                                       :params (assoc-in response path config-value))]
-                                      (-> (rpc.call/rpc-call& sys api args)
+                                      (-> (lib.rpc/rpc-call& sys api args)
                                           (lib.promise/then #(println "SET->" %))
                                           (lib.promise/catch #(println "SET ERROR-> " %))))))
                                  (lib.promise/catch #(println "ERROR-> " %)))))

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/profile.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/profile.cljs
@@ -1,0 +1,13 @@
+(ns com.kubelt.ddt.cmds.rpc.core.profile
+  "RPC core options"
+  {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.ddt.cmds.rpc.core.profile.get :as core.profile.get]))
+
+(defonce command
+  {:command "profile"
+   :desc "Work with RPC core profile APIs"
+   :builder (fn [^js yargs]
+              (-> yargs
+                  (.command (clj->js core.profile.get/command))
+                  (.demandCommand)))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/profile.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/profile.cljs
@@ -2,7 +2,8 @@
   "RPC core options"
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.ddt.cmds.rpc.core.profile.get :as core.profile.get]))
+   [com.kubelt.ddt.cmds.rpc.core.profile.get :as core.profile.get]
+   [com.kubelt.ddt.cmds.rpc.core.profile.set :as core.profile.set]))
 
 (defonce command
   {:command "profile"
@@ -10,4 +11,5 @@
    :builder (fn [^js yargs]
               (-> yargs
                   (.command (clj->js core.profile.get/command))
+                  (.command (clj->js core.profile.set/command))
                   (.demandCommand)))})

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/profile/get.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/profile/get.cljs
@@ -1,15 +1,15 @@
-(ns com.kubelt.ddt.cmds.rpc.core.config.get
-  "RPC core config get"
+(ns com.kubelt.ddt.cmds.rpc.core.profile.get
+  "RPC core profile get"
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [com.kubelt.ddt.cmds.rpc.call :as rpc.call]
    [com.kubelt.ddt.options :as ddt.options]))
 
 (defonce command
-  {:command "get [path]"
-   :desc "Make an RPC call."
+  {:command "get"
+   :desc "Make an RPC get profile call."
    :requiresArg true
    :builder (fn [^Yargs yargs]
               (ddt.options/options yargs)
               (.option yargs rpc.call/ethers-rpc-name rpc.call/ethers-rpc-config))
-   :handler (rpc.call/ddt-rpc-call ":kb:get:config")})
+   :handler (rpc.call/ddt-rpc-call ":kb:get:profile")})

--- a/src/main/com/kubelt/ddt/cmds/rpc/core/profile/set.cljs
+++ b/src/main/com/kubelt/ddt/cmds/rpc/core/profile/set.cljs
@@ -1,0 +1,16 @@
+(ns com.kubelt.ddt.cmds.rpc.core.profile.set
+  "RPC core options"
+  {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [com.kubelt.ddt.cmds.rpc.call :as rpc.call ]
+   [com.kubelt.ddt.options :as ddt.options]))
+
+(defonce command
+  {:command "set <profile-value>"
+   :desc "Make an RPC call to set profile value (by default in json)"
+   :requiresArg true
+   :builder (fn [^Yargs yargs]
+              (ddt.options/options yargs)
+              (.option yargs rpc.call/ethers-rpc-name rpc.call/ethers-rpc-config)
+              (.option yargs rpc.call/edn-name rpc.call/edn-value))
+   :handler (rpc.call/ddt-rpc-call ":kb:set:profile" [:profile-value])})

--- a/src/main/com/kubelt/lib/rpc.cljs
+++ b/src/main/com/kubelt/lib/rpc.cljs
@@ -15,6 +15,7 @@
      (let [wallet-address (-> sys :crypto/wallet :wallet/address)
            client (-> {:uri/domain (-> sys :client/p2p :http/host)
                        :uri/port (-> sys :client/p2p :http/port)
+                       :uri/scheme (-> sys :client/p2p :http/scheme)
                        :uri/path (cstr/join "" ["/@" wallet-address "/jsonrpc"])
                        :http/client (:client/http sys)
                        :rpc/jwt (get-in sys [:crypto/session :vault/tokens* wallet-address])}

--- a/src/main/com/kubelt/lib/rpc.cljs
+++ b/src/main/com/kubelt/lib/rpc.cljs
@@ -1,0 +1,32 @@
+(ns com.kubelt.lib.rpc
+  "Play with rpc."
+  {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
+  (:require
+   [clojure.string :as cstr])
+  (:require
+   [com.kubelt.lib.promise :as lib.promise]
+   [com.kubelt.rpc :as rpc]
+   [com.kubelt.rpc.schema :as rpc.schema]
+   [com.kubelt.sdk.v1.core :as sdk.core]))
+
+(defn rpc-call& [sys api args]
+  (lib.promise/promise
+   (fn [resolve reject]
+     (let [wallet-address (-> sys :crypto/wallet :wallet/address)
+           client (-> {:uri/domain (-> sys :client/p2p :http/host)
+                       :uri/port (-> sys :client/p2p :http/port)
+                       :uri/path (cstr/join "" ["/@" wallet-address "/jsonrpc"])
+                       :http/client (:client/http sys)
+                       :rpc/jwt (get-in sys [:crypto/session :vault/tokens* wallet-address])}
+                      rpc/init
+                      (rpc.schema/schema api))
+           request (rpc/prepare client (:method args) (or (:params args) {}))
+           rpc-method (:method/name (:rpc/method request))
+           rpc-params (:rpc/params request)]
+       (if (:rpc-client-type args)
+         (-> (sdk.core/call-rpc-method sys wallet-address rpc-method (into [] (vals rpc-params)))
+             (lib.promise/then resolve)
+             (lib.promise/catch reject))
+         (-> (rpc/execute client request)
+             (lib.promise/then #(resolve (-> % :http/body :result)))
+             (lib.promise/catch reject)))))))

--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -21,7 +21,7 @@
                  (when-let [jwt (:rpc/jwt options)]
                    {"KBT-Access-JWT-Assertion" jwt}))
         trailers {}
-        scheme :http
+        scheme (:uri/scheme options :http)
         domain (:uri/domain options "example.com")
         port (:uri/port options 33337)
         path (:uri/path options "/foo")]

--- a/src/test/com/kubelt/lib/test_utils.cljs
+++ b/src/test/com/kubelt/lib/test_utils.cljs
@@ -1,0 +1,47 @@
+(ns com.kubelt.lib.test-utils
+  (:require
+   [cljs.core.async :refer [go <!]]
+   [cljs.core.async.interop :refer-macros [<p!]]
+   [cljs.test :refer-macros [is async] :as t]
+   [taoensso.timbre :as log])
+  (:require
+   [com.kubelt.lib.wallet.node :as wallet]))
+
+(defn create-wallet [app-name wallet-name wallet-password]
+  (go
+    (log/debug "creating-wallet: " wallet-name)
+    (try
+      (let [w (<p! (wallet/init& app-name wallet-name wallet-password))]
+        (is true "wallet created")
+        w)
+      (catch js/Error err (do (is false err) err)))))
+
+(defn delete-wallet [app-name wallet-name wallet-password]
+  (go
+    (log/debug "deleting-wallet: " wallet-name)
+    (try
+      (let [can-decrypt? (<p! (wallet/can-decrypt?& app-name wallet-name wallet-password))]
+        (log/debug "can-decrypt?: " can-decrypt?)
+        (when can-decrypt?
+          (let [deleted (<p! (wallet/delete!& app-name wallet-name))]
+            (log/debug :deleted deleted)
+            true)))
+      (catch js/Error err (do (is false err) err)))))
+
+(defn create-wallet-fixture [app-name wallet-name wallet-password]
+  #(async
+    done
+    (go
+      (try
+        (<! (create-wallet app-name wallet-name wallet-password))
+        (catch js/Error err (js/console.log err))
+        (finally (done))))))
+
+(defn delete-wallet-fixture [app-name wallet-name wallet-password]
+  #(async
+    done
+    (go
+      (try
+        (<! (delete-wallet app-name wallet-name wallet-password))
+        (catch js/Error err (js/console.log err))
+        (finally (done))))))

--- a/src/test/com/kubelt/rpc/auth_test.cljs
+++ b/src/test/com/kubelt/rpc/auth_test.cljs
@@ -1,64 +1,33 @@
 (ns com.kubelt.rpc.auth-test
   (:require
-   [cljs.core.async :refer [go <!]]
+   [cljs.core.async :refer [go]]
    [cljs.core.async.interop :refer-macros [<p!]]
-   [cljs.test :refer-macros [deftest is testing async] :as t]
+   [cljs.test :refer-macros [deftest is testing async use-fixtures] :as t]
    [taoensso.timbre :as log])
   (:require
+   [com.kubelt.rpc.test-commons :as t.commons]
+   [com.kubelt.lib.test-utils :as lib.test-utils]
    [com.kubelt.lib.wallet.node :as wallet]
    [com.kubelt.sdk.v1 :as sdk]
    [com.kubelt.sdk.v1.core :as sdk.core]))
 
-(def app-name "com.kubelt.ddt.js")
-(def wallet-name "auth_test")
-(def wallet-password "auth_foo_pw")
 
-(defn- create-wallet [app-name wallet-name wallet-password]
-  (go
-    (log/debug "creating-wallet: " wallet-name)
-    (try
-      (let [w (<p! (wallet/init& app-name wallet-name wallet-password))]
-        (is true "wallet created")
-        w)
-      (catch js/Error err (do (is false err) err)))))
-
-(defn delete-wallet [app-name wallet-name wallet-password]
-  (go
-    (log/debug "deleting-wallet: " wallet-name)
-    (try
-      (let [can-decrypt? (<p! (wallet/can-decrypt?& app-name wallet-name wallet-password))]
-        (log/debug "can-decrypt?: " can-decrypt?)
-        (when can-decrypt?
-          (let [deleted (<p! (wallet/delete!& app-name wallet-name))]
-            (log/debug :deleted deleted)
-            true)))
-      (catch js/Error err (do (is false err) err)))))
+(use-fixtures :once
+  {:before  (lib.test-utils/create-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)
+   :after (lib.test-utils/delete-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)})
 
 (deftest rpc-core-auth-test
   (testing "rpc auth test"
     (async done
            (go
-             (try
-               (<! (create-wallet app-name wallet-name wallet-password))
-               (catch js/Error err (js/console.log err)))
-             (try
-               (let [config {:p2p/scheme :https
-                             :p2p/host "oort-devnet.admin1337.workers.dev"
-                             :p2p/port  443}
+              (try
+               (let [config (t.commons/p2p-config)
                      sys (<p! (sdk/init config))
-                     wallet (<p! (wallet/load& app-name wallet-name wallet-password))
+                     wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
                      core (:wallet/address wallet)
                      kbt (<p! (sdk.core/authenticate& (assoc sys :crypto/wallet wallet)))]
-                 (is (= {} (-> sys :crypto/session :vault/tokens)))
+                  (is (= {} (-> sys :crypto/session :vault/tokens)))
                  (is (map? (get-in kbt [:crypto/session :vault/tokens core])))
                  (is (string? (get-in kbt [:crypto/session :vault/tokens* core]))))
-               (catch js/Error err (js/console.log err))
-               (finally
-                 (try
-                   (<! (delete-wallet app-name wallet-name wallet-password))
-                   (catch js/Error err (js/console.log err))
-                   (finally (done)))))))))
-
-(comment
-  (t/run-tests)
-  )
+               (catch js/Error err (log/error err))
+               (finally (done)))))))

--- a/src/test/com/kubelt/rpc/auth_test.cljs
+++ b/src/test/com/kubelt/rpc/auth_test.cljs
@@ -26,7 +26,7 @@
                      wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
                      core (:wallet/address wallet)
                      kbt (<p! (sdk.core/authenticate& (assoc sys :crypto/wallet wallet)))]
-                  (is (= {} (-> sys :crypto/session :vault/tokens)))
+                 (is (= {} (-> sys :crypto/session :vault/tokens)))
                  (is (map? (get-in kbt [:crypto/session :vault/tokens core])))
                  (is (string? (get-in kbt [:crypto/session :vault/tokens* core]))))
                (catch js/Error err (log/error err))

--- a/src/test/com/kubelt/rpc/profile_test.cljs
+++ b/src/test/com/kubelt/rpc/profile_test.cljs
@@ -33,12 +33,11 @@
                        _ (<p! (rpc.call/rpc-call& kbt api {:method [:kb :set :profile]
                                                            :params {:profile {:profilePicture updated-profile-picture}}}))
                        updated-profile (<p! (rpc.call/rpc-call& kbt api {:method [:kb :get :profile]}))]
-                   (is (= [{:profile-picture updated-profile-picture}] updated-profile))))
+                   (is (= {:profile-picture updated-profile-picture} updated-profile))))
                (catch js/Error err (log/error err))
                (finally (done)))))))
 
 (comment
-  "TODO: incosistent get-profile result after set-profile"
   "TODO:  should be rpc params be camelcased?"
   (t/run-tests)
   )

--- a/src/test/com/kubelt/rpc/profile_test.cljs
+++ b/src/test/com/kubelt/rpc/profile_test.cljs
@@ -7,7 +7,7 @@
   (:require
    [com.kubelt.rpc.test-commons :as t.commons]
    [com.kubelt.lib.test-utils :as lib.test-utils]
-   [com.kubelt.ddt.cmds.rpc.call :as rpc.call]
+   [com.kubelt.lib.rpc :as lib.rpc]
    [com.kubelt.lib.wallet.node :as wallet]
    [com.kubelt.sdk.v1 :as sdk]
    [com.kubelt.sdk.v1.core :as sdk.core]))
@@ -27,12 +27,12 @@
                      core (:wallet/address wallet)
                      kbt (<p! (sdk.core/authenticate& (assoc sys :crypto/wallet wallet)))
                      api (<p! (sdk.core/rpc-api sys core))
-                     profile (<p! (rpc.call/rpc-call& kbt api {:method [:kb :get :profile]}))]
+                     profile (<p! (lib.rpc/rpc-call& kbt api {:method [:kb :get :profile]}))]
                  (is (= {:profile-picture "DefaultKubeltPFP"} profile))
                  (let [updated-profile-picture "UpdatedProfilePicture"
-                       _ (<p! (rpc.call/rpc-call& kbt api {:method [:kb :set :profile]
+                       _ (<p! (lib.rpc/rpc-call& kbt api {:method [:kb :set :profile]
                                                            :params {:profile {:profilePicture updated-profile-picture}}}))
-                       updated-profile (<p! (rpc.call/rpc-call& kbt api {:method [:kb :get :profile]}))]
+                       updated-profile (<p! (lib.rpc/rpc-call& kbt api {:method [:kb :get :profile]}))]
                    (is (= {:profile-picture updated-profile-picture} updated-profile))))
                (catch js/Error err (log/error err))
                (finally (done)))))))

--- a/src/test/com/kubelt/rpc/profile_test.cljs
+++ b/src/test/com/kubelt/rpc/profile_test.cljs
@@ -1,0 +1,44 @@
+(ns com.kubelt.rpc.profile-test
+  (:require
+   [cljs.core.async :refer [go <!]]
+   [cljs.core.async.interop :refer-macros [<p!]]
+   [cljs.test :refer-macros [deftest is testing async use-fixtures] :as t]
+   [taoensso.timbre :as log])
+  (:require
+   [com.kubelt.rpc.test-commons :as t.commons]
+   [com.kubelt.lib.test-utils :as lib.test-utils]
+   [com.kubelt.ddt.cmds.rpc.call :as rpc.call]
+   [com.kubelt.lib.wallet.node :as wallet]
+   [com.kubelt.sdk.v1 :as sdk]
+   [com.kubelt.sdk.v1.core :as sdk.core]))
+
+(use-fixtures :once
+  {:before  (lib.test-utils/create-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)
+   :after (lib.test-utils/delete-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)})
+
+(deftest rpc-core-profile-test
+  (testing "rpc core profile get/set test"
+    (async done
+           (go
+             (try
+               (let [config (t.commons/p2p-config)
+                     sys (<p! (sdk/init config))
+                     wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
+                     core (:wallet/address wallet)
+                     kbt (<p! (sdk.core/authenticate& (assoc sys :crypto/wallet wallet)))
+                     api (<p! (sdk.core/rpc-api sys core))
+                     profile (<p! (rpc.call/rpc-call& kbt api {:method [:kb :get :profile]}))]
+                 (is (= {:profile-picture "DefaultKubeltPFP"} profile))
+                 (let [updated-profile-picture "UpdatedProfilePicture"
+                       _ (<p! (rpc.call/rpc-call& kbt api {:method [:kb :set :profile]
+                                                           :params {:profile {:profilePicture updated-profile-picture}}}))
+                       updated-profile (<p! (rpc.call/rpc-call& kbt api {:method [:kb :get :profile]}))]
+                   (is (= [{:profile-picture updated-profile-picture}] updated-profile))))
+               (catch js/Error err (log/error err))
+               (finally (done)))))))
+
+(comment
+  "TODO: incosistent get-profile result after set-profile"
+  "TODO:  should be rpc params be camelcased?"
+  (t/run-tests)
+  )

--- a/src/test/com/kubelt/rpc/schema_test.cljs
+++ b/src/test/com/kubelt/rpc/schema_test.cljs
@@ -14,9 +14,6 @@
    [com.kubelt.rpc.schema.parse :as rpc.schema.parse]
    [malli.core :as malli]))
 
-
-
-
 (def json-path
   (if (= "runner" (:username (node-env)))
     "./fix/openrpc/"

--- a/src/test/com/kubelt/rpc/test_commons.cljs
+++ b/src/test/com/kubelt/rpc/test_commons.cljs
@@ -14,6 +14,6 @@
   []
   (if (ci-env)
     {:p2p/scheme :https
-     :p2p/host "oort-devnet.admin1337.workers.dev"
+     :p2p/host "d42a-46-6-209-110.eu.ngrok.io"
      :p2p/port  443}
     {}))

--- a/src/test/com/kubelt/rpc/test_commons.cljs
+++ b/src/test/com/kubelt/rpc/test_commons.cljs
@@ -1,0 +1,19 @@
+(ns com.kubelt.rpc.test-commons
+  (:require [com.kubelt.lib.util :as lib.util :refer [node-env]]))
+
+(def app-name "com.kubelt.ddt.js")
+(def wallet-name "auth_test")
+(def wallet-password "auth_foo_pw")
+
+(defn ci-env
+  []
+  (some? (get-in (node-env) [:environment "GITHUB_ACTIONS"])))
+
+(defn p2p-config
+  "return p2p config based on env"
+  []
+  (if (ci-env)
+    {:p2p/scheme :https
+     :p2p/host "oort-devnet.admin1337.workers.dev"
+     :p2p/port  443}
+    {}))


### PR DESCRIPTION
# Description

- [x] ddt core 
  - [x] get profile support `node ddt.js rpc core profile get -w default`
  - [x] set profile support `node ddt.js rpc core profile set "{:profile {:profilePicture \"https://avatars.githubusercontent.com/u/731829?s=400&u=637516776d3af751973fa48bb4bbe255742ee337&v=4\"}}" -f true -w default`
- [x] rpc.profile-test
- [x] refactor auth-test logic to be reusable. 
  - [x] Defines fixtures to create/drop wallet
  - [x] Use oort(dev) or local (miniflare) backend based on env config


## Type of change


- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Includes com.kubelt.rpc.profile-test
- [x] Updates com.kubelt.rpc.auth-test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
