### PR TITLE
chore(three-id): Add claims test which confirms when a wallet is allowed, it can pass gate

### DIFF
--- a/three-id/src/screens/AuthLayout.tsx
+++ b/three-id/src/screens/AuthLayout.tsx
@@ -116,6 +116,7 @@ export default function Layout({
               }}
             >
               <Text
+                testID="wallet-address"
                 style={{
                   paddingHorizontal: 37.5,
                   fontFamily: "Manrope_700Bold",

--- a/three-id/tests/e2e/specs/gate-allowed-spec.js
+++ b/three-id/tests/e2e/specs/gate-allowed-spec.js
@@ -1,5 +1,11 @@
 describe('Metamask', () => {
   context('Gate commands', () => {
+    it(`Ensure correct wallet address is being used for gate test`, () => {
+      cy.getMetamaskWalletAddress().then(address => {
+        expect(address).to.be.eq('0xC5221bd8a49A855DB0E5D2dee9e53d1C3Dcaceb1');
+      });
+    });
+
     it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
       cy.visit('/');
       cy.findByTestId('connect-wallet').click();
@@ -9,9 +15,15 @@ describe('Metamask', () => {
     });
 
     it(`confirmMetamaskSignatureRequest should succeed`, () => {
+      cy.wait(5000);
       cy.confirmMetamaskSignatureRequest().then(signed => {
         expect(signed).to.be.true;
       });
+    });
+
+    it(`Allowed wallet should be let into gated application`, () => {
+      cy.url().should('eq', 'http://localhost:19006/settings');
+      cy.findByTestId('wallet-address').contains('0xC5...ceb1');
     });
   });
 });


### PR DESCRIPTION
# Description

Agreeing to a Signature Request with a wallet that has claims for 3iD allows it to pass the gate.

Investigated flaky behaviour for `sign` which pops up the extension but does it AFTER synpress triggers the click on signature request.

Issue: https://github.com/kubelt/kubelt/issues/602

![Screen Shot 2022-07-26 at 12 38 10](https://user-images.githubusercontent.com/24436662/181062178-bcb98213-58f3-4df6-983e-c1d958a6e0e1.png)


## Type of change

- [x] Automation test

# How Has This Been Tested?

- [x] Ran tests several times locally 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
