### PR TITLE
fix(gha): update next pipeline

### DIFF
--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -72,26 +72,15 @@ jobs:
         working-directory: ./three-id
         run: npm ci
 
-      - name: generate wrangler.toml
+      - name: build and deploy three-id
         working-directory: ./three-id
         env:
           # These values are injected into the generated wrangler.toml.
           ADMIN_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           NEXT_KV_APP_ID: ${{ secrets.NEXT_KV_APP_ID }}
           CURRENT_KV_APP_ID: ${{ secrets.CURRENT_KV_APP_ID }}
-        run: bb wrangler:toml
-
-      - name: build and deploy three-id
-        env:
+          # The Datadog client token.
+          DATADOG_TOKEN: ${{ secrets.DATADOG_TOKEN }}
           # The Cloudflare API token used by wrangler.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
-        working-directory: ./three-id
         run: bb deploy:app --deploy-env next
-
-      ## In which we do a little printf debugging:
-      # - working-directory: ./three-id
-      #   run: bb -prn:env-vars
-      # - working-directory: ./three-id
-      #   run: bb -prn:env
-      # - working-directory: ./three-id
-      #   run: cat worker/wrangler.toml

--- a/bb.edn
+++ b/bb.edn
@@ -14,12 +14,22 @@
     ;; Add shared build code to classpath.
     (cp/add-classpath "./bb")
     (require '[com.kubelt.cli :as cli])
+    (require '[com.kubelt.edn :as kb.edn])
+    (require '[com.kubelt.dot-env :as dot-env])
     (require '[com.kubelt.package :as package])
     (require '[com.kubelt.semver :as semver])
     (require '[com.kubelt.shadow :as shadow])
     (require '[com.kubelt.time :as time])
     ;; Extract version from package.json.
-    (def version (cli/release-version "package.json" *command-line-args*)))
+    (def version (cli/release-version "package.json" *command-line-args*))
+
+    ;; FILES
+
+    ;; The path of local-only configuration file containing various
+    ;; build configuration values.
+    (def deploy-edn (str (fs/path "three-id" "deploy.edn")))
+    ;; Secrets used by act (local GitHub Actions workflow runner).
+    (def act-secrets "act.secrets"))
 
   ;; Development
   ;; ---------------------------------------------------------------------------
@@ -43,6 +53,30 @@
   cmd:example
   {:doc "Invoke Clojure build script via shadow-cljs."
    :task (shell "npx shadow-cljs run build.command/example")},
+
+  -deploy:edn
+  {:doc "A map of values read from deployment configuration file"
+   :task (if (fs/regular-file? deploy-edn)
+           (kb.edn/read deploy-edn)
+           {})}
+
+  -act:secrets
+  {:doc "Generate a secret-containing env-file for use with act"
+   :depends [-deploy:edn]
+   :task (let [{admin-account-id :admin/account-id
+                cloudflare-token :cloudflare/token
+                next-kv-app-id :next/kv-app-id
+                current-kv-app-id :current/kv-app-id} -deploy:edn
+               secrets {:admin-account-id admin-account-id
+                        :cloudflare-token cloudflare-token
+                        :next-kv-app-id next-kv-app-id
+                        :current-kv-app-id current-kv-app-id}]
+           (dot-env/write act-secrets secrets))}
+
+  -act:next:three-id
+  {:doc "Run GitHub Actions 'next' pipeline, 'three-id' job locally"
+   :depends [-act:secrets]
+   :task (shell "act --insecure-secrets -W .github/workflows/next.yaml -j three-id")}
 
   ;; Tasks
   ;; ---------------------------------------------------------------------------

--- a/three-id/bb.edn
+++ b/three-id/bb.edn
@@ -365,6 +365,7 @@
   ;; datadog
   ;; -----------------------------------------------------------------------------
 
+  ;; A unique per-environment name used to bucket metrics in Datadog.
   -datadog:env
   {:doc "Generate the DATADOG_ENV environment variable value"
    :depends [-deploy:env]
@@ -373,11 +374,15 @@
            env-current -deploy:env
            (str "dev:" -deploy:env))}
 
+  ;; Taken from deploy.edn, overridden by presence of DATADOG_TOKEN
+  ;; environment variable.
   -datadog:token
-  {:doc "The Datadog client-side token set as the DATADOG_CLIENT_TOKEN value"
-   :depends [-deploy:edn]
-   :task (get -deploy:edn :datadog/token)}
+  {:doc "The Datadog client-side token"
+   :depends [-env:merged]
+   :task (get -env:merged :datadog/token)}
 
+  ;; These values will be injected into the .env file for use as
+  ;; compile-time constants.
   -datadog:config
   {:doc "Return a map of Datadog configuration values"
    :depends [-datadog:env -datadog:token]
@@ -388,7 +393,7 @@
   ;; -----------------------------------------------------------------------------
 
   -version:config
-  {:doc "Return a map of application version information."
+  {:doc "Return a map of application version information"
    :depends [-app:version -git:head]
    :task {:git-commit -git:head
           :app-version -app:version}}
@@ -409,6 +414,9 @@
   -env:robert-account-id (system/env "ROBERT_ACCOUNT_ID")
   -env:robert-kv-app-id (system/env "ROBERT_KV_APP_ID")
 
+  -env:cloudflare-token (system/env "CLOUDFLARE_TOKEN")
+  -env:datadog-token (system/env "DATADOG_TOKEN")
+
   ;; environment
   ;; -----------------------------------------------------------------------------
 
@@ -424,7 +432,9 @@
              -env:cosmin-account-id
              -env:cosmin-kv-app-id
              -env:next-kv-app-id
-             -env:current-kv-app-id]
+             -env:current-kv-app-id
+             -env:cloudflare-token
+             -env:datadog-token]
    :task (do
            {:robert/account-id -env:robert-account-id
             :robert/kv-app-id -env:robert-kv-app-id
@@ -436,7 +446,9 @@
             :dhruv/kv-app-id -env:dhruv-kv-app-id
             :admin/account-id -env:admin-account-id
             :next/kv-app-id -env:next-kv-app-id
-            :current/kv-app-id -env:current-kv-app-id})}
+            :current/kv-app-id -env:current-kv-app-id
+            :cloudflare/token -env:cloudflare-token
+            :datadog/token -env:datadog-token})}
 
   -deploy:edn
   {:doc "A map of values read from deployment configuration file"
@@ -523,6 +535,11 @@
    :task (let [secret (:cloudflare/token -env:merged)]
            (github.secret/set "CLOUDFLARE_TOKEN" secret))}
 
+  -gh:secret:datadog-token
+  {:depends [-env:merged]
+   :task (let [secret (:datadog/token -env:merged)]
+           (github.secret/set "DATADOG_TOKEN" secret))}
+
   -gh:secret:admin-account-id
   {:depends [-env:merged]
    :task (let [secret (:admin/account-id -env:merged)]
@@ -541,6 +558,7 @@
   gh:secret:init
   {:doc "Set up secrets in GitHub Actions"
    :depends [-gh:secret:cloudflare-token
+             -gh:secret:datadog-token
              -gh:secret:admin-account-id
              -gh:secret:next-kv-app-id
              -gh:secret:current-kv-app-id]}
@@ -674,6 +692,19 @@
    :task (let [message (str "[🌸] Deployment: successful [env:'" -deploy:env "']")]
            (println message))}
 
+  git:tag
+  {:doc "Create a signed tag using release signing key"
+   :depends []
+   ;; -u <keyid>
+   ;; -s sign
+   ;; -m "message"
+   :task (let [tag-name "v1"
+               message tag-name
+               key-id "fixme"
+               command ["git" "tag" tag-name "-u" key-id "-s" "-m" message]]
+           (pprint/pprint command)
+           )}
+
   ;; test
 
   ;; TODO on production deploy, smoke test internal *and* external URL.
@@ -683,7 +714,6 @@
   ;; KV store.
   test:smoke:http
   {:doc "Perform HTTP request for every deployed asset"
-   :requires []
    :depends [asset:manifest -url:deploy -test:strict?]
    :task (let [remote-paths (vals asset:manifest)
                ;; Turn the paths into full URLs.


### PR DESCRIPTION
# Description

- [x] add command for invoking `act` to run `next` workflow, `three-id` job locally
- [x] set `DATADOG_TOKEN` value in GitHub
- [x] load value for DATADOG token from `DATADOG_TOKEN` or `deploy.edn`
- [x] add missing environment variables to `three-id` job in `next` workflow
- [x] improve generation of `.env` file for `three-id`