### PR TITLE
fix(sdk): update check for login status based on JWT presence

### DIFF
--- a/3iD/src/provider/kubelt.ts
+++ b/3iD/src/provider/kubelt.ts
@@ -65,6 +65,10 @@ export const authenticate = async (
     }
 
     const restoredSdk = await sdkWeb.node_v1.restore(sdk);
+    if ('error' === restoredSdk.type) {
+      console.error('There was a problem restoring Kubelt SDK state');
+      console.error(restoredSdk.error);
+    }
 
     // We use isLoggedIn as a way to check if SDK
     // was persisted, as there is no other way;

--- a/src/test/com/kubelt/rpc/nfts_test.cljs
+++ b/src/test/com/kubelt/rpc/nfts_test.cljs
@@ -65,7 +65,7 @@
                         (set (keys nfts))))
 
                  (is (= (set (keys (first (:owned-nfts nfts))))
-                        #{:description :token-uri :contract :time-last-updated :title :balance :id :media :metadata})))
+                        #{:description :token-uri :contract :time-last-updated :title :balance :id :media :contract-metadata :metadata})))
 
                (catch js/Error err (do
                                      (log/error err)


### PR DESCRIPTION
# Description

We have had an issue where calls to the SDK `isLoggedIn()` function would always return false. This was caused by:
1. a schema conformance check on the "restored" SDK
2. the schema non-conformance error being returned as an opaque edn map
3. not checking for a valid SDK instance in the calling context

This is a patch that removes the conformance check, so that the SDK is always returned, with no possibility of a schema error. We also add:
- [x] check for an error when calling `restore&` and convert an error map into an object
- [x] check in the calling context for an error result

Additional work to come:
- restore the schema conformance check after the schema is updated to reflect recent changes; the check should only fail when the restored SDK instance is actually invalid
- improvements to the login status checking