### PR TITLE
chore(sdk-api): Refactor sdk oort rpc api

### DIFF
--- a/3iD/src/provider/kubelt.ts
+++ b/3iD/src/provider/kubelt.ts
@@ -113,41 +113,36 @@ export const kbGetClaims = async (): Promise<string[]> => {
 };
 export const kbGetProfile = async (core: string) => {
   const profile: Profile = await new Promise((resolve, reject) => {
-    sdkWeb?.node_v1?.oort.rpcApi(sdk, core).then((api: any) => {
-      // TODO: async / await? 🤔
-      sdkWeb?.node_v1?.oort
-        .callRpcClient(sdk, api, {
-          method: ["kb", "get-profile"],
-          params: [],
-        })
-        .then((x: any) => {
-          if (x?.body?.error) {
-            reject(x.body.error);
-          } else {
-            resolve(x?.body?.result);
-          }
-        });
-    });
+    sdkWeb?.node_v1?.oort
+      .callRpc(sdk, {
+        method: ["kb", "get-profile"],
+        params: [],
+      })
+      .then((x: any) => {
+        if (x?.body?.error) {
+          reject(x.body.error);
+        } else {
+          resolve(x?.body?.result);
+        }
+      });
   });
   return profile;
 };
 
 export const kbSetProfile = async (core: string, updatedProfile: Profile) => {
   const profile = await new Promise((resolve, reject) => {
-    sdkWeb?.node_v1?.oort.rpcApi(sdk, core).then((api: any) => {
-      sdkWeb?.node_v1?.oort
-        .callRpcClient(sdk, api, {
-          method: ["kb", "set-profile"],
-          params: { profile: updatedProfile },
-        })
-        .then((x: any) => {
-          if (x?.body?.error) {
-            reject(x.body.error);
-          } else {
-            resolve(x?.body?.result);
-          }
-        });
-    });
+    sdkWeb?.node_v1?.oort
+      .callRpc(sdk, {
+        method: ["kb", "set-profile"],
+        params: { profile: updatedProfile },
+      })
+      .then((x: any) => {
+        if (x?.body?.error) {
+          reject(x.body.error);
+        } else {
+          resolve(x?.body?.result);
+        }
+      });
   });
   return profile;
 };

--- a/src/main/com/kubelt/lib/rpc.cljs
+++ b/src/main/com/kubelt/lib/rpc.cljs
@@ -33,7 +33,7 @@
              (lib.promise/then resolve)
              (lib.promise/catch reject)))))))
 
-(defn rpc-call-js [sys api args]
+(defn call-rpc-with-api-js [sys api args]
   (let [core (-> (get-in sys [:crypto/session :vault/tokens]) keys first)]
     (-> (assoc sys :crypto/wallet {:wallet/address core})
         (rpc-call& api (update (js->clj args :keywordize-keys true) :method #(mapv keyword %)))

--- a/src/main/com/kubelt/sdk.cljs
+++ b/src/main/com/kubelt/sdk.cljs
@@ -54,8 +54,8 @@
        ;; oort
        :oort #js {:authenticate sdk.v1.oort/authenticate-js!
                   :claims sdk.v1.oort/claims-js
-                  :callRpc sdk.v1.oort/call-rpc-api-js
-                  :callRpcClient lib.rpc/rpc-call-js
+                  :callRpc sdk.v1.oort/call-rpc-js
+                  :callRpcWithApi lib.rpc/call-rpc-with-api-js
                   :rpcApi sdk.v1.oort/rpc-api-js
                   :isLoggedIn sdk.v1.oort/logged-in-js?
                   :setWallet sdk.v1.oort/set-wallet-js}


### PR DESCRIPTION
# Description

These changes [ease](https://github.com/kubelt/kubelt/pull/616/files#diff-ae67f4f0237d224aaa55cf3dad4700e1659726971f332b2173cb80c14599d1db) the rpc calls from js env, avoiding to explicitly
obtain the sdk-rpc-api to allow sdk-rpc calls


## Type of change

Refactoring

# How Has This Been Tested?

Existent tests should add coverage

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation website
- [X] I have made corresponding changes to the literal docs
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
