### PR TITLE
chore(3iD): Add tests for deny flow with multiple ETH accounts on Metamask

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -25,7 +25,7 @@ jobs:
             dapp: 'dapp/**'
             www: 'www/**'
             ext: 'ext/**'
-            3iD: '3iD/**'
+            three-id: '3iD/**'
 
   # To detect lint errors across namespaces in your project, a cache is
   # needed. A cache will be created at .clj-kondo/ when you run

--- a/3iD/src/screens/funnel/Gate.tsx
+++ b/3iD/src/screens/funnel/Gate.tsx
@@ -87,6 +87,7 @@ export default function Gate({ navigation }: { navigation: any }) {
           onPress={() => tryDifferentWallet()}
         >
           <Text
+            testID="try-different-wallet"
             style={{
               fontFamily: "Manrope_700Bold",
               fontSize: 16,

--- a/3iD/tests/e2e/specs/gate-denied-spec.js
+++ b/3iD/tests/e2e/specs/gate-denied-spec.js
@@ -1,0 +1,82 @@
+describe('Metamask', () => {
+  context('Gate commands', () => {
+    it(`Switch Metamask account to wallet that does not have claims`, () => {
+      // Need to disconnect from dapp to ensure state is cleared.
+      cy.disconnectMetamaskWalletFromDapp().then(disconnected => {
+        expect(disconnected).to.be.true;
+      });
+      // `switchMetamaskAccount` function doesn't work because multiple accounts
+      // with 0 ETH balance do not get automatically imported.
+      // However, it is possible to use `createMetamaskAccount` with the second
+      // account's name and that will result in the same ETH address being imported.
+      cy.createMetamaskAccount('3id test - denied').then(switched => {
+        expect(switched).to.be.true;
+      });
+    });
+
+    it(`Ensure correct wallet address is being used for gate denied test`, () => {
+      cy.getMetamaskWalletAddress().then(address => {
+        expect(address).to.be.eq('0xb2a0Ad4bc89BD11B0E293F351DbcFDB31cd1caA6');
+      });
+    });
+
+    it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
+      cy.visit('/');
+      cy.findByTestId('connect-wallet').click();
+      cy.acceptMetamaskAccess().then(connected => {
+        expect(connected).to.be.true;
+      });
+    });
+
+    it(`confirmMetamaskSignatureRequest should succeed`, () => {
+      cy.wait(5000);
+      cy.confirmMetamaskSignatureRequest().then(signed => {
+        expect(signed).to.be.true;
+      });
+    });
+
+    it(`Denied wallet should be redirected to gate`, () => {
+      cy.url().should('eq', 'http://localhost:19006/gate');
+      cy.findByTestId('try-different-wallet').click();
+      cy.url().should('eq', 'http://localhost:19006/');
+    });
+
+
+    it(`Switch to allowed wallet to pass the gate`, () => {
+      // Need to disconnect from dapp to ensure state is cleared.
+      cy.disconnectMetamaskWalletFromDapp().then(disconnected => {
+        expect(disconnected).to.be.true;
+      });
+      // `Account 1` is how the default wallet is named when imported.
+      cy.switchMetamaskAccount('Account 1').then(switched => {
+        expect(switched).to.be.true;
+      });
+    });
+
+    it(`Ensure correct wallet address is being used after switching`, () => {
+      cy.getMetamaskWalletAddress().then(address => {
+        expect(address).to.be.eq('0xC5221bd8a49A855DB0E5D2dee9e53d1C3Dcaceb1');
+      });
+    });
+
+    it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
+      cy.visit('/');
+      cy.findByTestId('connect-wallet').click();
+      cy.acceptMetamaskAccess().then(connected => {
+        expect(connected).to.be.true;
+      });
+    });
+
+    it(`confirmMetamaskSignatureRequest should succeed`, () => {
+      cy.wait(5000);
+      cy.confirmMetamaskSignatureRequest().then(signed => {
+        expect(signed).to.be.true;
+      });
+    });
+
+    it(`Allowed wallet should be let into gated application`, () => {
+      cy.url().should('eq', 'http://localhost:19006/settings');
+      cy.findByTestId('wallet-address').contains('0xC5...ceb1');
+    });
+  });
+});


### PR DESCRIPTION
# Description

Tests the following flow:
- denied wallet signs
- should get a message to `Try Different Wallet`
- then the account is switched to use an allowed wallet
- allowed wallet signs
- gets accepted into the application

Due to the nature of sessions being saved and a redirect in place from the base route (`/`) to (`/authentication`), it is necessary to disconnect the account from the app for the tests to succeed.

Closes #602 

## Type of change

- [x] Automation test

# How Has This Been Tested?

- [x] Ran test suite locally
- [x] Test run on CI

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes