### PR TITLE
Return camelCase on sdk.oort.callRpc calls

### DIFF
--- a/src/main/com/kubelt/sdk/v1/oort.cljs
+++ b/src/main/com/kubelt/sdk/v1/oort.cljs
@@ -2,6 +2,8 @@
   "Account management."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
+   [camel-snake-kebab.core :as csk]
+   [camel-snake-kebab.extras :as cske]
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.jwt :as lib.jwt]
    [com.kubelt.lib.oort :as lib.oort]
@@ -126,16 +128,16 @@
   ([sys args]
    (let [{:keys [method params]} (js->clj args :keywordize-keys true)]
      (-> (call-rpc& sys
-                          (-> sys :crypto/wallet :wallet/address)
-                          (mapv keyword (js->clj method))
-                          params)
-         (lib.promise/then clj->js)
+                    (-> sys :crypto/wallet :wallet/address)
+                    (mapv keyword (js->clj method))
+                    params)
+         (lib.promise/then #(clj->js (cske/transform-keys csk/->camelCaseString %)))
          (lib.promise/catch clj->js))))
   ([sys method params]
    (let [method (mapv keyword (js->clj method))
          params (js->clj params :keywordize-keys true)]
      (-> (call-rpc& sys (-> sys :crypto/wallet :wallet/address) method params)
-         (lib.promise/then clj->js)
+         (lib.promise/then #(clj->js (cske/transform-keys csk/->camelCaseString %)))
          (lib.promise/catch clj->js)))))
 
 ;; logged-in?

--- a/src/test/com/kubelt/rpc/sdk_test.cljs
+++ b/src/test/com/kubelt/rpc/sdk_test.cljs
@@ -57,3 +57,27 @@
                (finally (done)))))))
 
 
+
+(deftest js-rpc-profile-test
+  (testing "test rpc profile from js env,
+            relates https://github.com/kubelt/kubelt/issues/630"
+    (async done
+           (go
+             (try
+               (let [sys (<p! (sdk/init (t.commons/oort-config)))
+                     wallet (<p! (wallet/load& t.commons/app-name t.commons/test-wallet-name t.commons/test-wallet-password))
+                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet)))
+                     result (-> (<p! (sdk.oort/call-rpc-js
+                                      kbt
+                                      #js ["kb" "get-profile"]
+                                      #js []))
+                                js->clj
+                                (get-in ["body" "result"]))]
+
+                 (is (= #{"profilePicture" "nickname" "job" "location" "website" "email" "bio"}
+                        (set (keys result))))
+                 (is (= #{"name" "imageUrl" "collectionId" "collectionTokenId"} (set (keys (get result "profilePicture"))))))
+               (catch js/Error err (do
+                                     (log/error err)
+                                     (is false err)))
+               (finally (done)))))))


### PR DESCRIPTION
By default we csk/->kebab-case-keyword on  https://github.com/kubelt/kubelt/blob/fix-rpc-call-response-format/src/main/com/kubelt/lib/json.cljc#L27

Closes #630

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] [com.kubelt.rpc.sdk-test/js-rpc-profile-test](https://github.com/kubelt/kubelt/blob/3d91957cad7c0d2a933fe6c9805e262d338c123a/src/test/com/kubelt/rpc/sdk_test.cljs#L61)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation website
- [X] I have made corresponding changes to the literal docs
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
