### PR TITLE
chore(3iD): update deps, tweak next workflow

### DIFF
--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -86,3 +86,7 @@ jobs:
           # The Cloudflare API token used by wrangler.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         run: bb deploy:app --deploy-env next
+
+      - name: run smoke tests
+        working-directory: ./three-id
+        run: bb test:smoke --deploy-env next

--- a/three-id/bb.edn
+++ b/three-id/bb.edn
@@ -735,7 +735,7 @@
 
   deploy:app
   {:doc "Build and deploy the application"
-   :depends [-deploy:env clean:release build:release publish:site test:smoke]
+   :depends [-deploy:env clean:release build:release publish:site]
    :task (let [message (str "[🌸] Deployment: successful [env:'" -deploy:env "']")]
            (println message))}
 

--- a/three-id/package-lock.json
+++ b/three-id/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coinbase/wallet-sdk": "3.3.0",
-        "@datadog/browser-rum": "4.14.0",
+        "@datadog/browser-rum": "4.15.0",
         "@expo-google-fonts/inter": "0.2.2",
         "@expo-google-fonts/manrope": "0.2.2",
         "@expo/webpack-config": "0.16.25",
@@ -39,9 +39,9 @@
         "@babel/core": "7.18.6",
         "@types/react": "17.0.21",
         "@types/react-native": "0.66.13",
-        "expo-cli": "5.4.12",
+        "expo-cli": "5.5.1",
         "typescript": "4.7.4",
-        "wrangler": "2.0.17"
+        "wrangler": "2.0.18"
       }
     },
     "../kubelt/packages/sdk-web": {
@@ -2009,25 +2009,25 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
-      "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.15.0.tgz",
+      "integrity": "sha512-uLyCiksfrkrSdpYpfaS+e3feI0YQIRtJu5pEZpMrww9hvjY4XFdicG73Va8+O6WhZeGFfV13RMTlxWhsQSFA0w=="
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.14.0.tgz",
-      "integrity": "sha512-C4vl+lo6XugpcydZb4Fo+iRBs04D8+Z3k+aXcnbGkRBFKvr0ZXY1Z8ZaC60ZHDiiJq2WzmphxVvm0Q6UI5R0YQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.15.0.tgz",
+      "integrity": "sha512-4QHf84rC8CEkZbvPh1x48/fk3vv0CVy/aT2lX/da8raIHCyF5j/zXsKpMiV6DJ7ZSFaYIfiuinGiNKH/0cVf7Q==",
       "dependencies": {
-        "@datadog/browser-core": "4.14.0",
-        "@datadog/browser-rum-core": "4.14.0"
+        "@datadog/browser-core": "4.15.0",
+        "@datadog/browser-rum-core": "4.15.0"
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.14.0.tgz",
-      "integrity": "sha512-BoO3Q9AyNd5NahnjKWPBt+HqMCIp5EskirGp91KGXUYFsXROsTu0DqpQlr70CVwqPCbKUhG219P+AR7vHHaPQw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.15.0.tgz",
+      "integrity": "sha512-7HiOGO7Du5kNknGs0CzVrUzmdYRf+7I++d8EqIWIIb8KMx8eKaiCBlY1ac+0nTHrbQCdQuV4s6xFpKYpEa8oiA==",
       "dependencies": {
-        "@datadog/browser-core": "4.14.0"
+        "@datadog/browser-core": "4.15.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -3169,12 +3169,12 @@
       }
     },
     "node_modules/@expo/dev-server": {
-      "version": "0.1.114",
-      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.114.tgz",
-      "integrity": "sha512-gJULhPFRMc3Qk3CmvDyGzZbSC6Ulilr27VRzkAdA51186r2mR/OuUdpy5KDGxhqcdns2w9VTOikU8HulE3fphQ==",
+      "version": "0.1.116",
+      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.116.tgz",
+      "integrity": "sha512-jUyOv3S55wBsYiFhiYVz35Ui8QTnUGVKlsPRgQHnKU70Ey4jxJqObtGkNnrgazzDfy9S7qFJKiyJQro7621ipA==",
       "dependencies": {
         "@expo/bunyan": "4.0.0",
-        "@expo/metro-config": "0.3.18",
+        "@expo/metro-config": "0.3.19",
         "@expo/osascript": "2.0.33",
         "body-parser": "1.19.0",
         "chalk": "^4.0.0",
@@ -3264,12 +3264,12 @@
       }
     },
     "node_modules/@expo/dev-tools": {
-      "version": "0.13.159",
-      "resolved": "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.159.tgz",
-      "integrity": "sha512-PAU9Fdeh2BuhfwD9+xodp7TjwGFb/Ewv0g0p6GOWDUATskeww+Tg7W0nEoADzWx4vqFkzw+ZdT9B0A1VA3Ao9g==",
+      "version": "0.13.161",
+      "resolved": "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.161.tgz",
+      "integrity": "sha512-YAWSPQn0eOxVIP78ymasJVaDVov9pBtkj2j/Ve40e71olzbCC6zlIiqMcAn0MkGEpaSyOdwY8DKWT+/Vd2/qTg==",
       "dev": true,
       "dependencies": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "base64url": "3.0.1",
         "better-opn": "^3.0.1",
         "express": "4.16.4",
@@ -3282,6 +3282,34 @@
       },
       "peerDependencies": {
         "xdl": "*"
+      }
+    },
+    "node_modules/@expo/dev-tools/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/dev-tools/node_modules/@expo/config": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+      "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "4.1.5",
+        "@expo/config-types": "^45.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
       }
     },
     "node_modules/@expo/dev-tools/node_modules/@types/node": {
@@ -3331,15 +3359,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/@expo/dev-tools/node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/@expo/dev-tools/node_modules/bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -3365,6 +3384,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@expo/dev-tools/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
       }
     },
     "node_modules/@expo/dev-tools/node_modules/destroy": {
@@ -3420,15 +3448,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/@expo/dev-tools/node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/@expo/dev-tools/node_modules/finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -3445,15 +3464,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/@expo/dev-tools/node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/@expo/dev-tools/node_modules/graphql": {
@@ -3554,6 +3564,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/@expo/dev-tools/node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@expo/dev-tools/node_modules/send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -3576,15 +3598,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@expo/dev-tools/node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/@expo/dev-tools/node_modules/serve-static": {
@@ -3863,17 +3876,43 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.3.18.tgz",
-      "integrity": "sha512-DWtwV67kD8X2uOKIs5QyHlHD+6L6RAgudZZDBmu433ZvL62HAUYfjEi3+i0jeMiUqN85o1vbXg6xqWnBCpS50g==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.3.19.tgz",
+      "integrity": "sha512-UZlwnD0g/7uAx/AZ5ulC7Y4unfJFJywXy3Ozu40dhQnSciOU/nkzK94XpKbxHuRZJ3crZxvL2EDwQ8jguDjASw==",
       "dependencies": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/json-file": "8.2.36",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
         "find-yarn-workspace-root": "~2.0.0",
         "getenv": "^1.0.0",
         "resolve-from": "^5.0.0",
+        "sucrase": "^3.20.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/config": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+      "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "4.1.5",
+        "@expo/config-types": "^45.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
         "sucrase": "^3.20.0"
       }
     },
@@ -3928,6 +3967,17 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@expo/metro-config/node_modules/supports-color": {
@@ -4050,11 +4100,11 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-4.0.3.tgz",
-      "integrity": "sha512-ZRMn0a9Wo/coKXLMvizUytqtG5pniUHaBMSS28yFTcGVvyDJh2nFVkBf9po52mSkbm9rGp/Pev6GAf57m6S2BA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-4.0.4.tgz",
+      "integrity": "sha512-yvoc2w4zwiq1wko8FE8/N3e1HSrXQP8XUvX8nIJtQ2mrSLGktbg9SzNM8+s8aBVTd4j1Zp3bcMzTsYnG9ygYbA==",
       "dependencies": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
         "@expo/config-types": "^45.0.0",
         "@expo/image-utils": "0.3.21",
@@ -4065,6 +4115,32 @@
         "resolve-from": "^5.0.0",
         "semver": "7.3.2",
         "xml2js": "0.4.23"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/config": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+      "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "4.1.5",
+        "@expo/config-types": "^45.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/ansi-styles": {
@@ -11523,23 +11599,23 @@
       }
     },
     "node_modules/expo-cli": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-5.4.12.tgz",
-      "integrity": "sha512-NNau44nKvKa7LUTPuoQ3flM9VGHGaMuVNkf/e73l1tc69L72Rt8BOIq2khWId0uYT8Dng9cQ0np0LE5qLvwxTQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-5.5.1.tgz",
+      "integrity": "sha512-dwFvHPl/xhhu3TF+/zJYOiFjKi9a9oDUR/ew+Q1/yIaZzqjruhtOjVrGlpd4WkNosrJC/v1sVjfoSV+lybQy/g==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "7.9.0",
         "@expo/apple-utils": "0.0.0-alpha.31",
         "@expo/bunyan": "4.0.0",
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
-        "@expo/dev-server": "0.1.114",
-        "@expo/dev-tools": "0.13.159",
+        "@expo/dev-server": "0.1.116",
+        "@expo/dev-tools": "0.13.161",
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.55",
         "@expo/plist": "0.0.18",
-        "@expo/prebuild-config": "4.0.3",
+        "@expo/prebuild-config": "4.0.4",
         "@expo/spawn-async": "1.5.0",
         "@expo/xcpretty": "^4.1.0",
         "better-opn": "^3.0.1",
@@ -11584,7 +11660,7 @@
         "url-join": "4.0.0",
         "uuid": "^8.0.0",
         "wrap-ansi": "^7.0.0",
-        "xdl": "59.2.42"
+        "xdl": "59.2.44"
       },
       "bin": {
         "expo": "bin/expo.js",
@@ -11594,6 +11670,15 @@
         "node": ">=12 <=16"
       }
     },
+    "node_modules/expo-cli/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
     "node_modules/expo-cli/node_modules/@babel/runtime": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
@@ -11601,6 +11686,25 @@
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/expo-cli/node_modules/@expo/config": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+      "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "4.1.5",
+        "@expo/config-types": "^45.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
       }
     },
     "node_modules/expo-cli/node_modules/ansi-styles": {
@@ -24498,9 +24602,9 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.17.tgz",
-      "integrity": "sha512-U4PSx1j0JUPX/fDvQSqeCVZeAww+DLZkm1tWeFovOxgzpvpvZ/2s+2IINR+dhw4FGiSpDUsQgiA4EDm64fV4RA==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.18.tgz",
+      "integrity": "sha512-BkKoYBjGLKbng9SEsDLjcEH8X0cDuI5mWG9ih6pGO5t7xnvlzcny3r/XhgpCE8UWv+uYM6kd3CqO5JhQf38ZeA==",
       "dev": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -24657,15 +24761,15 @@
       }
     },
     "node_modules/xdl": {
-      "version": "59.2.42",
-      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.42.tgz",
-      "integrity": "sha512-fNY9efY58ZK/ehuaI6hlxgmTXvjy4NgPtQyt3tw2WC2+GvpgwKNxAeeqlw2w7xjPmx19XWgGprcr3EUSd/YSeg==",
+      "version": "59.2.44",
+      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.44.tgz",
+      "integrity": "sha512-54lgz+OVVhTQaI0BjXI0zJX23UHuJRY6x8ytgeKDwHITI4LZFm7VzHuNacTgvipDRqYVVgRVaLq1gFpmvit9xQ==",
       "dev": true,
       "dependencies": {
         "@expo/bunyan": "4.0.0",
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
-        "@expo/dev-server": "0.1.114",
+        "@expo/dev-server": "0.1.116",
         "@expo/devcert": "^1.0.0",
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
@@ -24675,7 +24779,7 @@
         "@expo/schemer": "1.4.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@expo/spawn-async": "1.5.0",
-        "@expo/webpack-config": "0.16.25",
+        "@expo/webpack-config": "0.16.26",
         "axios": "0.21.1",
         "better-opn": "^3.0.1",
         "boxen": "^5.0.1",
@@ -24726,6 +24830,115 @@
         "webpack": "4.43.0",
         "webpack-dev-server": "3.11.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/xdl/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/xdl/node_modules/@babel/core": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/xdl/node_modules/@babel/core/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/xdl/node_modules/@expo/config": {
+      "version": "6.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+      "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "4.1.5",
+        "@expo/config-types": "^45.0.0",
+        "@expo/json-file": "8.2.36",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.3.2",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
+      }
+    },
+    "node_modules/xdl/node_modules/@expo/webpack-config": {
+      "version": "0.16.26",
+      "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.16.26.tgz",
+      "integrity": "sha512-tOZ70r/MJp1+TP5XOvjroRbHVSdJAxSqKVv2ZJ5nml4pv8E7LeLeXbKC5mvIS0+0PQK3PuuD5mm7zBy4sqnq/A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "7.9.0",
+        "@expo/config": "6.0.26",
+        "babel-loader": "8.1.0",
+        "chalk": "^4.0.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "copy-webpack-plugin": "~6.0.3",
+        "css-loader": "~3.6.0",
+        "expo-pwa": "0.0.121",
+        "file-loader": "~6.0.0",
+        "find-yarn-workspace-root": "~2.0.0",
+        "getenv": "^1.0.0",
+        "html-loader": "~1.1.0",
+        "html-webpack-plugin": "~4.3.0",
+        "image-size": "^1.0.0",
+        "is-wsl": "^2.0.0",
+        "loader-utils": "^2.0.0",
+        "mini-css-extract-plugin": "^0.5.0",
+        "node-html-parser": "^1.2.12",
+        "optimize-css-assets-webpack-plugin": "^5.0.3",
+        "pnp-webpack-plugin": "^1.5.0",
+        "postcss-safe-parser": "^4.0.2",
+        "react-dev-utils": "~11.0.1",
+        "schema-utils": "^3.1.1",
+        "semver": "~7.3.2",
+        "style-loader": "~1.2.1",
+        "terser-webpack-plugin": "^3.0.6",
+        "url-loader": "~4.1.0",
+        "webpack": "4.43.0",
+        "webpack-dev-server": "3.11.0",
+        "webpack-manifest-plugin": "~2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/xdl/node_modules/ansi-styles": {
@@ -24822,6 +25035,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/xdl/node_modules/commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
     "node_modules/xdl/node_modules/content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -24845,6 +25064,22 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
       "dev": true
+    },
+    "node_modules/xdl/node_modules/expo-pwa": {
+      "version": "0.0.121",
+      "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.121.tgz",
+      "integrity": "sha512-GlqhWs09HUbcViofjGFxTvFNPITAndyy2PXveY8dw2gViCEk3itnk0JmGs3pgmOmq262dOHejvcbu3JczEgeww==",
+      "dev": true,
+      "dependencies": {
+        "@expo/config": "6.0.26",
+        "@expo/image-utils": "0.3.21",
+        "chalk": "^4.0.0",
+        "commander": "2.20.0",
+        "update-check": "1.5.3"
+      },
+      "bin": {
+        "expo-pwa": "build/cli.js"
+      }
     },
     "node_modules/xdl/node_modules/express": {
       "version": "4.16.4",
@@ -24979,6 +25214,15 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true
     },
+    "node_modules/xdl/node_modules/mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      }
+    },
     "node_modules/xdl/node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -25098,15 +25342,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/xdl/node_modules/send/node_modules/mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
       }
     },
     "node_modules/xdl/node_modules/serve-static": {
@@ -26665,25 +26900,25 @@
       "optional": true
     },
     "@datadog/browser-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.14.0.tgz",
-      "integrity": "sha512-ogtZSxHCi/Uh2V4fe88rlXHPeHy4oYbAzuCjDGn60gVECL4US6xYJ4AVi4nPAvkQun8KaxUQdYMfeohcGBMrYQ=="
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.15.0.tgz",
+      "integrity": "sha512-uLyCiksfrkrSdpYpfaS+e3feI0YQIRtJu5pEZpMrww9hvjY4XFdicG73Va8+O6WhZeGFfV13RMTlxWhsQSFA0w=="
     },
     "@datadog/browser-rum": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.14.0.tgz",
-      "integrity": "sha512-C4vl+lo6XugpcydZb4Fo+iRBs04D8+Z3k+aXcnbGkRBFKvr0ZXY1Z8ZaC60ZHDiiJq2WzmphxVvm0Q6UI5R0YQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.15.0.tgz",
+      "integrity": "sha512-4QHf84rC8CEkZbvPh1x48/fk3vv0CVy/aT2lX/da8raIHCyF5j/zXsKpMiV6DJ7ZSFaYIfiuinGiNKH/0cVf7Q==",
       "requires": {
-        "@datadog/browser-core": "4.14.0",
-        "@datadog/browser-rum-core": "4.14.0"
+        "@datadog/browser-core": "4.15.0",
+        "@datadog/browser-rum-core": "4.15.0"
       }
     },
     "@datadog/browser-rum-core": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.14.0.tgz",
-      "integrity": "sha512-BoO3Q9AyNd5NahnjKWPBt+HqMCIp5EskirGp91KGXUYFsXROsTu0DqpQlr70CVwqPCbKUhG219P+AR7vHHaPQw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.15.0.tgz",
+      "integrity": "sha512-7HiOGO7Du5kNknGs0CzVrUzmdYRf+7I++d8EqIWIIb8KMx8eKaiCBlY1ac+0nTHrbQCdQuV4s6xFpKYpEa8oiA==",
       "requires": {
-        "@datadog/browser-core": "4.14.0"
+        "@datadog/browser-core": "4.15.0"
       }
     },
     "@emotion/is-prop-valid": {
@@ -27433,12 +27668,12 @@
       }
     },
     "@expo/dev-server": {
-      "version": "0.1.114",
-      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.114.tgz",
-      "integrity": "sha512-gJULhPFRMc3Qk3CmvDyGzZbSC6Ulilr27VRzkAdA51186r2mR/OuUdpy5KDGxhqcdns2w9VTOikU8HulE3fphQ==",
+      "version": "0.1.116",
+      "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.116.tgz",
+      "integrity": "sha512-jUyOv3S55wBsYiFhiYVz35Ui8QTnUGVKlsPRgQHnKU70Ey4jxJqObtGkNnrgazzDfy9S7qFJKiyJQro7621ipA==",
       "requires": {
         "@expo/bunyan": "4.0.0",
-        "@expo/metro-config": "0.3.18",
+        "@expo/metro-config": "0.3.19",
         "@expo/osascript": "2.0.33",
         "body-parser": "1.19.0",
         "chalk": "^4.0.0",
@@ -27503,12 +27738,12 @@
       }
     },
     "@expo/dev-tools": {
-      "version": "0.13.159",
-      "resolved": "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.159.tgz",
-      "integrity": "sha512-PAU9Fdeh2BuhfwD9+xodp7TjwGFb/Ewv0g0p6GOWDUATskeww+Tg7W0nEoADzWx4vqFkzw+ZdT9B0A1VA3Ao9g==",
+      "version": "0.13.161",
+      "resolved": "https://registry.npmjs.org/@expo/dev-tools/-/dev-tools-0.13.161.tgz",
+      "integrity": "sha512-YAWSPQn0eOxVIP78ymasJVaDVov9pBtkj2j/Ve40e71olzbCC6zlIiqMcAn0MkGEpaSyOdwY8DKWT+/Vd2/qTg==",
       "dev": true,
       "requires": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "base64url": "3.0.1",
         "better-opn": "^3.0.1",
         "express": "4.16.4",
@@ -27520,6 +27755,34 @@
         "subscriptions-transport-ws": "0.9.8"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@expo/config": {
+          "version": "6.0.26",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+          "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "~7.10.4",
+            "@expo/config-plugins": "4.1.5",
+            "@expo/config-types": "^45.0.0",
+            "@expo/json-file": "8.2.36",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4",
+            "sucrase": "^3.20.0"
+          }
+        },
         "@types/node": {
           "version": "9.6.61",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.61.tgz",
@@ -27559,17 +27822,6 @@
             "qs": "6.5.2",
             "raw-body": "2.3.3",
             "type-is": "~1.6.16"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "bytes": {
@@ -27589,6 +27841,15 @@
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
           "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "destroy": {
           "version": "1.0.4",
@@ -27638,17 +27899,6 @@
             "type-is": "~1.6.16",
             "utils-merge": "1.0.1",
             "vary": "~1.1.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "finalhandler": {
@@ -27664,17 +27914,6 @@
             "parseurl": "~1.3.2",
             "statuses": "~1.4.0",
             "unpipe": "~1.0.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "graphql": {
@@ -27756,6 +27995,12 @@
             "unpipe": "1.0.0"
           }
         },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
         "send": {
           "version": "0.16.2",
           "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
@@ -27775,17 +28020,6 @@
             "on-finished": "~2.3.0",
             "range-parser": "~1.2.0",
             "statuses": "~1.4.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
           }
         },
         "serve-static": {
@@ -28014,11 +28248,11 @@
       }
     },
     "@expo/metro-config": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.3.18.tgz",
-      "integrity": "sha512-DWtwV67kD8X2uOKIs5QyHlHD+6L6RAgudZZDBmu433ZvL62HAUYfjEi3+i0jeMiUqN85o1vbXg6xqWnBCpS50g==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.3.19.tgz",
+      "integrity": "sha512-UZlwnD0g/7uAx/AZ5ulC7Y4unfJFJywXy3Ozu40dhQnSciOU/nkzK94XpKbxHuRZJ3crZxvL2EDwQ8jguDjASw==",
       "requires": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/json-file": "8.2.36",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
@@ -28028,6 +28262,32 @@
         "sucrase": "^3.20.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@expo/config": {
+          "version": "6.0.26",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+          "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+          "requires": {
+            "@babel/code-frame": "~7.10.4",
+            "@expo/config-plugins": "4.1.5",
+            "@expo/config-types": "^45.0.0",
+            "@expo/json-file": "8.2.36",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4",
+            "sucrase": "^3.20.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -28062,6 +28322,11 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -28160,11 +28425,11 @@
       }
     },
     "@expo/prebuild-config": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-4.0.3.tgz",
-      "integrity": "sha512-ZRMn0a9Wo/coKXLMvizUytqtG5pniUHaBMSS28yFTcGVvyDJh2nFVkBf9po52mSkbm9rGp/Pev6GAf57m6S2BA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-4.0.4.tgz",
+      "integrity": "sha512-yvoc2w4zwiq1wko8FE8/N3e1HSrXQP8XUvX8nIJtQ2mrSLGktbg9SzNM8+s8aBVTd4j1Zp3bcMzTsYnG9ygYbA==",
       "requires": {
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
         "@expo/config-types": "^45.0.0",
         "@expo/image-utils": "0.3.21",
@@ -28177,6 +28442,32 @@
         "xml2js": "0.4.23"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@expo/config": {
+          "version": "6.0.26",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+          "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+          "requires": {
+            "@babel/code-frame": "~7.10.4",
+            "@expo/config-plugins": "4.1.5",
+            "@expo/config-types": "^45.0.0",
+            "@expo/json-file": "8.2.36",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4",
+            "sucrase": "^3.20.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -34014,23 +34305,23 @@
       }
     },
     "expo-cli": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-5.4.12.tgz",
-      "integrity": "sha512-NNau44nKvKa7LUTPuoQ3flM9VGHGaMuVNkf/e73l1tc69L72Rt8BOIq2khWId0uYT8Dng9cQ0np0LE5qLvwxTQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/expo-cli/-/expo-cli-5.5.1.tgz",
+      "integrity": "sha512-dwFvHPl/xhhu3TF+/zJYOiFjKi9a9oDUR/ew+Q1/yIaZzqjruhtOjVrGlpd4WkNosrJC/v1sVjfoSV+lybQy/g==",
       "dev": true,
       "requires": {
         "@babel/runtime": "7.9.0",
         "@expo/apple-utils": "0.0.0-alpha.31",
         "@expo/bunyan": "4.0.0",
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
-        "@expo/dev-server": "0.1.114",
-        "@expo/dev-tools": "0.13.159",
+        "@expo/dev-server": "0.1.116",
+        "@expo/dev-tools": "0.13.161",
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
         "@expo/package-manager": "0.0.55",
         "@expo/plist": "0.0.18",
-        "@expo/prebuild-config": "4.0.3",
+        "@expo/prebuild-config": "4.0.4",
         "@expo/spawn-async": "1.5.0",
         "@expo/xcpretty": "^4.1.0",
         "better-opn": "^3.0.1",
@@ -34075,9 +34366,18 @@
         "url-join": "4.0.0",
         "uuid": "^8.0.0",
         "wrap-ansi": "^7.0.0",
-        "xdl": "59.2.42"
+        "xdl": "59.2.44"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
         "@babel/runtime": {
           "version": "7.9.0",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
@@ -34085,6 +34385,25 @@
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@expo/config": {
+          "version": "6.0.26",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+          "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "~7.10.4",
+            "@expo/config-plugins": "4.1.5",
+            "@expo/config-types": "^45.0.0",
+            "@expo/json-file": "8.2.36",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4",
+            "sucrase": "^3.20.0"
           }
         },
         "ansi-styles": {
@@ -44295,9 +44614,9 @@
       }
     },
     "wrangler": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.17.tgz",
-      "integrity": "sha512-U4PSx1j0JUPX/fDvQSqeCVZeAww+DLZkm1tWeFovOxgzpvpvZ/2s+2IINR+dhw4FGiSpDUsQgiA4EDm64fV4RA==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-2.0.18.tgz",
+      "integrity": "sha512-BkKoYBjGLKbng9SEsDLjcEH8X0cDuI5mWG9ih6pGO5t7xnvlzcny3r/XhgpCE8UWv+uYM6kd3CqO5JhQf38ZeA==",
       "dev": true,
       "requires": {
         "@cloudflare/kv-asset-handler": "^0.2.0",
@@ -44410,15 +44729,15 @@
       }
     },
     "xdl": {
-      "version": "59.2.42",
-      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.42.tgz",
-      "integrity": "sha512-fNY9efY58ZK/ehuaI6hlxgmTXvjy4NgPtQyt3tw2WC2+GvpgwKNxAeeqlw2w7xjPmx19XWgGprcr3EUSd/YSeg==",
+      "version": "59.2.44",
+      "resolved": "https://registry.npmjs.org/xdl/-/xdl-59.2.44.tgz",
+      "integrity": "sha512-54lgz+OVVhTQaI0BjXI0zJX23UHuJRY6x8ytgeKDwHITI4LZFm7VzHuNacTgvipDRqYVVgRVaLq1gFpmvit9xQ==",
       "dev": true,
       "requires": {
         "@expo/bunyan": "4.0.0",
-        "@expo/config": "6.0.24",
+        "@expo/config": "6.0.26",
         "@expo/config-plugins": "4.1.5",
-        "@expo/dev-server": "0.1.114",
+        "@expo/dev-server": "0.1.116",
         "@expo/devcert": "^1.0.0",
         "@expo/json-file": "8.2.36",
         "@expo/osascript": "2.0.33",
@@ -44428,7 +44747,7 @@
         "@expo/schemer": "1.4.2",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "@expo/spawn-async": "1.5.0",
-        "@expo/webpack-config": "0.16.25",
+        "@expo/webpack-config": "0.16.26",
         "axios": "0.21.1",
         "better-opn": "^3.0.1",
         "boxen": "^5.0.1",
@@ -44481,6 +44800,104 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/core": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.0",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.0",
+            "@babel/parser": "^7.9.0",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "@expo/config": {
+          "version": "6.0.26",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-6.0.26.tgz",
+          "integrity": "sha512-nMQaZl69r6CMJFhCj0xcGJN9bIi4Uws0k9K6q6rGFPFNarS0z0aexeyNLv93/J+hsTJVn0GEYtGz5Y/R8boXxw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "~7.10.4",
+            "@expo/config-plugins": "4.1.5",
+            "@expo/config-types": "^45.0.0",
+            "@expo/json-file": "8.2.36",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4",
+            "sucrase": "^3.20.0"
+          }
+        },
+        "@expo/webpack-config": {
+          "version": "0.16.26",
+          "resolved": "https://registry.npmjs.org/@expo/webpack-config/-/webpack-config-0.16.26.tgz",
+          "integrity": "sha512-tOZ70r/MJp1+TP5XOvjroRbHVSdJAxSqKVv2ZJ5nml4pv8E7LeLeXbKC5mvIS0+0PQK3PuuD5mm7zBy4sqnq/A==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "7.9.0",
+            "@expo/config": "6.0.26",
+            "babel-loader": "8.1.0",
+            "chalk": "^4.0.0",
+            "clean-webpack-plugin": "^3.0.0",
+            "copy-webpack-plugin": "~6.0.3",
+            "css-loader": "~3.6.0",
+            "expo-pwa": "0.0.121",
+            "file-loader": "~6.0.0",
+            "find-yarn-workspace-root": "~2.0.0",
+            "getenv": "^1.0.0",
+            "html-loader": "~1.1.0",
+            "html-webpack-plugin": "~4.3.0",
+            "image-size": "^1.0.0",
+            "is-wsl": "^2.0.0",
+            "loader-utils": "^2.0.0",
+            "mini-css-extract-plugin": "^0.5.0",
+            "node-html-parser": "^1.2.12",
+            "optimize-css-assets-webpack-plugin": "^5.0.3",
+            "pnp-webpack-plugin": "^1.5.0",
+            "postcss-safe-parser": "^4.0.2",
+            "react-dev-utils": "~11.0.1",
+            "schema-utils": "^3.1.1",
+            "semver": "~7.3.2",
+            "style-loader": "~1.2.1",
+            "terser-webpack-plugin": "^3.0.6",
+            "url-loader": "~4.1.0",
+            "webpack": "4.43.0",
+            "webpack-dev-server": "3.11.0",
+            "webpack-manifest-plugin": "~2.2.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -44556,6 +44973,12 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
         "content-disposition": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
@@ -44573,6 +44996,19 @@
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==",
           "dev": true
+        },
+        "expo-pwa": {
+          "version": "0.0.121",
+          "resolved": "https://registry.npmjs.org/expo-pwa/-/expo-pwa-0.0.121.tgz",
+          "integrity": "sha512-GlqhWs09HUbcViofjGFxTvFNPITAndyy2PXveY8dw2gViCEk3itnk0JmGs3pgmOmq262dOHejvcbu3JczEgeww==",
+          "dev": true,
+          "requires": {
+            "@expo/config": "6.0.26",
+            "@expo/image-utils": "0.3.21",
+            "chalk": "^4.0.0",
+            "commander": "2.20.0",
+            "update-check": "1.5.3"
+          }
         },
         "express": {
           "version": "4.16.4",
@@ -44693,6 +45129,12 @@
           "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
           "dev": true
         },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -44786,12 +45228,6 @@
               "requires": {
                 "ms": "2.0.0"
               }
-            },
-            "mime": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-              "dev": true
             }
           }
         },

--- a/three-id/package.json
+++ b/three-id/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "3.3.0",
-    "@datadog/browser-rum": "4.14.0",
+    "@datadog/browser-rum": "4.15.0",
     "@expo-google-fonts/inter": "0.2.2",
     "@expo-google-fonts/manrope": "0.2.2",
     "@expo/webpack-config": "0.16.25",
@@ -58,9 +58,9 @@
     "@babel/core": "7.18.6",
     "@types/react": "17.0.21",
     "@types/react-native": "0.66.13",
-    "expo-cli": "5.4.12",
+    "expo-cli": "5.5.1",
     "typescript": "4.7.4",
-    "wrangler": "2.0.17"
+    "wrangler": "2.0.18"
   },
   "private": true
 }


### PR DESCRIPTION
# Description

Updates a few dependencies:
- [x] `@datadog/browser-rum`: `4.15.0`
- [x] `expo-cli`: `5.5.1`
- [x] `wrangler`: `2.0.18`

Also tweaks the `next` workflow, `three-id` job:
- [x] don't automatically run smoke tests as part of `deploy:app` task
- [x] add separate step in `three-id` workflow job to run smoke tests