### PR TITLE
FIX(3iD): Try restore SDK

### DIFF
--- a/3iD/src/provider/kubelt.ts
+++ b/3iD/src/provider/kubelt.ts
@@ -62,21 +62,21 @@ export const authenticate = async (
   try {
     if (!sdk) {
       sdk = await getSDK();
-
-      const restoredSdk = await sdkWeb.node_v1.restore(sdk);
-
-      // We use isLoggedIn as a way to check if SDK
-      // was persisted, as there is no other way;
-      const isLoggedIn = await sdkWeb.node_v1.oort.isLoggedIn(
-        restoredSdk,
-        address
-      );
-
-      // If TRUE => SDK was persisted and is authenticated
-      if (isLoggedIn) {
-        sdk = restoredSdk;
-      } // IF FALSE => Either not authenticated or not persisted
     }
+
+    const restoredSdk = await sdkWeb.node_v1.restore(sdk);
+
+    // We use isLoggedIn as a way to check if SDK
+    // was persisted, as there is no other way;
+    const isLoggedIn = await sdkWeb.node_v1.oort.isLoggedIn(
+      restoredSdk,
+      address
+    );
+
+    // If TRUE => SDK was persisted and is authenticated
+    if (isLoggedIn) {
+      sdk = restoredSdk;
+    } // IF FALSE => Either not authenticated or not persisted
 
     let isAuth = await isAuthenticated(address);
     if (force || !isAuth) {


### PR DESCRIPTION
# Description

`getSDK` is now available throughout the client-side code, as such we can't link SDK restoration to it being null. Solution is to force restoration in case of specific `authenticate` call and ignore it if it doesn't return logged in. This should preserve current behavior.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
