### PR TITLE
BUG(layout): Cap gate text width

### DIFF
--- a/three-id/src/screens/Gate.tsx
+++ b/three-id/src/screens/Gate.tsx
@@ -51,6 +51,8 @@ export default function Gate({ navigation }: { navigation: any }) {
             fontWeight: "400",
             lineHeight: 32,
             color: "#1F2937",
+            maxWidth: 758,
+            textAlign: "center",
           }}
         >
           To get onto the whitelist{" "}
@@ -68,15 +70,16 @@ export default function Gate({ navigation }: { navigation: any }) {
             href={Constants.manifest?.extra?.discordUrl}
           >
             join our Discord
-          </a>
-          , and leave us a message in{" "}
+          </a>{" "}
+          and leave us a message in{" "}
           <a
             target={"_blank"}
             rel={"noopener noopener noreferrer"}
             href={Constants.manifest?.extra?.discordChannelUrl}
           >
             #3iD
-          </a>
+          </a>{" "}
+          channel
         </Text>
       </View>
     </Layout>


### PR DESCRIPTION
# Description

I've capped the text property in the gate screen to the one specified in the design. I tried to get it to flow precisely as there, but I ended up setting the pre-defined value from the design. 

Closes https://github.com/kubelt/three-id/issues/90

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Visually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
