### PR TITLE
fix(3iD): inject zone ID into GHA build context

### DIFF
--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -77,6 +77,8 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           # The Cloudflare API token used by wrangler.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Cloudflare zone identifier for threeid.xyz.
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: bb deploy:app --deploy-env next
 
       - name: run smoke tests
@@ -92,4 +94,6 @@ jobs:
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
           # The Cloudflare API token used by wrangler.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Cloudflare zone identifier for threeid.xyz.
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
         run: bb test:smoke --deploy-env next

--- a/three-id/bb.edn
+++ b/three-id/bb.edn
@@ -475,6 +475,7 @@
   -env:robert-kv-app-id (system/env "ROBERT_KV_APP_ID")
 
   -env:cloudflare-api-token (system/env "CLOUDFLARE_API_TOKEN")
+  -env:cloudflare-zone-id (system/env "CLOUDFLARE_ZONE_ID")
   -env:datadog-client-token (system/env "DATADOG_CLIENT_TOKEN")
 
   ;; environment
@@ -496,6 +497,7 @@
              -env:current-kv-app-id
              -env:current-url
              -env:cloudflare-api-token
+             -env:cloudflare-zone-id
              -env:datadog-client-token]
    :task (do
            {:robert/account-id -env:robert-account-id
@@ -512,6 +514,7 @@
             :current/kv-app-id -env:current-kv-app-id
             :current/url -env:current-url
             :cloudflare/api-token -env:cloudflare-api-token
+            :cloudflare/zone-id -env:cloudflare-zone-id
             :datadog/client-token -env:datadog-client-token})}
 
   -deploy:edn
@@ -599,6 +602,11 @@
    :task (let [secret (:cloudflare/api-token -env:merged)]
            (github.secret/set "CLOUDFLARE_API_TOKEN" secret))}
 
+  -gh:secret:cloudflare-zone-id
+  {:depends [-env:merged]
+   :task (let [secret (:cloudflare/zone-id -env:merged)]
+           (github.secret/set "CLOUDFLARE_ZONE_ID" secret))}
+
   -gh:secret:datadog-client-token
   {:depends [-env:merged]
    :task (let [secret (:datadog/client-token -env:merged)]
@@ -642,6 +650,7 @@
   gh:secret:init
   {:doc "Set up secrets in GitHub Actions"
    :depends [-gh:secret:cloudflare-api-token
+             -gh:secret:cloudflare-zone-id
              -gh:secret:datadog-client-token
              -gh:secret:admin-account-id
              -gh:secret:next-kv-app-id


### PR DESCRIPTION
# Description

Injects a missing value (`CLOUDFLARE_ZONE_ID`) into the GHA build context.