### PR TITLE
Fix bug with rpc calls

### DIFF
--- a/src/main/com/kubelt/lib/json.cljc
+++ b/src/main/com/kubelt/lib/json.cljc
@@ -42,6 +42,11 @@
 
 ;; Public
 ;; -----------------------------------------------------------------------------
+(defn edn->json-forjs-str
+  "json parseable from js env (without transit, so eg: no keyword support)"
+  [x]
+  #?(:clj (json/write-value-as-string x)
+     :cljs  (js/JSON.stringify (clj->js x))))
 
 (defn edn->json-str
   "Write edn data as a JSON string."

--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -59,7 +59,7 @@
         ;; Collect parameters from the supplied parameter map, removing
         ;; any nil entries.
         params (filter some? (map #(get params %) all-params))]
-    (lib.json/edn->json-str
+    (lib.json/edn->json-forjs-str
      {:id request-id
       :jsonrpc rpc-version
       :method method-name

--- a/src/test/com/kubelt/rpc/test_commons.cljs
+++ b/src/test/com/kubelt/rpc/test_commons.cljs
@@ -16,6 +16,6 @@
   (if (ci-env)
       {:p2p/scheme :https
        :app/name "kubelt-test"
-       :p2p/host "d42a-46-6-209-110.eu.ngrok.io"
+       :p2p/host "oort-devnet.admin1337.workers.dev"
        :p2p/port  443}
     {}))


### PR DESCRIPTION
# Description

Don't use transit in json generation for rpc calls

Example data generated:
with transit

```
[\"^
\",\"~:id\",\"e12636e0-b6ff-4118-943b-e66450dfc57e\",\"~:jsonrpc\",\"2.0\",\"~:method\",\"kb_get_profile\",\"~:params\",[\"~#list\",[]]]
```

without transit

`{\"id\":\"6f17f4d8-429c-4b70-a842-5d0c7cf3d884\",\"jsonrpc\":\"2.0\",\"method\":\"kb_get_profile\",\"params\":[]}`


## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

[There were already failing tests](https://github.com/kubelt/kubelt/runs/6724824810?check_suite_focus=true#step:8:391) ... with this change we'll have them happy again

