### PR TITLE
chore: update root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24216,7 +24216,7 @@
             "@rdfjs/types": "*",
             "@types/sparqljs": "^3.1.2",
             "fast-deep-equal": "^3.1.3",
-            "minimist": "^1.2.5",
+            "minimist": "^1.2.6",
             "rdf-data-factory": "^1.1.0",
             "rdf-isomorphic": "^1.3.0",
             "rdf-string": "^1.6.0",
@@ -29118,7 +29118,7 @@
       "requires": {
         "acorn-node": "^1.6.1",
         "defined": "^1.0.0",
-        "minimist": "^1.1.1"
+        "minimist": "^1.2.6"
       }
     },
     "dezalgo": {
@@ -30378,7 +30378,7 @@
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
@@ -30427,7 +30427,7 @@
       "version": "4.7.7",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
@@ -35573,7 +35573,7 @@
       "version": "2.5.5",
       "requires": {
         "fast-deep-equal": "^3.1.3",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "rdf-data-factory": "^1.0.4",
         "rdf-isomorphic": "^1.2.0",
         "rdf-string": "^1.5.0",
@@ -35841,7 +35841,7 @@
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.6",
         "through": "^2.3.4"
       }
     },


### PR DESCRIPTION
# Description

I noticed that after recent changes to dependencies, the `package-lock.json` file wasn't up to date. Ran `npm i` to freshen it.