### PR TITLE
fix(sdk): improve JS handling of SDK init options

### DIFF
--- a/packages/sdk-js/__tests__/api-v1.js
+++ b/packages/sdk-js/__tests__/api-v1.js
@@ -54,7 +54,13 @@ tap.test('SDK v1 has expected API', (t) => {
     check(kbt, ['v1'], 'init');
     check(kbt, ['v1'], 'halt');
     check(kbt, ['v1'], 'options');
+
+    check(kbt, ['v1'], 'store');
+    check(kbt, ['v1'], 'restore');
+
     check(kbt, ['v1', 'core'], 'authenticate');
+    check(kbt, ['v1', 'core'], 'isLoggedIn');
+    check(kbt, ['v1', 'core'], 'setWallet');
 
     t.end();
 });
@@ -95,6 +101,57 @@ tap.test('sdk init', (t) => {
     tap.test('with valid config', (t) => {
         return kbt.v1.init({
             "log/level": "info",
+        }).then((sdk) => {
+            t.type(sdk, 'object');
+            return kbt.v1.halt(sdk);
+        }).then(() => {
+            t.pass('ok');
+        });
+    });
+
+    tap.test('with app name config', (t) => {
+        return kbt.v1.init({
+            "app/name": "foobar",
+        }).then((sdk) => {
+            t.type(sdk, 'object');
+            return kbt.v1.halt(sdk);
+        }).then(() => {
+            t.pass('ok');
+        });
+    });
+
+    tap.test('with empty credential config', (t) => {
+        return kbt.v1.init({
+            "credential/jwt": {},
+        }).then((sdk) => {
+            t.type(sdk, 'object');
+            return kbt.v1.halt(sdk);
+        }).then(() => {
+            t.pass('ok');
+        });
+    });
+
+    tap.test('with p2p config', (t) => {
+        return kbt.v1.init({
+            "p2p/scheme": "http",
+            "p2p/host": "127.0.0.1",
+            "p2p/port": 5001,
+        }).then((sdk) => {
+            t.type(sdk, 'object');
+            return kbt.v1.halt(sdk);
+        }).then(() => {
+            t.pass('ok');
+        });
+    });
+
+    tap.test('with ipfs config', (t) => {
+        return kbt.v1.init({
+            "ipfs.read/scheme": "http",
+            "ipfs.read/host": "127.0.0.1",
+            "ipfs.read/port": 5001,
+            "ipfs.write/scheme": "http",
+            "ipfs.write/host": "127.0.0.1",
+            "ipfs.write/port": 5001,
         }).then((sdk) => {
             t.type(sdk, 'object');
             return kbt.v1.halt(sdk);

--- a/src/main/com/kubelt/lib/config.cljs
+++ b/src/main/com/kubelt/lib/config.cljs
@@ -2,29 +2,26 @@
   "Configuration-related support."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [clojure.string :as str]))
+   [com.kubelt.lib.config.default :as lib.config.default]
+   [com.kubelt.lib.config.util :as lib.config.util]))
 
-;; Internal
-;; -----------------------------------------------------------------------------
-
-(defn- log-level->keyword
-  "Convert a log level string (e.g. 'info', ':info') to a keyword."
-  [s]
-  (if (string? s)
-    (keyword (str/replace s #"^:" ""))
-    log-level))
-
-;; Public
+;; obj->map
 ;; -----------------------------------------------------------------------------
 
 (defn obj->map
-  "Convert a JavaScript configuration object to a Clojure config map."
+  "Convert a JavaScript object containing SDK initialization options to a
+  Clojure config map containing the same configuration options but
+  updated to conform to the schema that defines what is allowed as an
+  option to the SDK (init) call. Any configuration options that aren't
+  provided are set to their default values in the returned map."
   [o]
   {:pre [(object? o)]}
-  (let [config (js->clj o :keywordize-keys true)]
-    (if (empty? config)
-      default-config
-      ;; Fix up any config map values that didn't translate from
-      ;; JavaScript.
-      (-> config
-          (update-in [:log/level] log-level->keyword)))))
+  (let [config  (js->clj o :keywordize-keys true)
+        config  (merge lib.config.default/sdk config)]
+    ;; Fix up any config map values that didn't translate from
+    ;; JavaScript.
+    (-> config
+        (update-in [:log/level] lib.config.util/str->kw)
+        (update-in [:p2p/scheme] lib.config.util/str->kw)
+        (update-in [:ipfs.read/scheme] lib.config.util/str->kw)
+        (update-in [:ipfs.write/scheme] lib.config.util/str->kw))))

--- a/src/main/com/kubelt/lib/config/util.cljc
+++ b/src/main/com/kubelt/lib/config/util.cljc
@@ -6,28 +6,12 @@
   (:require
    [com.kubelt.lib.config.default :as lib.config.default]))
 
-;; Internal
+;; str->kw
 ;; -----------------------------------------------------------------------------
 
-(defn log-level->keyword
+(defn str->kw
   "Convert a log level string (e.g. 'info', ':info') to a keyword."
   [log-level]
   (if (string? log-level)
-    (keyword (cstr/replace log-level #"^:" ""))
+    (keyword (-> log-level (cstr/trim) (cstr/replace #"^:" "")))
     log-level))
-
-;; Public
-;; -----------------------------------------------------------------------------
-
-#?(:cljs
-   (defn obj->map
-     "Convert a JavaScript configuration object to a Clojure config map."
-     [o]
-     {:pre [(object? o)]}
-     (let [config  (js->clj o :keywordize-keys true)]
-       (if (empty? config)
-         lib.config.default/sdk
-         ;; Fix up any config map values that didn't translate from
-         ;; JavaScript.
-         (-> config
-             (update-in [:log/level] log-level->keyword))))))

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -5,10 +5,10 @@
    [malli.core :as m]
    [malli.error :as me])
   (:require
+   [com.kubelt.lib.config :as lib.config]
    [com.kubelt.lib.config.default :as lib.config.default]
    [com.kubelt.lib.config.sdk :as lib.config.sdk]
    [com.kubelt.lib.config.system :as lib.config.system]
-   [com.kubelt.lib.config.util :as lib.config.util]
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.init :as lib.init]
    [com.kubelt.lib.promise :as lib.promise :refer [promise?]]
@@ -65,13 +65,13 @@
   ;; The 1-arity implementation uses expects a configuration object.
   ([config]
    {:pre [(object? config)] :post [(promise? %)]}
-   (let [config (lib.config.util/obj->map config)]
+   (let [config (lib.config/obj->map config)]
      (-> (init config)
          ;; If an error occurred, convert the returned error map into an
          ;; JavaScript object.
          (lib.promise/catch
           (fn [e]
-            (clj->js e)))))))
+            (lib.promise/rejected (clj->js e))))))))
 
 ;; halt
 ;; -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Adds some JavaScript tests of SDK initialization where we supply various subsets of configuration options, e.g. connection details for p2p, IPFS read and write nodes, etc. Fixes an issue in the conversion of the JS configuration object into a CLJ(S) configuration map so that the results conform to our schema. Specifically, some configuration values provided in JavaScript (e.g. `{"ipfs.read/scheme": "http"}`) require that the value be converted to a keyword to conform to our config schema.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)