### PR TITLE
chore(gha): update build pipelines and tooling

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -94,7 +94,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -157,7 +157,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -177,7 +177,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -198,7 +198,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -217,7 +217,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -237,7 +237,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium
@@ -256,7 +256,7 @@ jobs:
   #     - uses: DeLaGuardo/setup-clojure@6.0
   #       with:
   #         bb: 0.8.156
-  #         cli: 1.11.1.1119
+  #         cli: 1.11.1.1129
   #     - uses: actions/setup-node@v3
   #       with:
   #         node-version: lts/gallium
@@ -282,7 +282,7 @@ jobs:
       - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1119
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium

--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -20,10 +20,10 @@ jobs:
           - 8787:8787
     steps:
       - uses: actions/checkout@master
-      - uses: DeLaGuardo/setup-clojure@5.1
+      - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1113
+          cli: 1.11.1.1129
       - uses: actions/setup-node@v3
         with:
           node-version: lts/gallium

--- a/.github/workflows/ref-docs.yaml
+++ b/.github/workflows/ref-docs.yaml
@@ -33,9 +33,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - uses: DeLaGuardo/setup-clojure@5.1
+      - uses: DeLaGuardo/setup-clojure@6.0
         with:
-          cli: 1.11.1.1113
+          cli: 1.11.1.1129
           #lein: latest
           #boot: latest
           #bb: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
           - 8787:8787
     steps:
       - uses: actions/checkout@master
-      - uses: DeLaGuardo/setup-clojure@5.1
+      - uses: DeLaGuardo/setup-clojure@6.0
         with:
           bb: 0.8.156
-          cli: 1.11.1.1113
+          cli: 1.11.1.1129
       - name: Build & Test
         uses: actions/setup-node@v3
         with:

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-;; deps.edn
+; deps.edn
 {:paths ["src/dev"
          "src/main"
          "src/test"
@@ -62,7 +62,7 @@
   :robert {:extra-deps {}}
 
   :cljs {:extra-deps {;; ClojureScript compilation made easy
-                      thheller/shadow-cljs {:mvn/version "2.19.2"}}}
+                      thheller/shadow-cljs {:mvn/version "2.19.3"}}}
 
   :dapp {:extra-deps {;; Chrome DevTools enhancements for CLJS developers
                       binaryage/devtools {:mvn/version "1.0.6"}


### PR DESCRIPTION
# Description

Update remaining build pipelines to newer version of `setup-clojure` action, update Clojure to `1.11.1.1129`, and update `shadow-cljs` to `2.19.3`.