### PR TITLE
fix(gha): update next and release workflows

### DIFF
--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -20,17 +20,16 @@ jobs:
           - 8787:8787
     steps:
       - uses: actions/checkout@master
-      - name: Source Builds
-        uses: actions/setup-node@v3
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - name: Setup & Run Build
-        uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.4
       - run: npm install cypress --save-dev
       - run: npm run test:all:release
       # TODO: Do we want to replease a @kubelt/package@prerelease to github registry or npm?

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,10 @@ jobs:
           - 8787:8787
     steps:
       - uses: actions/checkout@master
+      - uses: DeLaGuardo/setup-clojure@5.1
+        with:
+          bb: 0.8.156
+          cli: 1.11.1.1113
       - name: Build & Test
         uses: actions/setup-node@v3
         with:
@@ -27,10 +31,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - name: Setup & Run Build
-        uses: turtlequeue/setup-babashka@v1.3.0
-        with:
-          babashka-version: 0.7.4
       - run: npm install cypress --save-dev
       - run: npm run test:all:release
       - name: Get tag


### PR DESCRIPTION
# Description

Updates the `next` and `release` workflows to install Clojure and babashka using a single action. Clojure is now required as it is used in the invocation of `shadow-cljs` (now that we keep our dependencies in `deps.edn`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)