### PR TITLE
CHORE(3iD-testing): Allow multi-wallet

### DIFF
--- a/3iD/.env.example
+++ b/3iD/.env.example
@@ -15,5 +15,17 @@ DATADOG_APPLICATION_ID=363ca8f1-fcb5-4d22-94c2-739699759278
 DATADOG_SERVICE_NAME=3id-application
 DATADOG_ENV=dev
 
+# TESTING
+
+## General config
 NETWORK_NAME=mainnet
-SECRET_WORDS='your, wallet, sercret, words, here'
+
+### Skips global metamask setup
+### for synpress; this allows us
+### to use different wallets 
+### for different tests
+SKIP_METAMASK_SETUP=true
+
+## Generic config
+CYPRESS_GENERIC_SECRET_WORDS=""
+CYPRESS_GENERIC_ACCOUNT=0x

--- a/3iD/tests/e2e/specs/gate-allowed-spec.js
+++ b/3iD/tests/e2e/specs/gate-allowed-spec.js
@@ -1,29 +1,39 @@
-describe('Metamask', () => {
-  context('Gate commands', () => {
+describe("Metamask", () => {
+  context("Gate commands", () => {
+    before(() => {
+      cy.setupMetamask(Cypress.env("GENERIC_SECRET_WORDS"));
+    });
+
     it(`Ensure correct wallet address is being used for gate test`, () => {
-      cy.getMetamaskWalletAddress().then(address => {
-        expect(address).to.be.eq('0xC5221bd8a49A855DB0E5D2dee9e53d1C3Dcaceb1');
+      cy.getMetamaskWalletAddress().then((address) => {
+        expect(address).to.be.eq(Cypress.env("GENERIC_ACCOUNT"));
       });
     });
 
     it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
-      cy.visit('/');
-      cy.findByTestId('connect-wallet').click();
-      cy.acceptMetamaskAccess().then(connected => {
+      cy.visit("/");
+      cy.findByTestId("connect-wallet").click();
+      cy.acceptMetamaskAccess().then((connected) => {
         expect(connected).to.be.true;
       });
     });
 
     it(`confirmMetamaskSignatureRequest should succeed`, () => {
       cy.wait(5000);
-      cy.confirmMetamaskSignatureRequest().then(signed => {
+      cy.confirmMetamaskSignatureRequest().then((signed) => {
         expect(signed).to.be.true;
       });
     });
 
     it(`Allowed wallet should be let into gated application`, () => {
-      cy.url().should('eq', 'http://localhost:19006/settings');
-      cy.findByTestId('wallet-address').contains('0xC5...ceb1');
+      cy.url().should("eq", "http://localhost:19006/settings");
+
+      const genericAccount = Cypress.env("GENERIC_ACCOUNT");
+      cy.findByTestId("wallet-address").contains(
+        `${genericAccount.substring(0, 4)}...${genericAccount.substring(
+          genericAccount.length - 4
+        )}`
+      );
     });
   });
 });

--- a/3iD/tests/e2e/specs/gate-denied-spec.js
+++ b/3iD/tests/e2e/specs/gate-denied-spec.js
@@ -1,82 +1,91 @@
-describe('Metamask', () => {
-  context('Gate commands', () => {
+describe("Metamask", () => {
+  context("Gate commands", () => {
+    before(() => {
+      cy.setupMetamask(Cypress.env("GENERIC_SECRET_WORDS"));
+    });
+
     it(`Switch Metamask account to wallet that does not have claims`, () => {
       // Need to disconnect from dapp to ensure state is cleared.
-      cy.disconnectMetamaskWalletFromDapp().then(disconnected => {
+      cy.disconnectMetamaskWalletFromDapp().then((disconnected) => {
         expect(disconnected).to.be.true;
       });
       // `switchMetamaskAccount` function doesn't work because multiple accounts
       // with 0 ETH balance do not get automatically imported.
       // However, it is possible to use `createMetamaskAccount` with the second
       // account's name and that will result in the same ETH address being imported.
-      cy.createMetamaskAccount('3id test - denied').then(switched => {
+      cy.createMetamaskAccount("3id test - denied").then((switched) => {
         expect(switched).to.be.true;
       });
     });
 
     it(`Ensure correct wallet address is being used for gate denied test`, () => {
-      cy.getMetamaskWalletAddress().then(address => {
-        expect(address).to.be.eq('0xb2a0Ad4bc89BD11B0E293F351DbcFDB31cd1caA6');
+      cy.getMetamaskWalletAddress().then((address) => {
+        expect(address).to.be.eq("0xb2a0Ad4bc89BD11B0E293F351DbcFDB31cd1caA6");
       });
     });
 
     it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
-      cy.visit('/');
-      cy.findByTestId('connect-wallet').click();
-      cy.acceptMetamaskAccess().then(connected => {
+      cy.visit("/");
+      cy.findByTestId("connect-wallet").click();
+      cy.acceptMetamaskAccess().then((connected) => {
         expect(connected).to.be.true;
       });
     });
 
     it(`confirmMetamaskSignatureRequest should succeed`, () => {
       cy.wait(5000);
-      cy.confirmMetamaskSignatureRequest().then(signed => {
+      cy.confirmMetamaskSignatureRequest().then((signed) => {
         expect(signed).to.be.true;
       });
     });
 
     it(`Denied wallet should be redirected to gate`, () => {
-      cy.url().should('eq', 'http://localhost:19006/gate');
-      cy.findByTestId('try-different-wallet').click();
-      cy.url().should('eq', 'http://localhost:19006/');
+      cy.url().should("eq", "http://localhost:19006/gate");
+      cy.findByTestId("try-different-wallet").click();
+      cy.url().should("eq", "http://localhost:19006/");
     });
-
 
     it(`Switch to allowed wallet to pass the gate`, () => {
       // Need to disconnect from dapp to ensure state is cleared.
-      cy.disconnectMetamaskWalletFromDapp().then(disconnected => {
+      cy.disconnectMetamaskWalletFromDapp().then((disconnected) => {
         expect(disconnected).to.be.true;
       });
       // `Account 1` is how the default wallet is named when imported.
-      cy.switchMetamaskAccount('Account 1').then(switched => {
+      cy.switchMetamaskAccount("Account 1").then((switched) => {
         expect(switched).to.be.true;
       });
     });
 
     it(`Ensure correct wallet address is being used after switching`, () => {
-      cy.getMetamaskWalletAddress().then(address => {
-        expect(address).to.be.eq('0xC5221bd8a49A855DB0E5D2dee9e53d1C3Dcaceb1');
+      cy.getMetamaskWalletAddress().then((address) => {
+        expect(address).to.be.eq(Cypress.env("GENERIC_ACCOUNT"));
       });
     });
 
     it(`acceptMetamaskAccess should accept connection request to metamask`, () => {
-      cy.visit('/');
-      cy.findByTestId('connect-wallet').click();
-      cy.acceptMetamaskAccess().then(connected => {
+      cy.visit("/");
+      cy.findByTestId("connect-wallet").click();
+      cy.acceptMetamaskAccess().then((connected) => {
         expect(connected).to.be.true;
       });
     });
 
     it(`confirmMetamaskSignatureRequest should succeed`, () => {
       cy.wait(5000);
-      cy.confirmMetamaskSignatureRequest().then(signed => {
+      cy.confirmMetamaskSignatureRequest().then((signed) => {
         expect(signed).to.be.true;
       });
     });
 
     it(`Allowed wallet should be let into gated application`, () => {
-      cy.url().should('eq', 'http://localhost:19006/settings');
-      cy.findByTestId('wallet-address').contains('0xC5...ceb1');
+      cy.url().should("eq", "http://localhost:19006/settings");
+
+      const genericAccount = Cypress.env("GENERIC_ACCOUNT");
+      cy.findByTestId("wallet-address").contains(
+        `${genericAccount.substring(0, 4)}...${genericAccount.substring(
+          genericAccount.length - 4
+        )}`
+      );
     });
   });
 });


### PR DESCRIPTION
# Description

Added a new configuration in the .ENV which should allow us to use multiple wallets throughout testing (for example we might need it in the case of invitations where we want to always maintain an account with an invitation that can check the gating to the invitation screen).

Things to note:
- Cypress automagically injects as an environment variable in the testing any env variable that starts with CYPRESS_ or cypress_. We latch onto this mechanism to inject multiple wallet configurations;
- Cypress automagically does wallet setup before tests, so we need to disable that and do it manually;
- If there is a SECRET_WORDS env variables, that will override whatever values sent to setupMetamask, so that needs to be away.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires or is a documentation update

# How Has This Been Tested?

- [x] I've run this manually on my box, with two different wallets as part of the Invite task

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
