### PR TITLE
FEAT(DD): RUM session setup

### DIFF
--- a/three-id/src/App.tsx
+++ b/three-id/src/App.tsx
@@ -14,6 +14,8 @@ import { Manrope_700Bold } from "@expo-google-fonts/manrope";
 import Landing from "./screens/Landing";
 import Auth from "./screens/Auth";
 import Gate from "./screens/Gate";
+import { useEffect } from "react";
+import { startSession, stopSession } from "./analytics/datadog";
 
 const Stack = createNativeStackNavigator();
 
@@ -25,6 +27,20 @@ export default function App() {
     Inter_800ExtraBold,
     Manrope_700Bold,
   });
+
+  useEffect(() => {
+    stopSession()
+
+    const asyncFn = async () => {
+      await startSession() 
+    }
+
+    asyncFn()
+
+    return () => {
+      stopSession()
+    }
+  }, [])
 
   if (!fontsLoaded) return null;
 

--- a/three-id/src/analytics/datadog.ts
+++ b/three-id/src/analytics/datadog.ts
@@ -19,17 +19,44 @@ const configuration: RumInitConfiguration = {
 };
 
 let initialized: boolean = false;
-const init = async () => {
+let sessionStarted: boolean = false
+
+const init = async (record?: boolean) => {
   if (!initialized) {
     datadogRum.init(configuration);
+
+    if (record) {
+      startSession()
+    }
+
     initialized = true;
   }
 };
 
-export const startView = async (viewKey: string): Promise<void> => {
+export const startSession = async () => {
   await init();
 
+  if (!sessionStarted) {
+    datadogRum.startSessionReplayRecording()
+    sessionStarted = true
+  }
+  else
+    console.info("Session already started")
+}
+
+export const stopSession = () => {
+  if (sessionStarted) {
+    datadogRum.stopSessionReplayRecording()
+    sessionStarted = false
+  }
+  else
+    console.info("No session started")
+}
+
+export const startView = async (viewKey: string): Promise<void> => {
+  if(!sessionStarted) {
+    await startSession()
+  }
+  
   datadogRum.startView(viewKey);
 };
-
-export default init;


### PR DESCRIPTION
# Description

This changeset is concerned with activating Data Dog's mechanism for recording user sessions. Once activated, it should hook itself into browser events and create an analytics funnel which can be then used to build dashboard informing us of user activity and / or errors.

Closes https://github.com/kubelt/three-id/issues/96

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manually, by listening for local events in the DD console
- [ ] Dev env deployment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
