### PR TITLE
chore(3iD): remove "site" deployment configuration

### DIFF
--- a/three-id/bb.edn
+++ b/three-id/bb.edn
@@ -35,7 +35,11 @@
     ;; The name of the application to build and deploy.
     (def app-id "three-id")
     ;; The KV namespace ("binding") where files are stored.
-    (def kv-namespace "GATE")
+    (def kv-namespace "APP")
+
+    ;; The public host name that is aliased to our production deployment
+    ;; worker.
+    (def public-host "dapp.threeid.xyz")
 
     ;; Developers
     ;; -------------------------------------------------------------------------
@@ -80,8 +84,8 @@
     (def wrangler-toml (str (fs/path worker-dir "wrangler.toml")))
     ;; Example wrangler config file we use as template.
     (def wrangler-example (str (fs/path worker-dir "wrangler.toml.example")))
-    ;; Compiler-generated build manifest.
-    ;;(def manifest-edn (str (fs/path output-dir "manifest.edn")))
+    ;; Worker asset manifest used to list files in KV store.
+    (def worker-manifest (str (fs/path worker-dir "src" "asset-manifest.json")))
 
     ;; INIT
     ;; -------------------------------------------------------------------------
@@ -312,8 +316,8 @@
 
   -app:common
   (do
-    {:oort-port 8787
-     :oort-schema "http"})
+    {:oort-port 443
+     :oort-schema "https"})
 
   -app:development
   (do
@@ -339,64 +343,46 @@
   ;; -----------------------------------------------------------------------------
 
   -env:admin-account-id (system/env "ADMIN_ACCOUNT_ID")
-  -env:next-kv-gate-id (system/env "NEXT_KV_GATE_ID")
-  -env:next-kv-site-id (system/env "NEXT_KV_SITE_ID")
-  -env:current-kv-gate-id (system/env "CURRENT_KV_GATE_ID")
-  -env:current-kv-site-id (system/env "CURRENT_KV_SITE_ID")
+  -env:next-kv-app-id (system/env "NEXT_KV_APP_ID")
+  -env:current-kv-app-id (system/env "CURRENT_KV_APP_ID")
 
   -env:cosmin-account-id (system/env "COSMIN_ACCOUNT_ID")
-  -env:cosmin-kv-gate-id (system/env "COSMIN_KV_GATE_ID")
-  -env:cosmin-kv-site-id (system/env "COSMIN_KV_SITE_ID")
+  -env:cosmin-kv-app-id (system/env "COSMIN_KV_APP_ID")
   -env:dhruv-account-id (system/env "DHRUV_ACCOUNT_ID")
-  -env:dhruv-kv-gate-id (system/env "DHRUV_KV_GATE_ID")
-  -env:dhruv-kv-site-id (system/env "DHRUV_KV_SITE_ID")
+  -env:dhruv-kv-app-id (system/env "DHRUV_KV_APP_ID")
   -env:juan-account-id (system/env "JUAN_ACCOUNT_ID")
-  -env:juan-kv-gate-id (system/env "JUAN_KV_GATE_ID")
-  -env:juan-kv-site-id (system/env "JUAN_KV_SITE_ID")
+  -env:juan-kv-app-id (system/env "JUAN_KV_APP_ID")
   -env:robert-account-id (system/env "ROBERT_ACCOUNT_ID")
-  -env:robert-kv-gate-id (system/env "ROBERT_KV_GATE_ID")
-  -env:robert-kv-site-id (system/env "ROBERT_KV_SITE_ID")
+  -env:robert-kv-app-id (system/env "ROBERT_KV_APP_ID")
 
   ;; environment
   ;; -----------------------------------------------------------------------------
 
   -env:variables
   {:doc "A map of values read from environment variables"
-   :depends [-env:current-kv-site-id
-             -env:current-kv-gate-id
-             -env:admin-account-id
+   :depends [-env:admin-account-id
              -env:robert-account-id
-             -env:robert-kv-site-id
-             -env:robert-kv-gate-id
+             -env:robert-kv-app-id
              -env:dhruv-account-id
-             -env:dhruv-kv-site-id
-             -env:dhruv-kv-gate-id
+             -env:dhruv-kv-app-id
              -env:juan-account-id
-             -env:juan-kv-site-id
-             -env:juan-kv-gate-id
+             -env:juan-kv-app-id
              -env:cosmin-account-id
-             -env:cosmin-kv-site-id
-             -env:cosmin-kv-gate-id
-             -env:next-kv-site-id
-             -env:next-kv-gate-id]
+             -env:cosmin-kv-app-id
+             -env:next-kv-app-id
+             -env:current-kv-app-id]
    :task (do
            {:robert/account-id -env:robert-account-id
-            :robert/kv-site-id -env:robert-kv-site-id
-            :robert/kv-gate-id -env:robert-kv-gate-id
+            :robert/kv-app-id -env:robert-kv-app-id
             :juan/account-id -env:juan-account-id
-            :juan/kv-site-id -env:juan-kv-site-id
-            :juan/kv-gate-id -env:juan-kv-gate-id
+            :juan/kv-app-id -env:juan-kv-app-id
             :cosmin/account-id -env:cosmin-account-id
-            :cosmin/kv-site-id -env:cosmin-kv-site-id
-            :cosmin/kv-gate-id -env:cosmin-kv-gate-id
+            :cosmin/kv-app-id -env:cosmin-kv-app-id
             :dhruv/account-id -env:dhruv-account-id
-            :dhruv/kv-site-id -env:dhruv-kv-site-id
-            :dhruv/kv-gate-id -env:dhruv-kv-gate-id
+            :dhruv/kv-app-id -env:dhruv-kv-app-id
             :admin/account-id -env:admin-account-id
-            :next/kv-site-id -env:next-kv-site-id
-            :next/kv-gate-id -env:next-kv-gate-id
-            :current/kv-site-id -env:current-kv-site-id
-            :current/kv-gate-id -env:current-kv-gate-id})}
+            :next/kv-app-id -env:next-kv-app-id
+            :current/kv-app-id -env:current-kv-app-id})}
 
   -deploy:edn
   {:doc "A map of values read from deployment configuration file"
@@ -479,33 +465,21 @@
    :task (let [secret (:admin/account-id -env:merged)]
            (github.secret/set "ADMIN_ACCOUNT_ID" secret))}
 
-  -gh:secret:next-kv-gate-id
+  -gh:secret:next-kv-app-id
   {:depends [-env:merged]
-   :task (let [secret (:next/kv-gate-id -env:merged)]
-           (github.secret/set "NEXT_KV_GATE_ID" secret))}
+   :task (let [secret (:next/kv-app-id -env:merged)]
+           (github.secret/set "NEXT_KV_APP_ID" secret))}
 
-  -gh:secret:next-kv-site-id
+  -gh:secret:current-kv-app-id
   {:depends [-env:merged]
-   :task (let [secret (:next/kv-site-id -env:merged)]
-           (github.secret/set "NEXT_KV_SITE_ID" secret))}
-
-  -gh:secret:current-kv-gate-id
-  {:depends [-env:merged]
-   :task (let [secret (:current/kv-gate-id -env:merged)]
-           (github.secret/set "CURRENT_KV_GATE_ID" secret))}
-
-  -gh:secret:current-kv-site-id
-  {:depends [-env:merged]
-   :task (let [secret (:current/kv-site-id -env:merged)]
-           (github.secret/set "CURRENT_KV_SITE_ID" secret))}
+   :task (let [secret (:current/kv-app-id -env:merged)]
+           (github.secret/set "CURRENT_KV_APP_ID" secret))}
 
   gh:secret:init
   {:doc "Set up secrets in GitHub Actions"
    :depends [-gh:secret:admin-account-id
-             -gh:secret:next-kv-gate-id
-             -gh:secret:next-kv-site-id
-             -gh:secret:current-kv-gate-id
-             -gh:secret:current-kv-site-id]}
+             -gh:secret:next-kv-app-id
+             -gh:secret:current-kv-app-id]}
 
   ;; compile
   ;; ---------------------------------------------------------------------------
@@ -589,7 +563,7 @@
    :task (let [;; For each file under public-dir, the manifest has an entry:
                ;; {"some/path": "/some/path"}
                manifest-edn (cf.asset/manifest -app:files)
-               out-path (str (fs/path worker-dir "src" "gate-manifest.json"))]
+               out-path worker-manifest]
            (json/generate-stream manifest-edn (clojure.java.io/writer out-path))
            ;; Return the asset manifest content
            manifest-edn)}
@@ -601,7 +575,7 @@
 
   publish:worker
   {:doc "Publish the CloudFlare worker"
-   :depends [-deploy:env asset:manifest install:worker]
+   :depends [-deploy:env wrangler:toml asset:manifest install:worker]
    :task (let [command ["npx" "wrangler" "publish" "--env" -deploy:env]]
            (shell {:dir worker-dir} (cstr/join " " command))
            ;; Sleep for a bit to give the worker time to become
@@ -610,7 +584,7 @@
 
   publish:assets
   {:doc "Publish website assets to CloudFlare KV store"
-   :depends [-app:files -options:cloudflare]
+   :depends [-app:files -options:cloudflare wrangler:toml]
    :task (do
            ;; Remove any values in the KV store.
            (cf.kv/truncate -options:cloudflare)
@@ -628,6 +602,8 @@
            (println message))}
 
   ;; test
+
+  ;; TODO on production deploy, smoke test internal *and* external URL.
 
   ;; The asset manifest is mapping from KV store key to remote
   ;; path. This is a sequence of the paths of every file stored in the

--- a/three-id/package-lock.json
+++ b/three-id/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react": "17.0.21",
         "@types/react-native": "0.66.13",
         "typescript": "4.3.5",
-        "wrangler": "2.0.15"
+        "wrangler": "2.0.16"
       }
     },
     "../kubelt/packages/sdk-web": {
@@ -9868,9 +9868,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-      "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
+      "integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -9880,32 +9880,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.34",
-        "esbuild-android-arm64": "0.14.34",
-        "esbuild-darwin-64": "0.14.34",
-        "esbuild-darwin-arm64": "0.14.34",
-        "esbuild-freebsd-64": "0.14.34",
-        "esbuild-freebsd-arm64": "0.14.34",
-        "esbuild-linux-32": "0.14.34",
-        "esbuild-linux-64": "0.14.34",
-        "esbuild-linux-arm": "0.14.34",
-        "esbuild-linux-arm64": "0.14.34",
-        "esbuild-linux-mips64le": "0.14.34",
-        "esbuild-linux-ppc64le": "0.14.34",
-        "esbuild-linux-riscv64": "0.14.34",
-        "esbuild-linux-s390x": "0.14.34",
-        "esbuild-netbsd-64": "0.14.34",
-        "esbuild-openbsd-64": "0.14.34",
-        "esbuild-sunos-64": "0.14.34",
-        "esbuild-windows-32": "0.14.34",
-        "esbuild-windows-64": "0.14.34",
-        "esbuild-windows-arm64": "0.14.34"
+        "esbuild-android-64": "0.14.47",
+        "esbuild-android-arm64": "0.14.47",
+        "esbuild-darwin-64": "0.14.47",
+        "esbuild-darwin-arm64": "0.14.47",
+        "esbuild-freebsd-64": "0.14.47",
+        "esbuild-freebsd-arm64": "0.14.47",
+        "esbuild-linux-32": "0.14.47",
+        "esbuild-linux-64": "0.14.47",
+        "esbuild-linux-arm": "0.14.47",
+        "esbuild-linux-arm64": "0.14.47",
+        "esbuild-linux-mips64le": "0.14.47",
+        "esbuild-linux-ppc64le": "0.14.47",
+        "esbuild-linux-riscv64": "0.14.47",
+        "esbuild-linux-s390x": "0.14.47",
+        "esbuild-netbsd-64": "0.14.47",
+        "esbuild-openbsd-64": "0.14.47",
+        "esbuild-sunos-64": "0.14.47",
+        "esbuild-windows-32": "0.14.47",
+        "esbuild-windows-64": "0.14.47",
+        "esbuild-windows-arm64": "0.14.47"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-      "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
+      "integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
       "cpu": [
         "x64"
       ],
@@ -9919,9 +9919,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-      "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
+      "integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
       "cpu": [
         "arm64"
       ],
@@ -9935,9 +9935,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-      "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
+      "integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
       "cpu": [
         "x64"
       ],
@@ -9951,9 +9951,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-      "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
+      "integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
       "cpu": [
         "arm64"
       ],
@@ -9967,9 +9967,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-      "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
+      "integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
       "cpu": [
         "x64"
       ],
@@ -9983,9 +9983,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-      "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
+      "integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
       "cpu": [
         "arm64"
       ],
@@ -9999,9 +9999,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-      "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
+      "integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
       "cpu": [
         "ia32"
       ],
@@ -10015,9 +10015,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-      "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
+      "integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
       "cpu": [
         "x64"
       ],
@@ -10031,9 +10031,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-      "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
+      "integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
       "cpu": [
         "arm"
       ],
@@ -10047,9 +10047,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-      "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
+      "integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
       "cpu": [
         "arm64"
       ],
@@ -10063,9 +10063,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-      "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
+      "integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
       "cpu": [
         "mips64el"
       ],
@@ -10079,9 +10079,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-      "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
+      "integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
       "cpu": [
         "ppc64"
       ],
@@ -10095,9 +10095,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-      "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
+      "integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
       "cpu": [
         "riscv64"
       ],
@@ -10111,9 +10111,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-      "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
+      "integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
       "cpu": [
         "s390x"
       ],
@@ -10127,9 +10127,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-      "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
+      "integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
       "cpu": [
         "x64"
       ],
@@ -10143,9 +10143,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-      "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
+      "integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
       "cpu": [
         "x64"
       ],
@@ -10159,9 +10159,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-      "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
+      "integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
       "cpu": [
         "x64"
       ],
@@ -10175,9 +10175,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-      "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
+      "integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
       "cpu": [
         "ia32"
       ],
@@ -10191,9 +10191,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-      "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
+      "integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
       "cpu": [
         "x64"
       ],
@@ -10207,9 +10207,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-      "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
+      "integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
       "cpu": [
         "arm64"
       ],
@@ -23203,16 +23203,16 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.15.tgz",
-      "integrity": "sha512-iBigg/qR1U74wJSR81njVNG69h/tcAGxXoBS1iKeLu1WIhTR/jfBbZdXWcspgkFaex4J6roJnhbFNy7Ob7caUA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.16.tgz",
+      "integrity": "sha512-Fx3DCbQcYpnmUfRvCt4e7nxT0s6WVtIgjdBljvqOX6M/Cd1nJae8VpDtYG1XHtMjIkakRqmdtLCFds9a5usZGQ==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "blake3-wasm": "^2.1.5",
-        "esbuild": "0.14.34",
+        "esbuild": "0.14.47",
         "miniflare": "^2.5.1",
         "nanoid": "^3.3.3",
         "path-to-regexp": "^6.2.0",
@@ -30929,170 +30929,170 @@
       }
     },
     "esbuild": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-      "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.47.tgz",
+      "integrity": "sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.34",
-        "esbuild-android-arm64": "0.14.34",
-        "esbuild-darwin-64": "0.14.34",
-        "esbuild-darwin-arm64": "0.14.34",
-        "esbuild-freebsd-64": "0.14.34",
-        "esbuild-freebsd-arm64": "0.14.34",
-        "esbuild-linux-32": "0.14.34",
-        "esbuild-linux-64": "0.14.34",
-        "esbuild-linux-arm": "0.14.34",
-        "esbuild-linux-arm64": "0.14.34",
-        "esbuild-linux-mips64le": "0.14.34",
-        "esbuild-linux-ppc64le": "0.14.34",
-        "esbuild-linux-riscv64": "0.14.34",
-        "esbuild-linux-s390x": "0.14.34",
-        "esbuild-netbsd-64": "0.14.34",
-        "esbuild-openbsd-64": "0.14.34",
-        "esbuild-sunos-64": "0.14.34",
-        "esbuild-windows-32": "0.14.34",
-        "esbuild-windows-64": "0.14.34",
-        "esbuild-windows-arm64": "0.14.34"
+        "esbuild-android-64": "0.14.47",
+        "esbuild-android-arm64": "0.14.47",
+        "esbuild-darwin-64": "0.14.47",
+        "esbuild-darwin-arm64": "0.14.47",
+        "esbuild-freebsd-64": "0.14.47",
+        "esbuild-freebsd-arm64": "0.14.47",
+        "esbuild-linux-32": "0.14.47",
+        "esbuild-linux-64": "0.14.47",
+        "esbuild-linux-arm": "0.14.47",
+        "esbuild-linux-arm64": "0.14.47",
+        "esbuild-linux-mips64le": "0.14.47",
+        "esbuild-linux-ppc64le": "0.14.47",
+        "esbuild-linux-riscv64": "0.14.47",
+        "esbuild-linux-s390x": "0.14.47",
+        "esbuild-netbsd-64": "0.14.47",
+        "esbuild-openbsd-64": "0.14.47",
+        "esbuild-sunos-64": "0.14.47",
+        "esbuild-windows-32": "0.14.47",
+        "esbuild-windows-64": "0.14.47",
+        "esbuild-windows-arm64": "0.14.47"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-      "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.47.tgz",
+      "integrity": "sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-      "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.47.tgz",
+      "integrity": "sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-      "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.47.tgz",
+      "integrity": "sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-      "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.47.tgz",
+      "integrity": "sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-      "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.47.tgz",
+      "integrity": "sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-      "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.47.tgz",
+      "integrity": "sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-      "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.47.tgz",
+      "integrity": "sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-      "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.47.tgz",
+      "integrity": "sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-      "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.47.tgz",
+      "integrity": "sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-      "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.47.tgz",
+      "integrity": "sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-      "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.47.tgz",
+      "integrity": "sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-      "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.47.tgz",
+      "integrity": "sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-      "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.47.tgz",
+      "integrity": "sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-      "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.47.tgz",
+      "integrity": "sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-      "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.47.tgz",
+      "integrity": "sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-      "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.47.tgz",
+      "integrity": "sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-      "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.47.tgz",
+      "integrity": "sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-      "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.47.tgz",
+      "integrity": "sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-      "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.47.tgz",
+      "integrity": "sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.34",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-      "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+      "version": "0.14.47",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.47.tgz",
+      "integrity": "sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==",
       "dev": true,
       "optional": true
     },
@@ -41359,16 +41359,16 @@
       }
     },
     "wrangler": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.15.tgz",
-      "integrity": "sha512-iBigg/qR1U74wJSR81njVNG69h/tcAGxXoBS1iKeLu1WIhTR/jfBbZdXWcspgkFaex4J6roJnhbFNy7Ob7caUA==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.16.tgz",
+      "integrity": "sha512-Fx3DCbQcYpnmUfRvCt4e7nxT0s6WVtIgjdBljvqOX6M/Cd1nJae8VpDtYG1XHtMjIkakRqmdtLCFds9a5usZGQ==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
         "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "blake3-wasm": "^2.1.5",
-        "esbuild": "0.14.34",
+        "esbuild": "0.14.47",
         "fsevents": "~2.3.2",
         "miniflare": "^2.5.1",
         "nanoid": "^3.3.3",

--- a/three-id/package.json
+++ b/three-id/package.json
@@ -57,7 +57,7 @@
     "@types/react": "17.0.21",
     "@types/react-native": "0.66.13",
     "typescript": "4.3.5",
-    "wrangler": "2.0.15"
+    "wrangler": "2.0.16"
   },
   "private": true
 }

--- a/three-id/worker/.gitignore
+++ b/three-id/worker/.gitignore
@@ -1,5 +1,4 @@
 # worker/.gitignore
 
 # Generated asset manifests, built as part of the deployment process.
-site-manifest.json
-gate-manifest.json
+asset-manifest.json

--- a/three-id/worker/wrangler.toml.example
+++ b/three-id/worker/wrangler.toml.example
@@ -20,75 +20,69 @@ workers_dev = true
 
 {% if robert/account-id %}
 [env.robert]
-name = "three-id-gate"
+name = "three-id"
 account_id = "{{robert/account-id}}"
 vars = { ENVIRONMENT = "development" }
 kv_namespaces = [
-  { binding = "SITE", id = "{{robert/kv-site-id}}" },
-  { binding = "GATE", id = "{{robert/kv-gate-id}}" },
+  { binding = "APP", id = "{{robert/kv-app-id}}" },
 ]
 {% endif %}
 
 {% if juan/account-id %}
 [env.juan]
-name = "three-id-gate"
+name = "three-id"
 account_id = "{{juan/account-id}}"
 vars = { ENVIRONMENT = "development" }
 kv_namespaces = [
-  { binding = "SITE", id = "{{juan/kv-site-id}}" },
-  { binding = "GATE", id = "{{juan/kv-gate-id}}" },
+  { binding = "APP", id = "{{juan/kv-app-id}}" },
 ]
 {% endif %}
 
 {% if cosmin/account-id %}
 [env.cosmin]
-name = "three-id-gate"
+name = "three-id"
 account_id = "{{cosmin/account-id}}"
 vars = { ENVIRONMENT = "development" }
 kv_namespaces = [
-  { binding = "SITE", id = "{{cosmin/kv-site-id}}" },
-  { binding = "GATE", id = "{{cosmin/kv-gate-id}}" },
+  { binding = "APP", id = "{{cosmin/kv-app-id}}" },
 ]
 {% endif %}
 
 {% if dhruv/account-id %}
 [env.dhruv]
-name = "three-id-gate"
+name = "three-id"
 account_id = "{{ dhruv/account-id }}"
 vars = { ENVIRONMENT = "development" }
 kv_namespaces = [
-  { binding = "SITE", id = "{{dhruv/kv-site-id}}" },
-  { binding = "GATE", id = "{{dhruv/kv-gate-id}}" },
+  { binding = "APP", id = "{{dhruv/kv-app-id}}" },
 ]
 {% endif %}
 
 {% if admin/account-id %}
 
-  {% if all next/kv-site-id next/kv-gate-id %}
+  {% if all next/kv-app-id %}
   # next (staging)
   # ------------------------------------------------------------------------------
 
   [env.next]
-  name = "three-id-gate-next"
+  name = "three-id-next"
   vars = { ENVIRONMENT = "next" }
   kv_namespaces = [
-    { binding = "SITE", id = "{{next/kv-site-id}}" },
-    { binding = "GATE", id = "{{next/kv-gate-id}}" },
+    { binding = "APP", id = "{{next/kv-app-id}}" },
   ]
   {% else %}
   # Skipping setup for next
   {% endif %}
 
-  {% if all current/kv-site-id current/kv-gate-id %}
+  {% if all current/kv-app-id %}
   # current (production)
   # ------------------------------------------------------------------------------
 
   [env.current]
-  name = "three-id-gate-current"
+  name = "three-id-current"
   vars = { ENVIRONMENT = "current" }
   kv_namespaces = [
-    { binding = "SITE", id = "{{current/kv-site-id}}" },
-    { binding = "GATE", id = "{{current/kv-gate-id}}" },
+    { binding = "APP", id = "{{current/kv-app-id}}" },
   ]
   {% else %}
   # Skipping setup for current


### PR DESCRIPTION
# Description

Removes some deployment configuration relating to the "SITE" application.
- [x] bumps `wrangler` to `2.0.16`
- [x] reverts "stitching" in "GATE" worker
- [x] updates build scripts and configuration
- [x] set `Access-Control-Allow-Origin: *` response header
- [x] set default OORT scheme (`https`) and port (`443`)

NB: if you have a personal development environment please:
- remove `-SITE` worker and KV store
- rename remaining service to `three-id`
- rename remaining KV store to `three-id-APP`