### PR TITLE
chore(gha): specify node version as lts/gallium

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -38,7 +38,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
@@ -56,7 +56,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
@@ -74,7 +74,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
@@ -92,7 +92,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm install
@@ -110,7 +110,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       #- run: sudo apt-get update
@@ -130,7 +130,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       #- run: sudo apt-get update
@@ -152,7 +152,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: sudo apt-get update
@@ -165,15 +165,16 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@master
+  #     - uses: DeLaGuardo/setup-clojure@5.1
+  #       with:
+  #         bb: 0.8.156
+  #         cli: 1.11.1.1113
   #     - uses: actions/setup-node@v3
   #       with:
-  #         node-version: '16'
+  #         node-version: lts/gallium
   #         cache: 'npm'
   #         cache-dependency-path: package-lock.json
   #     - run: npm install
-  #     - uses: turtlequeue/setup-babashka@v1.3.0
-  #       with:
-  #         babashka-version: 0.7.8
   #     - run: npm run test:sdk-web:develop
 
   test-dapp:
@@ -196,7 +197,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci

--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -26,7 +26,7 @@ jobs:
           cli: 1.11.1.1113
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Build & Test
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: lts/gallium
           cache: 'npm'
           cache-dependency-path: package-lock.json
       - run: npm ci


### PR DESCRIPTION
# Description

Improve readability of pipeline configuration by using a node `lts/*` version specifier instead of `'16'` to indicate the version of node that we rely on.

## Type of change

- [x] Clean-up and refactoring