### PR TITLE
BUG(Landing): Non-web3 browser exception

### DIFF
--- a/three-id/src/provider/web3.ts
+++ b/three-id/src/provider/web3.ts
@@ -7,7 +7,7 @@ let web3Provider: null | ethers.providers.Web3Provider = null;
 
 const eth = (window as any).ethereum;
 
-export const isMetamask = () => eth.isMetaMask;
+export const isMetamask = () => eth?.isMetaMask === true;
 
 const handleAccountsChanged = (accounts: string[]) => {
   if (accounts.length > 0) {


### PR DESCRIPTION
# Description

Browsers without an ethereum window object would try to gauge whether metamask is present, thus throwing an exception. This should be fixed now.

Closes https://github.com/kubelt/three-id/issues/91

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Firefox without web3 capabilities
- [ ] Safari iOS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
