### PR TITLE
RPC client adaptations and qn_fetchNFTs test

### DIFF
--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -59,7 +59,8 @@
         all-params (get method :method.params/all)
         ;; Collect parameters from the supplied parameter map, removing
         ;; any nil entries.
-        params (filter some? (map #(get params %) all-params))]
+        params (cond-> (filter some? (map #(get params %) all-params))
+                 (= "object" (-> method :method/params :params :schema :type)) first)]
     (lib.json/edn->json-forjs-str
      {:id request-id
       :jsonrpc rpc-version

--- a/src/main/com/kubelt/rpc/request.cljc
+++ b/src/main/com/kubelt/rpc/request.cljc
@@ -36,12 +36,13 @@
      :uri/port port
      :uri/path path}))
 
+(def uuid-at (atom 0))
 ;; TODO use an integer stored in client for incrementing counter?
 ;; Or perhaps a ULID / SQUUID to show calling sequence?
 (defn- make-request-id
   "Return a unique request identifier."
   []
-  (lib.uuid/random))
+  (swap! uuid-at inc))
 
 (defn- make-body
   [path method params]

--- a/src/test/com/kubelt/rpc/nfts_test.cljs
+++ b/src/test/com/kubelt/rpc/nfts_test.cljs
@@ -1,0 +1,57 @@
+(ns com.kubelt.rpc.nfts-test
+  (:require
+   [cljs.core.async :refer [go <!]]
+   [cljs.core.async.interop :refer-macros [<p!]]
+   [cljs.test :refer-macros [deftest is testing async use-fixtures] :as t])
+  (:require
+   [taoensso.timbre :as log])
+  (:require
+   [com.kubelt.lib.rpc :as lib.rpc]
+   [com.kubelt.lib.test-utils :as lib.test-utils]
+   [com.kubelt.lib.wallet.node :as wallet]
+   [com.kubelt.rpc.test-commons :as t.commons]
+   [com.kubelt.sdk.v1 :as sdk]
+   [com.kubelt.sdk.v1.oort :as sdk.oort]))
+
+(use-fixtures :once
+  {:before  (lib.test-utils/create-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)
+   :after (lib.test-utils/delete-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)})
+
+(deftest rpc-nfts-test
+  (testing "rpc core fetch nfts ... so far jwt not related with wallet(nfts owner) param"
+    (async done
+           (go
+             (try
+               (let [config (t.commons/oort-config)
+                     sys (<p! (sdk/init config))
+                     wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
+                     core (:wallet/address wallet)
+                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet)))
+                     api (-> (<p! (sdk.oort/rpc-api sys core))
+                             (update :methods conj (<! (lib.test-utils/read-local-edn&go "oort/methods/qn-fetch-nfts.edn"))))
+                     nfts (<p! (lib.rpc/rpc-call& kbt api
+                                                  {:method  [:qn :fetch-nf-ts]
+                                                   :params {:params {:wallet "0x505D79c7379EE65B6c2D6D18a0e7aB901b00756C"
+                                                                     :omitFields ["provenance" "traits"]
+                                                                     :perPage 1
+                                                                     :page 1}}}))]
+                 (is (= {:owner "0x505D79c7379EE65B6c2D6D18a0e7aB901b00756C",
+                         :assets
+                         [{:description "CryptoPunksMarket",
+                           :image-url
+                           "https://www.larvalabs.com/cryptopunks/cryptopunk1.png",
+                           :collection-address "0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB",
+                           :name "CryptoPunksMarket #1",
+                           :collection-token-id "1",
+                           :current-owner "0x1919DB36cA2fa2e15F9000fd9CdC2EdCF863E685",
+                           :chain "ETH",
+                           :collection-name "CryptoPunksMarket",
+                           :network "mainnet"}]} nfts)))
+               (catch js/Error err (do
+                                     (log/error err)
+                                     (is false err)))
+               (finally (done)))))))
+
+(comment
+  (t/run-tests)
+  )


### PR DESCRIPTION
# Description
There are rpc calls that needs an object instead of an array as params. This PR adds support to derive this type of params based on rpc method spec

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] [com.kubelt.rpc.nfts-test](https://github.com/kubelt/kubelt/blob/rpc-adaptations/src/test/com/kubelt/rpc/nfts_test.cljs)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation website
- [X] I have made corresponding changes to the literal docs
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
