### PR TITLE
chore(gha): update CLI to 1.11.0.1113 in ref-docs flow

### DIFF
--- a/.github/workflows/ref-docs.yaml
+++ b/.github/workflows/ref-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           java-version: '17'
       - uses: DeLaGuardo/setup-clojure@5.1
         with:
-          cli: 1.11.0.1100
+          cli: 1.11.0.1113
           #lein: latest
           #boot: latest
           #bb: latest


### PR DESCRIPTION
# Description

Update to the latest version of Clojure CLI in `ref-docs` flow.

## Type of change

- [x] Clean-up and refactoring