### PR TITLE
chore(3iD): build against "develop" version of sdk-web

### DIFF
--- a/.github/workflows/next.yaml
+++ b/.github/workflows/next.yaml
@@ -58,7 +58,7 @@ jobs:
         run: npm ci
 
       - name: build sdk-web
-        run: npm run build:sdk-web:release
+        run: npm run build:sdk-web:develop
 
       - name: install node dependencies (for three-id)
         working-directory: ./three-id

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
         run: npm ci
 
       - name: build sdk-web
-        run: npm run build:sdk-web:release
+        run: npm run build:sdk-web:develop
 
       - name: set tag as RELEASE_VERSION environment variable
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

Update GHA workflows for 3iD `next` and `release` to build the `develop` version of `sdk-web`. The whole application is bundled and optimized by `babel` and other JS ecosystem machinery and the optimization performed by a release build only makes the whole-app compilation more fragile. 