### PR TITLE
CHORE(Three-id): Add navigation by path on web

### DIFF
--- a/three-id/src/App.tsx
+++ b/three-id/src/App.tsx
@@ -45,7 +45,20 @@ export default function App() {
   if (!fontsLoaded) return null;
 
   return (
-    <NavigationContainer>
+    /**
+     * Prefixes should contain the urls
+     * perhaps they can be added through 
+     * constants module.
+     * 
+     * For now empty *seems* to work
+     */
+    <NavigationContainer linking={{ prefixes: [], config: {
+      screens: {
+        Landing: '/',
+        Auth: 'authentication',
+        Gate: 'gate',
+      }
+    } }}>
       <Stack.Navigator
         screenOptions={{
           headerShown: false,


### PR DESCRIPTION
# Description

We're enabling path navigation for web interfaces; this will have the effect of allowing us to implement features such as /profile/:id or /mint. For current sprint, it's a requirement that we are able to visit the mint page by url. Profile is probably also in this category.

Closes #555 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Funnel e2e manual test
- [x] Manual link navigation to authenticate page prompting signature

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
