### PR TITLE
chore(sdk): use deps.edn to define shadow-cljs dependencies

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -32,15 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run build:ddt:develop
 
   build-kbt:
@@ -49,15 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run build:kbt:develop
 
   build-sdk:
@@ -66,15 +68,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run build:sdk:develop
 
   build-sdk-web:
@@ -83,15 +86,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run build:sdk-web:develop
 
   test-sdk-cljs:
@@ -100,17 +104,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y libsystemd-dev
+      #- run: sudo apt-get update
+      #- run: sudo apt-get install -y libsystemd-dev
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run test:sdk:cljs:develop
 
   test-sdk-js:
@@ -119,17 +124,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y libsystemd-dev
+      #- run: sudo apt-get update
+      #- run: sudo apt-get install -y libsystemd-dev
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       - run: npm run test:sdk:js:develop
 
   test-web:
@@ -140,17 +146,18 @@ jobs:
       CHROME_BIN: /snap/bin/chromium
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: sudo apt-get update
-      - run: sudo apt-get install -y libsystemd-dev chromium-browser
+      - run: sudo apt-get install -y chromium-browser
       - run: npm install
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
         # Run the CI version of the web tests using headless Chrome.
       - run: npm run test:web:ci
 
@@ -183,15 +190,16 @@ jobs:
           - 8787:8787
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.8
       # TODO: Enable once JSON RPC work is ready
       # Compile and run dapp
       - run: npm run build:dapp:release

--- a/.github/workflows/ref-docs.yaml
+++ b/.github/workflows/ref-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           java-version: '17'
       - uses: DeLaGuardo/setup-clojure@5.1
         with:
-          cli: 1.11.0.1113
+          cli: 1.11.1.1113
           #lein: latest
           #boot: latest
           #bb: latest

--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,29 @@
 ;; deps.edn
-{:paths ["src/main"]
+{:paths ["src/dev"
+         "src/main"
+         "src/test"
+         "dapp/src"
+         "dapp/test"]
 
  :deps
  {;; a Clojure/Script library for word case conversions
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
   ;; Implementations of common encoders and decoders
   commons-codec/commons-codec {:mvn/version "1.15"}
+  ;; errors as simple, actionable, generic information
+  com.cognitect/anomalies {:mvn/version "0.1.12"}
   ;; A data format and set of libraries for conveying values
   com.cognitect/transit-clj {:mvn/version "1.0.329"}
+  ;; A data format for conveying values between applications
+  com.cognitect/transit-cljs {:mvn/version "0.8.269"}
   ;; Navigator-based query and transformation of Clojure data
   com.rpl/specter {:mvn/version "1.1.4"}
   ;; Pure Clojure/Script logging library
   com.taoensso/timbre {:mvn/version "5.2.1"}
+  ;; fast, idiomatic pretty-printer
+  fipp/fipp {:mvn/version "0.6.26"}
+  ;; Promise library for Clojure(Script)
+  funcool/promesa {:mvn/version "8.0.450"}
   ;; An http client for Clojure wrapping jdk 11's HttpClient
   hato/hato {:mvn/version "0.8.2"}
   ;; Micro-framework for data-driven architecture
@@ -26,6 +38,8 @@
   org.bouncycastle/bcprov-jdk15on {:mvn/version "1.70"}
   ;; Facilities for async programming and communication in Clojure
   org.clojure/core.async {:mvn/version "1.5.648"}
+  ;; tools for working with command line arguments
+  org.clojure/tools.cli {:mvn/version "1.0.206"}
   ;; Crypto library for tx signing and key/wallet management in Ethereum
   ;; cf. https://docs.web3j.io/4.8.7/advanced/web3j_core_modules/
   org.web3j/crypto {:mvn/version "5.0.0"}
@@ -46,6 +60,29 @@
  {:dev {:extra-paths ["src/dev"]
         :extra-deps {fipp/fipp {:mvn/version "0.6.26"}}}
   :robert {:extra-deps {}}
+
+  :cljs {:extra-deps {;; ClojureScript compilation made easy
+                      thheller/shadow-cljs {:mvn/version "2.19.2"}}}
+
+  :dapp {:extra-deps {;; Chrome DevTools enhancements for CLJS developers
+                      binaryage/devtools {:mvn/version "1.0.6"}
+                      ;; Reagent wrappers for @headlessui/react components
+                      com.github.mainej/headlessui-reagent {:mvn/version "1.6.4.68"}
+                      ;; A fast data-driven router for Clojure/Script
+                      metosin/reitit {:mvn/version "0.5.18"}
+                      ;; Minimalistic React for ClojureScript
+                      reagent/reagent {:mvn/version "1.1.1"}
+                      ;; A CLJS framework for building UIs leveraging React
+                      re-frame/re-frame {:mvn/version "1.2.0"}
+
+                      ;; TODO use deps below for ^:dev
+
+                      ;; inspection tool for re-frame events & app-db
+                      day8.re-frame/re-frame-10x {:mvn/version "1.3.0"}
+                      ;; testing for re-frame events & subs
+                      day8.re-frame/test {:mvn/version "0.1.5"}
+                      ;; tracing for re-frame events
+                      day8.re-frame/tracing {:mvn/version "0.6.2"}}}
 
   ;; Generate literate docs from the source code using sidenote (a fork
   ;; of marginalia).

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,63 +1,20 @@
 ;; sdk/shadow-cljs.edn
 
-{:source-paths
- ["src/dev"
-  "src/main"
-  "src/test"
-  "dapp/src"
-  "dapp/test"]
-
- ;; dapp dev configs
+{;; dapp dev configs
  :nrepl {:port 8777}
 
+ ;; Use the dependencies provided in deps.edn. The listed :aliases are
+ ;; activated when collecting dependencies which fact we use to specify
+ ;; CLJS-specific deps under the :cljs alias.
+ ;;
+ ;; NB: :source-paths must be provided in deps.edn when using that file
+ ;; to specify dependencies. If specified here they will be ignored.
+ ;;
  ;; NB: we depend on the shadow-cljs provided version of core.async;
  ;; adding an explicit dependency on same causes a warning to be
  ;; generated and the pinned version support by shadow-cljs to replace
  ;; it in any case.
-
- :dependencies
- [;; needed for dapp
-  [binaryage/devtools "1.0.6"]
-  ;; a Clojure/Script library for word case conversions
-  [camel-snake-kebab/camel-snake-kebab "0.4.3"]
-  ;; errors as simple, actionable, generic information
-  [com.cognitect/anomalies "0.1.12"]
-  ;; data format for conveying values between applications
-  [com.cognitect/transit-cljs "0.8.269"]
-  ;; Navigator-based query and transformation of Clojure data
-  [com.rpl/specter "1.1.4"]
-  ;; a pure Clojure/Script logging library
-  [com.taoensso/timbre "5.2.1"]
-  ;; tailwind components for dapp
-  [com.github.mainej/headlessui-reagent "1.6.4.68"]
-  ;; immutable database and Datalog query engine
-  [datascript/datascript "1.3.13"]
-  ;; inspection tool for re-frame events & app-db
-  ^:dev [day8.re-frame/re-frame-10x "1.3.0"]
-  ;; testing for re-frame events & subs
-  ^:dev [day8.re-frame/test "0.1.5"]
-  ;; tracing for re-frame events
-  ^:dev [day8.re-frame/tracing "0.6.2"]
-  ;; fast, idiomatic pretty-printer
-  [fipp/fipp "0.6.26"]
-  ;; Promise library for Clojure(Script)
-  [funcool/promesa "8.0.450"]
-  ;; a micro-framework for building data-driven applications
-  [integrant/integrant "0.8.0"]
-  ;; Time as a Clojure/Script value
-  [tick/tick "0.4.32"]
-  ;; fast JSON encoding and decoding
-  [metosin/jsonista "0.3.6"]
-  ;; data-driven schemas for Clojure/Script
-  [metosin/malli "0.8.4"]
-  ;; request router for dapp
-  [metosin/reitit "0.5.18"]
-  ;; tools for working with command line arguments
-  [org.clojure/tools.cli "1.0.206"]
-  ;; react for clojure
-  [reagent "1.1.1"]
-  ;; redux for reagent
-  [re-frame "1.2.0"]]
+ :deps {:aliases [:cljs :dapp]}
 
  ;;:nrepl {:init-ns user.shared}
 

--- a/src/main/com/kubelt/kbt.cljs
+++ b/src/main/com/kubelt/kbt.cljs
@@ -4,8 +4,7 @@
   (:require
    ["yargs" :as yargs :refer [Yargs]])
   (:require
-   [clojure.set :as cset]
-   [clojure.string :as str])
+   [clojure.set :as cset])
   (:require
    [com.kubelt.kbt.cmds :as kbt.cmds]))
 


### PR DESCRIPTION
# Description

Extract dependencies from `shadow-cljs.edn` and migrate them into `deps.edn`. This helps us to avoid overlapping sets of dependencies and possible discrepancies.

## Type of change

- [x] Clean-up and refactoring

## Changes

- update GHA `develop` workflow:
  - [x] no longer install `libsystemd-dev` during build 
  - [x] update installed version of `babashka` to `0.8.156` (matches with min version in `bb.edn` files) 
  - [x] install Clojure and babashka using single action
    - removes `turtlequeue/setup-babashka@v1.3.0` which only provides `babashka`
  - [x] fix installed Clojure version (unsupported version was in use causing exception)