### PR TITLE
FEAT(Three-id): Check claims after succesful authentication

### DIFF
--- a/src/main/com/kubelt/lib/rpc.cljs
+++ b/src/main/com/kubelt/lib/rpc.cljs
@@ -33,5 +33,7 @@
              (lib.promise/catch reject)))))))
 
 (defn rpc-call-js [sys api args]
- (-> (rpc-call& sys api (update (js->clj args :keywordize-keys true) :method #(mapv keyword %)))
-     (lib.promise/then clj->js)))
+  (let [core (-> (get-in sys [:crypto/session :vault/tokens]) keys first)]
+    (-> (assoc sys :crypto/wallet {:wallet/address core})
+        (rpc-call& api (update (js->clj args :keywordize-keys true) :method #(mapv keyword %)))
+        (lib.promise/then clj->js))))

--- a/src/main/com/kubelt/sdk/v1/oort.cljs
+++ b/src/main/com/kubelt/sdk/v1/oort.cljs
@@ -105,8 +105,10 @@
 
 
 (defn claims-js [sys]
-  (-> (claims& sys (get-in sys [:crypto/wallet :wallet/address]))
-      (lib.promise/then clj->js)))
+  (let [core (-> (get-in sys [:crypto/session :vault/tokens]) keys first)]
+    (-> (assoc sys :crypto/wallet {:wallet/address core})
+        (claims& core)
+        (lib.promise/then clj->js))))
 
 
 

--- a/three-id/README.md
+++ b/three-id/README.md
@@ -41,3 +41,26 @@ If you are doing any non-local development and the output of this command report
 ```shell
 $ npx wrangler login
 ```
+
+## Deployment
+
+### Generate .env file for environment
+
+`bb dot:env --deploy-env <env_name>`
+
+### Deploy app
+
+`bb deploy:app --deploy-env <env_name>`
+
+### Publish site
+
+#### Linux
+
+`bb publish:site --deploy-env <env-name>`
+
+#### Windows
+
+In case the `bb publish:site` task doesn't work on your windows configuration,
+deployment can be done through `wrangler`
+
+`wrangler publish -c .\wrangler.toml --env <env_name>`

--- a/three-id/src/hooks/account.ts
+++ b/three-id/src/hooks/account.ts
@@ -5,7 +5,7 @@ const useAccount = () => {
   const [account, setAccount] = useState<undefined | null | string>(undefined);
 
   useEffect(() => {
-    const sub = getAccountObs().subscribe(async (changedAccount) => {
+    const sub = getAccountObs().subscribe((changedAccount) => {
       if (changedAccount !== undefined && changedAccount !== account) {
         setAccount(changedAccount);
       }

--- a/three-id/src/hooks/account.ts
+++ b/three-id/src/hooks/account.ts
@@ -6,18 +6,16 @@ const useAccount = () => {
 
   useEffect(() => {
     const sub = getAccountObs().subscribe(async (changedAccount) => {
-      if (changedAccount !== account) {
-        const provider = await connect(false);
-        if (provider) {
-          const account = await provider.getSigner().getAddress();
-          setAccount(account);
-        } else {
-          throw new Error("Provider and address mismatch");
-        }
+      if (changedAccount !== undefined && changedAccount !== account) {
+        setAccount(changedAccount);
       }
     });
 
-    connect(false);
+    const asyncFn = async () => {
+      await connect(false);
+    };
+
+    asyncFn();
 
     return () => {
       sub.unsubscribe();

--- a/three-id/src/hooks/account.ts
+++ b/three-id/src/hooks/account.ts
@@ -5,9 +5,15 @@ const useAccount = () => {
   const [account, setAccount] = useState<undefined | null | string>(undefined);
 
   useEffect(() => {
-    const sub = getAccountObs().subscribe((changedAccount) => {
+    const sub = getAccountObs().subscribe(async (changedAccount) => {
       if (changedAccount !== account) {
-        setAccount(changedAccount);
+        const provider = await connect(false);
+        if (provider) {
+          const account = await provider.getSigner().getAddress();
+          setAccount(account);
+        } else {
+          throw new Error("Provider and address mismatch");
+        }
       }
     });
 

--- a/three-id/src/hooks/sdkAuth.ts
+++ b/three-id/src/hooks/sdkAuth.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+import { getIsAuthObs } from "../provider/kubelt";
+
+const useSDKAuth = () => {
+  const [auth, setAuth] = useState<any>();
+
+  useEffect(() => {
+    const sub = getIsAuthObs().subscribe(async (isAuth) => {
+      if (!auth && isAuth) {
+        setAuth(true);
+      } else if (auth && !isAuth) {
+        setAuth(false);
+      }
+    });
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, []);
+
+  return auth;
+};
+
+export default useSDKAuth;

--- a/three-id/src/hooks/sdkAuth.ts
+++ b/three-id/src/hooks/sdkAuth.ts
@@ -5,7 +5,7 @@ const useSDKAuth = () => {
   const [auth, setAuth] = useState<any>();
 
   useEffect(() => {
-    const sub = getIsAuthObs().subscribe(async (isAuth) => {
+    const sub = getIsAuthObs().subscribe((isAuth) => {
       if (!auth && isAuth) {
         setAuth(true);
       } else if (auth && !isAuth) {

--- a/three-id/src/provider/kubelt.ts
+++ b/three-id/src/provider/kubelt.ts
@@ -102,13 +102,9 @@ export const kbGetClaims = async (): Promise<string[]> => {
 
   try {
     claims = await sdkWeb?.node_v1?.oort.claims(sdk);
-    console.log(claims)
   } catch (e) {
-    console.error(e);
     console.warn("Failed to get claims, falling back to empty array");
   }
-
-  if (!claims) throw new Error("Null claims returned. This should not happen.");
 
   return claims;
 };

--- a/three-id/src/provider/kubelt.ts
+++ b/three-id/src/provider/kubelt.ts
@@ -48,6 +48,7 @@ export const authenticate = async (
         restoredSdk,
         address
       );
+
       if (isLoggedIn) {
         sdk = restoredSdk;
 

--- a/three-id/src/provider/kubelt.ts
+++ b/three-id/src/provider/kubelt.ts
@@ -156,3 +156,5 @@ export const kbSetProfile = async (core: string, updatedProfile: Profile) => {
   });
   return profile;
 };
+
+export const getIsAuthObs = () => isAuthSubj.asObservable();

--- a/three-id/src/provider/kubelt.ts
+++ b/three-id/src/provider/kubelt.ts
@@ -106,7 +106,7 @@ export const kbGetClaims = async (
   const address = await signer.getAddress();
 
   try {
-    claims = await sdkWeb?.node_v1?.oort.claims(sdk, address);
+    claims = await sdkWeb?.node_v1?.oort.claims(sdk);
   } catch (e) {
     console.error(e);
     console.warn("Failed to get claims, falling back to empty array");

--- a/three-id/src/provider/kubelt.ts
+++ b/three-id/src/provider/kubelt.ts
@@ -97,16 +97,12 @@ export const isAuthenticated = async (address: string | null | undefined) => {
   return isAuth || isAuthSDK;
 };
 
-export const kbGetClaims = async (
-  provider: ethers.providers.Web3Provider
-): Promise<string[]> => {
+export const kbGetClaims = async (): Promise<string[]> => {
   let claims: string[] = ["3iD.enter"];
-
-  const signer = provider.getSigner();
-  const address = await signer.getAddress();
 
   try {
     claims = await sdkWeb?.node_v1?.oort.claims(sdk);
+    console.log(claims)
   } catch (e) {
     console.error(e);
     console.warn("Failed to get claims, falling back to empty array");

--- a/three-id/src/provider/web3.ts
+++ b/three-id/src/provider/web3.ts
@@ -19,16 +19,12 @@ export const clearAccount = async (purge: boolean = false) => {
   // We force app wide refresh
   // this has to be handled in views
   // or layouts
-  console.debug(
-    `WEB3:CLEAR:Clearing account subject ${accountSubj.getValue()}`
-  );
   accountSubj.next(null);
 
   // This can remove the SDK from ls
   // so authentication is forced
   // and signing is requested again
   if (purge) {
-    console.debug(`WEB3:CLEAR:Purge detected. Clearing targets.`);
     localStorage.clear();
 
     // Not needed yet
@@ -37,17 +33,10 @@ export const clearAccount = async (purge: boolean = false) => {
 };
 
 const handleAccountsChanged = async (accounts: string[]) => {
-  console.debug(`WEB3: Handling accounts changed ${accounts}`);
-
   if (accounts.length > 0) {
-    console.debug(`WEB3: Detected accounts`);
-
     try {
-      const currentAccount = accountSubj.getValue();
-
       const provider = await connect(false);
       const account = await provider.getSigner().getAddress();
-      console.debug(`WEB3: Identified signer account ${account}`);
 
       // We want to make sure that the used account
       // is the same as the signer account;
@@ -59,16 +48,13 @@ const handleAccountsChanged = async (accounts: string[]) => {
         // unless the value changed
         if (account !== accountSubj.getValue()) {
           accountSubj.next(account);
-          console.debug(
-            `WEB3: Succesfully updated account observable from ${currentAccount} to ${account}`
-          );
         }
       }
     } catch (e) {
       console.error(`WEB3: ${e}`);
     }
   } else {
-    console.debug(`WEB3: No accounts detected`);
+    console.warn(`WEB3: No accounts detected`);
 
     await clearAccount();
   }

--- a/three-id/src/provider/web3.ts
+++ b/three-id/src/provider/web3.ts
@@ -9,31 +9,93 @@ const eth = (window as any).ethereum;
 
 export const isMetamask = () => eth?.isMetaMask === true;
 
-export const clearAccount = async () => {
+/**
+ * Clear account behavior (null) allowing observers to
+ * handle cleared accounts
+ *
+ * @param purge If true, local and session storages will be cleared
+ */
+export const clearAccount = async (purge: boolean = false) => {
+  // We force app wide refresh
+  // this has to be handled in views
+  // or layouts
+  console.debug(
+    `WEB3:CLEAR:Clearing account subject ${accountSubj.getValue()}`
+  );
   accountSubj.next(null);
 
-  sessionStorage.clear();
-  localStorage.clear();
+  // This can remove the SDK from ls
+  // so authentication is forced
+  // and signing is requested again
+  if (purge) {
+    console.debug(`WEB3:CLEAR:Purge detected. Clearing targets.`);
+    localStorage.clear();
+
+    // Not needed yet
+    // sessionStorage.clear();
+  }
 };
 
-const handleAccountsChanged = (accounts: string[]) => {
-  const currentAccount = accountSubj.getValue();
+const handleAccountsChanged = async (accounts: string[]) => {
+  console.debug(`WEB3: Handling accounts changed ${accounts}`);
+
   if (accounts.length > 0) {
-    if (accounts[0] !== currentAccount) {
-      accountSubj.next(accounts[0]);
+    console.debug(`WEB3: Detected accounts`);
+
+    try {
+      const currentAccount = accountSubj.getValue();
+
+      const provider = await connect(false);
+      const account = await provider.getSigner().getAddress();
+      console.debug(`WEB3: Identified signer account ${account}`);
+
+      // We want to make sure that the used account
+      // is the same as the signer account;
+      // Getting address via signer will generate
+      // a properly cased address string.
+      if (account.toLowerCase() === accounts[0].toLowerCase()) {
+        // We don't want to force unnecessary refreshes
+        // to subscribers so we don't update
+        // unless the value changed
+        if (account !== accountSubj.getValue()) {
+          accountSubj.next(account);
+          console.debug(
+            `WEB3: Succesfully updated account observable from ${currentAccount} to ${account}`
+          );
+        }
+      }
+    } catch (e) {
+      console.error(`WEB3: ${e}`);
     }
   } else {
-    accountSubj.next(null);
+    console.debug(`WEB3: No accounts detected`);
+
+    await clearAccount();
   }
 };
 
 eth?.on("accountsChanged", handleAccountsChanged);
 
+/**
+ * This method forces accounts to refresh
+ * by calling `eth_accounts` provider RPC
+ * can be used to check if user is already
+ * connected to the domain
+ */
 export const forceAccounts = async () => {
-  const accounts = (await eth?.request({ method: "eth_accounts" })) || [];
-  handleAccountsChanged(accounts);
+  const accounts = await eth?.request({ method: "eth_accounts" });
+  if (accounts) {
+    handleAccountsChanged(accounts);
+  }
 };
 
+/**
+ * General purpose method that can be used throughout to get access to the current web3 provider.
+ * If it doesn't exist, the provider will be created and set up.
+ *
+ * @param resync If true, will force a prompt for accounts even if they are already connected
+ * @returns available web3 provider
+ */
 export const connect = async (
   resync: boolean = true
 ): Promise<ethers.providers.Web3Provider> => {
@@ -42,11 +104,15 @@ export const connect = async (
   }
 
   if (resync && !accountSubj.getValue()) {
+    // This just fakes account disconnection
+    // if users would come back they would find their
+    // account still connected
     await web3Provider?.send("wallet_requestPermissions", [
       { eth_accounts: {} },
     ]);
+
+    await forceAccounts();
   }
-  await forceAccounts();
 
   return web3Provider;
 };

--- a/three-id/src/provider/web3.ts
+++ b/three-id/src/provider/web3.ts
@@ -11,7 +11,9 @@ export const isMetamask = () => eth?.isMetaMask === true;
 
 export const clearAccount = async () => {
   accountSubj.next(null);
+
   sessionStorage.clear();
+  localStorage.clear();
 };
 
 const handleAccountsChanged = (accounts: string[]) => {

--- a/three-id/src/screens/AuthLayout.tsx
+++ b/three-id/src/screens/AuthLayout.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 
 import { Image, ScrollView, View, Text, Pressable } from "react-native";
+import { console_log } from "../../../packages/sdk-web/lib/taoensso.encore";
 import useAccount from "../hooks/account";
 import useSDKAuth from "../hooks/sdkAuth";
 import { authenticate, isAuthenticated, kbGetClaims } from "../provider/kubelt";
@@ -19,8 +20,8 @@ export default function Layout({
   const claimsRedirect = async (claim: string) => {
     claim = claim.trim().toLowerCase();
 
-    const provider = await connect(false);
-    const claims = await kbGetClaims(provider);
+    const claims = await kbGetClaims();
+    console_log(claims)
     if (!claims.includes(claim)) {
       return navigation.navigate("Landing");
     }

--- a/three-id/src/screens/AuthLayout.tsx
+++ b/three-id/src/screens/AuthLayout.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { Image, ScrollView, View, Text, Pressable } from "react-native";
 import useAccount from "../hooks/account";
+import useSDKAuth from "../hooks/sdkAuth";
 import { authenticate, isAuthenticated, kbGetClaims } from "../provider/kubelt";
 import { connect } from "../provider/web3";
 
@@ -13,12 +14,12 @@ export default function Layout({
   navigation: any;
 }) {
   const account = useAccount();
+  const sdkAuth = useSDKAuth();
 
   const claimsRedirect = async (claim: string) => {
     claim = claim.trim().toLowerCase();
 
     const provider = await connect(false);
-
     const claims = await kbGetClaims(provider);
     if (!claims.includes(claim)) {
       return navigation.navigate("Landing");
@@ -53,7 +54,7 @@ export default function Layout({
     if (account) {
       asyncFn();
     }
-  }, [account]);
+  }, [account, sdkAuth]);
 
   return (
     <View

--- a/three-id/src/screens/AuthLayout.tsx
+++ b/three-id/src/screens/AuthLayout.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect } from "react";
 
 import { Image, ScrollView, View, Text, Pressable } from "react-native";
-import { console_log } from "../../../packages/sdk-web/lib/taoensso.encore";
 import useAccount from "../hooks/account";
 import useSDKAuth from "../hooks/sdkAuth";
 import { authenticate, isAuthenticated, kbGetClaims } from "../provider/kubelt";
-import { connect } from "../provider/web3";
+import { connect, forceAccounts } from "../provider/web3";
 
 export default function Layout({
   children,
@@ -21,7 +20,6 @@ export default function Layout({
     claim = claim.trim().toLowerCase();
 
     const claims = await kbGetClaims();
-    console_log(claims)
     if (!claims.includes(claim)) {
       return navigation.navigate("Landing");
     }
@@ -36,16 +34,17 @@ export default function Layout({
       const claim = "3id.enter";
 
       if (await isAuthenticated(account)) {
-        await claimsRedirect(claim);
+        return claimsRedirect(claim);
       } else {
         const provider = await connect(false);
+
         await authenticate(provider);
 
         const signer = provider.getSigner();
         const address = await signer.getAddress();
 
         if (await isAuthenticated(address)) {
-          await claimsRedirect(claim);
+          return claimsRedirect(claim);
         } else {
           return navigation.navigate("Landing");
         }
@@ -56,6 +55,14 @@ export default function Layout({
       asyncFn();
     }
   }, [account, sdkAuth]);
+
+  useEffect(() => {
+    const asyncFn = async () => {
+      await forceAccounts();
+    };
+
+    asyncFn();
+  }, []);
 
   return (
     <View

--- a/three-id/src/screens/funnel/Auth.tsx
+++ b/three-id/src/screens/funnel/Auth.tsx
@@ -1,4 +1,3 @@
-import Constants from "expo-constants";
 import React, { useEffect } from "react";
 
 import useAccount from "../../hooks/account";
@@ -23,9 +22,7 @@ export default function Auth({ navigation }: { navigation: any }) {
       throw new Error("Account is null");
     }
 
-    const provider = await connect(false);
-
-    const claims = await kbGetClaims(provider);
+    const claims = await kbGetClaims();
     if (claims.includes(claim)) {
       return navigation.navigate("Settings");
     } else {

--- a/three-id/src/screens/funnel/Gate.tsx
+++ b/three-id/src/screens/funnel/Gate.tsx
@@ -13,7 +13,7 @@ export default function Gate({ navigation }: { navigation: any }) {
   useEffect(() => {
     if (account === null) {
       // User maybe disconnected in the process
-      navigation.navigate("Landing");
+      return navigation.navigate("Landing");
     }
   }, [account]);
 

--- a/three-id/src/screens/funnel/Landing.tsx
+++ b/three-id/src/screens/funnel/Landing.tsx
@@ -3,32 +3,31 @@ import React, { useEffect } from "react";
 import { Pressable, Text, View } from "react-native";
 import useAccount from "../../hooks/account";
 import { isAuthenticated, kbGetClaims } from "../../provider/kubelt";
-import { connect, forceAccounts, isMetamask } from "../../provider/web3";
+import { connect, isMetamask } from "../../provider/web3";
 import Layout from "../Layout";
 
 export default function Landing({ navigation }: { navigation: any }) {
   const account = useAccount();
+
   const [hasMetamask, setHasMetamask] = React.useState(false);
 
   const claimsRedirect = async (claim: string) => {
     claim = claim.trim().toLowerCase();
 
     const claims = await kbGetClaims();
-    if (!claims.includes(claim)) {
+    if (claims.includes(claim)) {
       return navigation.navigate("Settings");
     }
   };
 
   useEffect(() => {
-    if (account === null) {
-      return navigation.navigate("Landing");
-    }
-
     const asyncFn = async () => {
+      setHasMetamask(isMetamask());
+
       const claim = "3id.enter";
 
       if (await isAuthenticated(account)) {
-        await claimsRedirect(claim);
+        return claimsRedirect(claim);
       } else {
         return navigation.navigate("Auth");
       }
@@ -38,16 +37,6 @@ export default function Landing({ navigation }: { navigation: any }) {
       asyncFn();
     }
   }, [account]);
-
-  useEffect(() => {
-    setHasMetamask(isMetamask());
-
-    const asyncFn = async () => {
-      await forceAccounts();
-    };
-
-    asyncFn();
-  }, []);
 
   return (
     <Layout>
@@ -83,8 +72,8 @@ export default function Landing({ navigation }: { navigation: any }) {
             borderColor: "#D1D5DB",
             borderWidth: 1,
           }}
-          onPress={() => connect()}
-          disabled={!hasMetamask}
+          onPress={() => connect(true)}
+          disabled={account != null && !hasMetamask}
         >
           <View
             style={{

--- a/three-id/src/screens/funnel/Landing.tsx
+++ b/three-id/src/screens/funnel/Landing.tsx
@@ -13,9 +13,7 @@ export default function Landing({ navigation }: { navigation: any }) {
   const claimsRedirect = async (claim: string) => {
     claim = claim.trim().toLowerCase();
 
-    const provider = await connect(false);
-
-    const claims = await kbGetClaims(provider);
+    const claims = await kbGetClaims();
     if (!claims.includes(claim)) {
       return navigation.navigate("Settings");
     }

--- a/three-id/src/screens/funnel/Landing.tsx
+++ b/three-id/src/screens/funnel/Landing.tsx
@@ -2,12 +2,44 @@ import React, { useEffect } from "react";
 
 import { Pressable, Text, View } from "react-native";
 import useAccount from "../../hooks/account";
+import { isAuthenticated, kbGetClaims } from "../../provider/kubelt";
 import { connect, forceAccounts, isMetamask } from "../../provider/web3";
 import Layout from "../Layout";
 
 export default function Landing({ navigation }: { navigation: any }) {
   const account = useAccount();
   const [hasMetamask, setHasMetamask] = React.useState(false);
+
+  const claimsRedirect = async (claim: string) => {
+    claim = claim.trim().toLowerCase();
+
+    const provider = await connect(false);
+
+    const claims = await kbGetClaims(provider);
+    if (!claims.includes(claim)) {
+      return navigation.navigate("Settings");
+    }
+  };
+
+  useEffect(() => {
+    if (account === null) {
+      return navigation.navigate("Landing");
+    }
+
+    const asyncFn = async () => {
+      const claim = "3id.enter";
+
+      if (await isAuthenticated(account)) {
+        await claimsRedirect(claim);
+      } else {
+        return navigation.navigate("Auth");
+      }
+    };
+
+    if (account) {
+      asyncFn();
+    }
+  }, [account]);
 
   useEffect(() => {
     setHasMetamask(isMetamask());
@@ -18,12 +50,6 @@ export default function Landing({ navigation }: { navigation: any }) {
 
     asyncFn();
   }, []);
-
-  useEffect(() => {
-    if (account) {
-      navigation.navigate("Auth");
-    }
-  }, [account]);
 
   return (
     <Layout>

--- a/three-id/src/screens/profile/Settings.tsx
+++ b/three-id/src/screens/profile/Settings.tsx
@@ -131,7 +131,7 @@ export default function Settings({
         >
           <Text
             style={{
-              paddingBottom: "1em",
+              paddingBottom: 41,
               fontFamily: "Inter_700Bold",
               fontSize: 24,
               fontWeight: "700",
@@ -341,6 +341,7 @@ export default function Settings({
                       lineHeight: 24,
                       shadowColor: "#D1D5DB",
                       shadowRadius: 2,
+                      color: "#6B7280",
                     }}
                     value={profile.website}
                     onChangeText={(website) =>
@@ -414,10 +415,11 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     shadowColor: "#D1D5DB",
     shadowRadius: 2,
+    color: "#6B7280",
   },
   textarea: {
     height: 66,
-    padding: 4,
+    paddingLeft: 5,
     shadowColor: "#D1D5DB",
     shadowRadius: 2,
     borderWidth: 1,
@@ -426,6 +428,8 @@ const styles = StyleSheet.create({
     fontStyle: "normal",
     fontSize: 16,
     lineHeight: 24,
+    color: "#6B7280",
+    resizeMode: "vertical",
   },
   view: {
     borderWidth: 0.5,
@@ -436,7 +440,7 @@ const styles = StyleSheet.create({
   label: {
     fontFamily: "Inter_500Medium",
     fontSize: 14,
-    fontWeight: "bold",
+    fontWeight: "500",
     lineHeight: 20,
     color: "#374151",
     paddingBottom: 7,

--- a/three-id/src/screens/profile/Settings.tsx
+++ b/three-id/src/screens/profile/Settings.tsx
@@ -4,10 +4,7 @@ import { StyleSheet, Pressable, Text, View, TextInput } from "react-native";
 
 import useAccount from "../../hooks/account";
 import Layout from "../AuthLayout";
-import {
-  kbGetProfile,
-  kbSetProfile,
-} from "../../provider/kubelt";
+import { kbGetProfile, kbSetProfile } from "../../provider/kubelt";
 import { Profile } from "../../types/Profile";
 
 import { Entypo } from "@expo/vector-icons";
@@ -40,7 +37,7 @@ export default function Settings({
 
   const [profile, setProfile] = useState<Profile>(emptyProfile);
 
-  const { getItem, setItem } = useAsyncStorage("kubelt_sdk");
+  const { getItem, setItem } = useAsyncStorage("kubelt:profile");
 
   const readItemFromStorage = async () => {
     const item = await getItem();
@@ -77,7 +74,6 @@ export default function Settings({
             console.warn("Failed to write profile to storage");
           }
         } catch (e) {
-          console.error(e);
           console.warn("Failed to retrieve persisted profile");
         }
       } else {
@@ -106,7 +102,6 @@ export default function Settings({
           console.warn("Failed to write profile to storage");
         }
       } catch (e) {
-        console.error(e);
         console.warn("Failed to persist profile");
       }
     }

--- a/three-id/src/screens/profile/Settings.tsx
+++ b/three-id/src/screens/profile/Settings.tsx
@@ -5,7 +5,6 @@ import { StyleSheet, Pressable, Text, View, TextInput } from "react-native";
 import useAccount from "../../hooks/account";
 import Layout from "../AuthLayout";
 import {
-  isAuthenticated,
   kbGetProfile,
   kbSetProfile,
 } from "../../provider/kubelt";
@@ -41,8 +40,7 @@ export default function Settings({
 
   const [profile, setProfile] = useState<Profile>(emptyProfile);
 
-  // TODO: Use correct storage key
-  const { getItem, setItem } = useAsyncStorage("@storage_key");
+  const { getItem, setItem } = useAsyncStorage("kubelt_sdk");
 
   const readItemFromStorage = async () => {
     const item = await getItem();


### PR DESCRIPTION
# Description

This PR adds claims checking functionality to the 3iD funnel so that users that can access 3iD will be redirected to their profile settings page if `3iD.enter` claim exists.

Closes #574 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [x] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
