### PR TITLE
fix(3iD): redirect to / after sign out

### DIFF
--- a/3iD/src/screens/funnel/Landing.tsx
+++ b/3iD/src/screens/funnel/Landing.tsx
@@ -43,7 +43,7 @@ export default function Landing({ navigation }: { navigation: any }) {
   useEffect(() => {
     const asyncFn = async () => {
       if (!(await otherWalletRequested.getItem())) {
-        await forceAccounts();
+        navigation.navigate("Landing");
       }
     };
 


### PR DESCRIPTION
# Description

Currently if user sign our after refreshing they will be automatically sign in back. To prevent this for now instead of trying different wallet this redirects them to landing page.

- Closes #654 
 
## Type of change

- Bug fix (non-breaking change which fixes an issue)
