### PR TITLE
BUG(3iD): Polish Tracker - Clear account

### DIFF
--- a/three-id/src/provider/web3.ts
+++ b/three-id/src/provider/web3.ts
@@ -9,7 +9,10 @@ const eth = (window as any).ethereum;
 
 export const isMetamask = () => eth?.isMetaMask === true;
 
-export const clearAccount = () => accountSubj.next(null);
+export const clearAccount = async () => {
+  accountSubj.next(null);
+  sessionStorage.clear();
+};
 
 const handleAccountsChanged = (accounts: string[]) => {
   const currentAccount = accountSubj.getValue();
@@ -34,7 +37,11 @@ export const connect = async (): Promise<ethers.providers.Web3Provider> => {
     web3Provider = new ethers.providers.Web3Provider(eth);
   }
 
-  await web3Provider?.send("eth_requestAccounts", []);
+  if (!accountSubj.getValue()) {
+    await web3Provider?.send("wallet_requestPermissions", [
+      { eth_accounts: {} },
+    ]);
+  }
   await forceAccounts();
 
   return web3Provider;


### PR DESCRIPTION
# Description

> When the user gets to the gate (screen 2C) and clicks "Try Different Wallet" they are sent back to 2A. When they then select Metamask the flow does not re-start. They should be asked to re-connect / re-sign the message.

References https://github.com/kubelt/three-id/issues/92

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
