### PR TITLE
chore(sdk): Update groupId for Maven to publish to Clojars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kubelt/sdk "0.0.1"
+(defproject com.kubelt/sdk "0.0.2"
   :description "Kubelt SDK"
   :url "https://kubelt.com/"
 


### PR DESCRIPTION
# Description

Clojars only supports groupId's with specific formats. In our case, we have `com.kubelt`.

See: https://github.com/clojars/administration/issues/260

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Pushed successfully to Clojars - https://clojars.org/com.kubelt/sdk

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
