### PR TITLE
v1/options and v1/restore fixes

### DIFF
--- a/dapp/test/dapp/sdk_test.cljs
+++ b/dapp/test/dapp/sdk_test.cljs
@@ -14,7 +14,8 @@
            (go
              (try
                (let [app-name "kubelt-dapp"
-                     sdk      (<p! (sdk.v1/init {:app/name app-name}))]
+                     sdk      (<p! (sdk.v1/init {:app/name app-name}))
+                     vault {:com.kubelt/type :kubelt.type/vault, :vault/tokens {}}]
                  (is (some? sdk))
                  (let [data (-> (<p! (sdk.v1/store&  sdk))
                                 :data
@@ -32,10 +33,11 @@
                             :ipfs.write/scheme :http,
                             :ipfs.write/host   "127.0.0.1",
                             :ipfs.write/port   5001,
-                            :log/level         :warn,},
-                           :vault {:com.kubelt/type :kubelt.type/vault, :vault/tokens {}}})))
+                            :log/level         :warn},
+                           :vault vault})))
                  (let [data (<p! (sdk.v1/restore& sdk))]
                    (is (= app-name (:app/name data)))
+                   (is (= vault (:crypto/session data)))
                    (is (= #{:app/name
                             :client/http
                             :client/oort

--- a/src/main/com/kubelt/lib/storage/browser.cljs
+++ b/src/main/com/kubelt/lib/storage/browser.cljs
@@ -2,8 +2,8 @@
   "Support for HTTP requests from a browser execution context."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.lib.promise :as lib.promise]
-   [com.kubelt.lib.json :as lib.json]))
+   [com.kubelt.lib.json :as lib.json]
+   [com.kubelt.lib.promise :as lib.promise]))
 
 (defn- get-storage
   []
@@ -48,7 +48,7 @@
    (fn [resolve _]
      (let [data (-> (get-item DB_ID_KEY)
                     (lib.json/json-str->edn))]
-       (resolve {:data data})))))
+       (resolve data)))))
 
 (defn create
   "Create a configuration storage capability."

--- a/src/main/com/kubelt/lib/storage/node.cljs
+++ b/src/main/com/kubelt/lib/storage/node.cljs
@@ -55,7 +55,7 @@
             (lib.promise/then
              (fn [data-str]
                (let [data (t/read r data-str)]
-                 {:data data}))))))))
+                 data))))))))
 
 (defn- make-path
   "Return the path to the file where state is stored."

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -182,9 +182,9 @@
         restore& (restore-fn)]
     (-> restore&
         (lib.promise/then
-         (fn [{:keys [data]}]
+         (fn [{:keys [options vault]}]
            ;; TODO fold options back into system map?
-           (assoc system :crypto/session (:vault data)))))))
+           (assoc system :crypto/session vault))))))
 
 (defn restore-js&
   "Return a system map that has had saved state restored."

--- a/src/main/com/kubelt/sdk/v1.cljs
+++ b/src/main/com/kubelt/sdk/v1.cljs
@@ -182,9 +182,9 @@
         restore& (restore-fn)]
     (-> restore&
         (lib.promise/then
-         (fn [{:keys [options vault]}]
+         (fn [{:keys [data]}]
            ;; TODO fold options back into system map?
-           (assoc system :crypto/session vault))))))
+           (assoc system :crypto/session (:vault data)))))))
 
 (defn restore-js&
   "Return a system map that has had saved state restored."

--- a/src/main/com/kubelt/sdk/v1/oort.cljs
+++ b/src/main/com/kubelt/sdk/v1/oort.cljs
@@ -6,6 +6,8 @@
    [com.kubelt.lib.http.status :as http.status]
    [com.kubelt.lib.jwt :as lib.jwt]
    [com.kubelt.lib.oort :as lib.oort]
+   [com.kubelt.lib.vault :as lib.vault]
+   [clojure.set :refer [rename-keys]]
    [com.kubelt.lib.promise :as lib.promise :refer [promise]]
    [com.kubelt.lib.wallet :as lib.wallet]))
 
@@ -73,8 +75,9 @@
                      ;; subset, e.g. tokens) to be frozen and thawed
                      ;; back out
                      (-> sys
-                         (assoc-in [:crypto/session :vault/tokens core] decoded-jwt)
-                         (assoc-in [:crypto/session :vault/tokens* core] verify-result)))))))))))))
+                         (assoc-in [:crypto/session] (lib.vault/vault {core decoded-jwt}))
+                         (assoc-in [:crypto/session] (-> (lib.vault/vault {core verify-result})
+                                                         (rename-keys {:vault/tokens :vault/tokens*})))))))))))))))
 
 (defn authenticate-js!
   "Create an account from a JavaScript context."

--- a/src/main/com/kubelt/sdk/v1/oort.cljs
+++ b/src/main/com/kubelt/sdk/v1/oort.cljs
@@ -7,7 +7,6 @@
    [com.kubelt.lib.jwt :as lib.jwt]
    [com.kubelt.lib.oort :as lib.oort]
    [com.kubelt.lib.vault :as lib.vault]
-   [clojure.set :refer [rename-keys]]
    [com.kubelt.lib.promise :as lib.promise :refer [promise]]
    [com.kubelt.lib.wallet :as lib.wallet]))
 
@@ -75,9 +74,8 @@
                      ;; subset, e.g. tokens) to be frozen and thawed
                      ;; back out
                      (-> sys
-                         (assoc-in [:crypto/session] (lib.vault/vault {core decoded-jwt}))
-                         (assoc-in [:crypto/session] (-> (lib.vault/vault {core verify-result})
-                                                         (rename-keys {:vault/tokens :vault/tokens*})))))))))))))))
+                         (assoc :crypto/session (lib.vault/vault {core decoded-jwt}))
+                         (assoc-in [:crypto/session :vault/tokens*]  {core verify-result})))))))))))))
 
 (defn authenticate-js!
   "Create an account from a JavaScript context."

--- a/src/test/com/kubelt/rpc/auth_test.cljs
+++ b/src/test/com/kubelt/rpc/auth_test.cljs
@@ -29,6 +29,7 @@
                      kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet)))]
                  (is (= {} (-> sys :crypto/session :vault/tokens)))
                  (is (map? (get-in kbt [:crypto/session :vault/tokens core])))
+                 (is (= :kubelt.type/vault (get-in kbt [:crypto/session :com.kubelt/type])))
                  (is (string? (get-in kbt [:crypto/session :vault/tokens* core]))))
                (catch js/Error err (do
                                      (log/error err)


### PR DESCRIPTION
# Description

## v1/options fix
In [com.kubelt.lib.config.sdk/options](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/src/main/com/kubelt/lib/config/sdk.cljc#L26) we use [(lib.vault/tokens (:crypto/session sys-map))](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/src/main/com/kubelt/lib/vault.cljc#L25) that expects the map contains a `:com.kubelt/type :kubelt.type/vault`

Changes added to fix the problem here https://github.com/kubelt/kubelt/pull/487/files#diff-3ef5211db2f5c7b23d28d4e1d7594b2e800417447163e2c5bf5cedf12891c592

## v1/restore fix
[browser](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/src/main/com/kubelt/lib/storage/browser.cljs#L40) and [node](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/src/main/com/kubelt/lib/storage/node.cljs#L43) impls wraps the data stored in this structure `{:data xxxx}` 
Related changes added  https://github.com/kubelt/kubelt/pull/487/files#diff-aa427a6991f84956a36cbcea0aeedc65b0ed6dddfb04db7a635894da16dfbc53

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] [com.kubelt.rpc.auth-test](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/src/test/com/kubelt/rpc/auth_test.cljs#L32)
- [X] [dapp.sdk-test](https://github.com/kubelt/kubelt/blob/v1-options-and-restore-fixes/dapp/test/dapp/sdk_test.cljs#L40)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation website
- [X] I have made corresponding changes to the literal docs
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
