### PR TITLE
feat(sdk): add chain, chain-id params to authenticate method

### DIFF
--- a/3iD/src/provider/kubelt.ts
+++ b/3iD/src/provider/kubelt.ts
@@ -11,6 +11,7 @@ let sdk: any = null;
 export const getSDK = async (): Promise<any> => {
   if (!sdk) {
     sdk = await sdkWeb.node_v1.init({
+      "app/name": "3iD",
       "oort/scheme": Constants.manifest?.extra?.oortSchema,
       "oort/host": Constants.manifest?.extra?.oortHost,
       "oort/port": Constants.manifest?.extra?.oortPort,
@@ -96,22 +97,27 @@ export const authenticate = async (
         window.location.reload();
       }
 
-      console.log({
-        chainId: network?.chainId,
-      });
-
       sdk = await sdkWeb.node_v1.oort.setWallet(sdk, {
         address,
         signFn,
       });
 
-      sdk = await sdkWeb.node_v1.oort.authenticate(sdk, {
-        "3id.profile": ["read", "write"],
-        "3id.app": ["read", "write"],
-      });
+      try {
+        sdk = await sdkWeb.node_v1.oort.authenticate(sdk, {
+          "3id.profile": ["read", "write"],
+          "3id.app": ["read", "write"],
+        }, {
+          blockchain: "ethereum",
+          chain: network?.name,
+          chainId: network?.chainId,
+        });
+      } catch (e) {
+        console.error(e);
+      }
 
       isAuth = await isAuthenticated(address);
       if (isAuth) {
+        console.log(`storing SDK instance`);
         await sdkWeb.node_v1.store(sdk);
       }
     }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -97,7 +97,6 @@
   ;; This is the core Node.js library that provides the Kubelt SDK,
   ;; compiled for use with Node.js.
 
-  ;; TODO rename to :sdk-node?
   :sdk
   {:target :node-library
    ;; Each keyword in the :exports map is available in the generated

--- a/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
+++ b/src/main/com/kubelt/ddt/cmds/sdk/core/authenticate.cljs
@@ -15,6 +15,36 @@
    :builder (fn [^Yargs yargs]
               ;; Include the common options.
               (ddt.options/options yargs)
+              ;; permission
+              (let [permission {;; NB: "p" is already used for "port" in common options.
+                                :alias "x"
+                                :describe "Permission to request"
+                                :requiresArg true
+                                :array true}]
+                (.option yargs "permission" (clj->js permission)))
+              ;; blockchain
+              (let [blockchain {:describe "Blockchain name"
+                                :requiresArg true
+                                :demandOption "blockchain name is required"
+                                :nargs 1
+                                :choices ["ethereum"]
+                                :default "ethereum"
+                                :string true}]
+                (.option yargs "blockchain" (clj->js blockchain)))
+              ;; chain
+              (let [chain {:describe "human-readable chain name"
+                           :requiresArg true
+                           :demandOption "chain name is required"
+                           :nargs 1
+                           :string true}]
+                (.option yargs "chain" (clj->js chain)))
+              ;; chain-id
+              (let [chain-id {:describe "numerical chain identifier"
+                              :requiresArg true
+                              :demandOption "chain identifier is required"
+                              :nargs 1
+                              :number true}]
+                (.option yargs "chain-id" (clj->js chain-id)))
               yargs)
 
    :handler (fn [args]

--- a/src/main/com/kubelt/lib/config/sdk.cljc
+++ b/src/main/com/kubelt/lib/config/sdk.cljc
@@ -12,7 +12,8 @@
   reinitialize the SDK with the same configuration by passing it
   to (com.kubelt.sdk.v1/init)."
   [sys-map]
-  (let [ipfs-read-scheme (get sys-map :ipfs.read/scheme)
+  (let [app-name (get sys-map :app/name)
+        ipfs-read-scheme (get sys-map :ipfs.read/scheme)
         ipfs-read-host (get sys-map :ipfs.read/host)
         ipfs-read-port (get sys-map :ipfs.read/port)
         ipfs-write-scheme (get sys-map :ipfs.write/scheme)
@@ -26,7 +27,7 @@
         credentials (lib.vault/tokens (:crypto/session sys-map))
         wallet (get sys-map :crypto/wallet)
         storage (get sys-map :config/storage)]
-    {:app/name (get sys-map :app/name)
+    {:app/name app-name
      :log/level log-level
      :ipfs.read/scheme ipfs-read-scheme
      :ipfs.read/host ipfs-read-host

--- a/src/main/com/kubelt/lib/io/node.cljs
+++ b/src/main/com/kubelt/lib/io/node.cljs
@@ -6,8 +6,8 @@
    ["fs" :refer [promises] :rename {promises fs-promises} :as fs]
    ["path" :as path])
   (:require
-   [com.kubelt.lib.path :as lib.path]
    [com.kubelt.lib.error :as lib.error]
+   [com.kubelt.lib.path :as lib.path]
    [com.kubelt.lib.promise :as lib.promise]))
 
 (defn fs-exists?&
@@ -27,9 +27,9 @@
     kubelt-path))
 
 (defn ensure-kubelt-dir&
-  "Return the directory path for the application as a string,
-  creating it if it doesn't already exist.
-  Rejects promise with error message if dir isn't available"
+  "Return the directory path for the application as a string, creating it
+  if it doesn't already exist. Rejects promise with error message if dir
+  isn't available"
   [app-name folder]
   (let [kubelt-dirp (kubelt-dir app-name folder)]
     (lib.promise/promise
@@ -42,5 +42,9 @@
                                        options #js {:mode mode
                                                     :recursive recursive?}]
                                    (.mkdir fs-promises kubelt-dirp options)))))
-           (lib.promise/then (fn [_] (resolve kubelt-dirp)))
-           (lib.promise/catch (fn [e] (reject (lib.error/error (str "Dir isn't available" e))))))))))
+           (lib.promise/then
+            (fn [_]
+              (resolve kubelt-dirp)))
+           (lib.promise/catch
+               (fn [e]
+                 (reject (lib.error/error (str "Dir isn't available" e))))))))))

--- a/src/main/com/kubelt/lib/oort.cljs
+++ b/src/main/com/kubelt/lib/oort.cljs
@@ -6,29 +6,54 @@
   (:require
    ["@ethersproject/providers" :refer [JsonRpcProvider]])
   (:require
+   [camel-snake-kebab.core :as csk]
    [taoensso.timbre :as log])
   (:require
    [com.kubelt.lib.error :as lib.error]
    [com.kubelt.lib.promise :as lib.promise]))
 
 ;; TODO .cljc
+;; TODO use a URI library (external, or lib.http)
 
-(defn- connection-uri [sys core]
-  (let [scheme (get-in sys [:client/oort :http/scheme])
-        host (get-in sys [:client/oort :http/host])
-        port (get-in sys [:client/oort :http/port])
-        path (cstr/join "" ["/" core "/jsonrpc"])
-        uri (str (name scheme) "://" host ":" port path)]
-    (log/debug {::connection-uri uri})
-    uri))
+(defn- connection-uri
+  "Returns the oort URI for a given core and environment as a string."
+  ([sys core]
+   (let [query-params {}]
+     (connection-uri sys core query-params)))
 
-(defn- json-rpc-provider [sys core]
-  (JsonRpcProvider. (connection-uri sys core)))
+  ([sys core query-params]
+   (let [scheme (get-in sys [:client/oort :http/scheme])
+         host (get-in sys [:client/oort :http/host])
+         port (get-in sys [:client/oort :http/port])
+         path (cstr/join "" ["/" core "/jsonrpc"])
+         query-str (cstr/join "&" (map (fn [[k v]] (str k "=" v)) query-params))
+         uri (str (name scheme) "://" host ":" port path)
+         uri (if-not (cstr/blank? query-str)
+               (str uri "?" query-str)
+               uri)]
+     (log/debug {::connection-uri uri})
+     uri)))
+
+(defn- json-rpc-provider
+  ([sys core]
+   (let [query-params {}]
+     (json-rpc-provider sys core query-params)))
+
+  ([sys core query-params]
+   (JsonRpcProvider. (connection-uri sys core query-params))))
 
 (defn- send
+  "Send an RPC request using the given provider and API method. When
+  params are provided (as a vector) they are injected into the RPC call
+  as the call parameters. When the query map is supplied its key/value
+  pairs are used as query parameters into the URL to which the request
+  is made."
   ([provider method]
-   (send provider method []))
+   (let [params []]
+     (send provider method params)))
+
   ([provider method params]
+   {:pre [(string? method) (vector? params)]}
    (log/debug {::send {:method method :params params}})
    (-> (.send provider method (clj->js params))
        (lib.promise/then
@@ -38,31 +63,47 @@
         (fn [e]
           (lib.error/from-obj e))))))
 
-(defn authenticate!
+;; TODO rename to lib.oort/discover
+(defn rpc-api
+  "Perform an RPC discovery request to obtain a description of the
+  supported methods on the provider."
+  [sys core]
+  {:pre [(string? core)]}
+  (let [;; The chain/id doesn't matter for discovery.
+        query {}
+        provider (json-rpc-provider sys core query)]
+    (send provider "rpc.discover")))
+
+(defn call-rpc-method
+  [sys core method args query]
+  {:pre [(string? core) (string? method) (vector? args) (map? query)]}
+  (let [provider (json-rpc-provider sys core query)]
+    (send provider method args)))
+
+;; Public
+;; -----------------------------------------------------------------------------
+
+(defn authenticate&
   "Authenticate a user against a core. The account is a map that contains
   the public key from the keypair that represents the user's account."
-  [sys permissions]
-  (let [address (get-in sys [:crypto/wallet :wallet/address])]
+  [sys permissions network]
+  {:pre [(map? sys) (map? permissions) (map? network)]}
+  (let [address (get-in sys [:crypto/wallet :wallet/address])
+        network (update-keys network (fn [k] (-> k name csk/->camelCase)))
+        provider (json-rpc-provider sys address)]
     ;; Make an JsonRpc call to oort backend, passing along the user's
-    ;; wallet address. Expect a nonce in return, which should be signed
-    ;; and returned to prove ownership of provided key and complete
-    ;; registration.
+    ;; wallet address, permission list, and a blockchain
+    ;; specifier (chain name and ID). Expect a nonce in return, which
+    ;; should be signed and returned to prove ownership of provided key
+    ;; and complete registration.
     ;;
     ;; Returns a promise.
-    (send (json-rpc-provider sys address) "kb_getNonce" [address permissions])))
+    (send provider "kb_getNonce" [address permissions network])))
 
-(defn verify!
+(defn verify&
   "Send a signed nonce to verify ownership of a keypair as part of the
   authentication flow."
   [sys core nonce signature]
   {:pre [(every? string? [core nonce])]}
   ;; Returns a promise.
   (send (json-rpc-provider sys core) "kb_verifyNonce" [nonce signature]))
-
-(defn rpc-api [sys core]
-  {:pre [(string? core)]}
-  (send (json-rpc-provider sys core) "rpc.discover"))
-
-(defn call-rpc-method [sys core method args]
-  {:pre [(string? core) (string? method) (vector? args)]}
-  (send (json-rpc-provider sys core) method args))

--- a/src/main/com/kubelt/lib/rpc.cljs
+++ b/src/main/com/kubelt/lib/rpc.cljs
@@ -1,16 +1,23 @@
 (ns com.kubelt.lib.rpc
-  "Play with rpc."
+  "Play with RPC."
   {:copyright "ⓒ2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
    [clojure.string :as cstr])
   (:require
+   [taoensso.timbre :as log])
+  (:require
    [com.kubelt.lib.oort :as lib.oort]
-   [com.kubelt.lib.wallet :as lib.wallet]
    [com.kubelt.lib.promise :as lib.promise]
+   [com.kubelt.lib.wallet :as lib.wallet]
    [com.kubelt.rpc :as rpc]
    [com.kubelt.rpc.schema :as rpc.schema]))
 
-(defn rpc-call& [sys api args]
+(defn rpc-call&
+  "Make an RPC call, returning a promise that resolves to the result of
+  the request. This is a convenience function that allows for arbitrary
+  RPC calls to be performed, rather than keeping RPC encapsulated within
+  the SDK. Try not to rely on it, it may go away some day."
+  [sys api args]
   (lib.promise/promise
    (fn [resolve reject]
      (let [wallet-address (get-in sys [:crypto/wallet :wallet/address])
@@ -22,18 +29,28 @@
                        :rpc/jwt (get-in sys [:crypto/session :vault/tokens* wallet-address])}
                       rpc/init
                       (rpc.schema/schema api))
-           request (rpc/prepare client (:method args) (or (:params args) {}))
+           method (:method args)
+           params (or (:params args) {})
+           request (rpc/prepare client method params)
            rpc-method (:method/name (:rpc/method request))
-           rpc-params (:rpc/params request)]
+           rpc-params (:rpc/params request)
+           rpc-args (into [] (vals rpc-params))
+           rpc-query {}]
        (if (:rpc-client-type args)
-         (-> (lib.oort/call-rpc-method sys wallet-address rpc-method (into [] (vals rpc-params)))
+         (-> (lib.oort/call-rpc-method sys wallet-address rpc-method rpc-args rpc-query)
              (lib.promise/then resolve)
              (lib.promise/catch reject))
          (-> (rpc/execute client request)
              (lib.promise/then resolve)
              (lib.promise/catch reject)))))))
 
-(defn call-rpc-with-api-js [sys api args]
+(defn call-rpc-with-api-js
+  "Make an RPC call from a JS context, returning a promise that resolves
+  to the result of the request. This is a convenience function that
+  allows for arbitrary RPC calls to be performed, rather than keeping
+  RPC encapsulated within the SDK. Try not to rely on it, it may go away
+  some day."
+  [sys api args]
   (let [core (-> (get-in sys [:crypto/session :vault/tokens]) keys first)]
     (-> (assoc sys :crypto/wallet {:wallet/address core})
         (rpc-call& api (update (js->clj args :keywordize-keys true) :method #(mapv keyword %)))

--- a/src/main/com/kubelt/lib/wallet/shared.cljc
+++ b/src/main/com/kubelt/lib/wallet/shared.cljc
@@ -1,23 +1,27 @@
 (ns com.kubelt.lib.wallet.shared
   (:require
-   [goog.object :as gobj]
-   [com.kubelt.lib.octet :as lib.octet]
-   [com.kubelt.lib.promise :as lib.promise])
+   [goog.object :as gobj])
   (:require
    ["@ethersproject/keccak256" :refer [keccak256]]
    ["@ethersproject/signing-key" :refer [SigningKey]]
-   ["@ethersproject/wallet" :refer [Wallet]]))
+   ["@ethersproject/wallet" :refer [Wallet]])
+  (:require
+   [taoensso.timbre :as log])
+  (:require
+   [com.kubelt.lib.octet :as lib.octet]
+   [com.kubelt.lib.promise :as lib.promise]))
 
 (defn make-sign-fn
   "Given an Ethereum wallet, return a signing function that uses the
   wallet's private key to sign the digest of some given data. To match
   what happens in the browser, the signing function returns a promise
   that resolves to the signature value."
-  [eth-wallet]
+  [^Wallet eth-wallet]
   (fn [data]
     (lib.promise/promise
      (fn [resolve _reject]
-       (let [private-key (.-privateKey eth-wallet)
+       (let [address (.-address eth-wallet)
+             private-key (.-privateKey eth-wallet)
              signing-key (SigningKey. private-key)
 
              data-length (count data)
@@ -28,6 +32,9 @@
              digest (keccak256 data-bytes)
              signature-raw (.signDigest signing-key digest private-key)
              signature (gobj/get signature-raw "compact")]
+         (log/debug {:log/msg "signing data" :wallet/address address
+                     :data/digest digest
+                     :data/signature signature})
          (resolve signature))))))
 
 (defn random-wallet

--- a/src/main/com/kubelt/sdk.cljs
+++ b/src/main/com/kubelt/sdk.cljs
@@ -2,8 +2,8 @@
   "Entry point for the Kubelt SDK."
   {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"}
   (:require
-   [com.kubelt.sdk.v1 :as sdk.v1]
    [com.kubelt.lib.rpc :as lib.rpc]
+   [com.kubelt.sdk.v1 :as sdk.v1]
    [com.kubelt.sdk.v1.oort :as sdk.v1.oort]))
 
 ;; Entrypoint
@@ -38,30 +38,37 @@
 ;;   kbt.v1.halt(sdk);
 ;;
 
-(defn web-v1
-  []
-  ;; TODO
-  (println "web-v1"))
+(def ^:private public-api
+  {:init sdk.v1/init-js
+   :halt sdk.v1/halt-js!
+   :options sdk.v1/options-js
+
+   ;; storage
+   :store sdk.v1/store-js&
+   :restore sdk.v1/restore-js&
+
+   ;; oort
+   :oort {:authenticate sdk.v1.oort/authenticate-js&
+          :claims sdk.v1.oort/claims-js
+          :isLoggedIn sdk.v1.oort/logged-in-js?
+          :setWallet sdk.v1.oort/set-wallet-js
+
+          ;; TODO this should only exist as dev-time escape hatch
+          :callRpc sdk.v1.oort/call-rpc-js}})
+
+(def ^:private develop-api
+  {:develop {:rpc {:call sdk.v1.oort/call-rpc-js}}})
+
+;; NB: The compiler sets this to false for release builds.
+;; (when goog.DEBUG
+;;   (def node-v1 (clj->js public-api)))
+;; Use a macro? (lib.sdk/api ...)
 
 (def node-v1
-  #js {:init sdk.v1/init-js
-       :halt sdk.v1/halt-js!
-       :options sdk.v1/options-js
+  (clj->js public-api))
 
-       ;; storage
-       :store sdk.v1/store-js&
-       :restore sdk.v1/restore-js&
+;;:callRpc sdk.v1.oort/call-rpc-js
 
-       ;; oort
-       :oort #js {:authenticate sdk.v1.oort/authenticate-js!
-                  :claims sdk.v1.oort/claims-js
-                  :callRpc sdk.v1.oort/call-rpc-js
-                  :callRpcWithApi lib.rpc/call-rpc-with-api-js
-                  :rpcApi sdk.v1.oort/rpc-api-js
-                  :isLoggedIn sdk.v1.oort/logged-in-js?
-                  :setWallet sdk.v1.oort/set-wallet-js}
-
-       ;; development (removed from production builds)
-       ;; TODO
-       ;;:develop #js {:rpc #js {:call sdk.v1.develop.rpc/call-js!}}
-       })
+;; TODO remove; they appear to be unused
+;;:callRpcWithApi lib.rpc/call-rpc-with-api-js
+;;:rpcApi sdk.v1.oort/rpc-api-js

--- a/src/main/com/kubelt/spec/provider.cljc
+++ b/src/main/com/kubelt/spec/provider.cljc
@@ -1,0 +1,29 @@
+(ns com.kubelt.spec.provider
+  "Blockchain-related provider schemas."
+  {:copyright "©2022 Proof Zero Inc." :license "Apache 2.0"})
+
+;; blockchain
+;; -----------------------------------------------------------------------------
+
+(def blockchain
+  [:enum "ethereum"])
+
+;; network
+;; -----------------------------------------------------------------------------
+;; This is based on the result of the RPC provider getNetwork() result.
+
+(def network
+  [:map
+   [:network/blockchain blockchain]
+   [:network/chain :string]
+   [:network/chain-id :int]])
+
+(def network-schema
+  [:and
+   {:name "Network"
+    :description "A provider network specifies a specific blockchain and
+    network (test, main) variant."
+    :example {:network/blockchain "ethereum"
+              :network/chain "goerli"
+              :network/chain-id 5}}
+   network])

--- a/src/test/com/kubelt/lib/test_utils.cljs
+++ b/src/test/com/kubelt/lib/test_utils.cljs
@@ -3,43 +3,52 @@
    [cljs.core.async :refer [go <!]]
    [cljs.core.async.interop :refer-macros [<p!]]
    [cljs.reader :refer [read-string]]
-   [cljs.test :refer-macros [is async] :as t]
-   [com.kubelt.lib.util :as lib.util :refer [node-env]]
+   [cljs.test :refer-macros [is async] :as t])
+  (:require
    [taoensso.timbre :as log])
   (:require
+   [com.kubelt.lib.util :as lib.util :refer [node-env]]
    [com.kubelt.lib.wallet.node :as wallet]
    [com.kubelt.rpc.schema.fs :as s.fs]))
 
-(defn create-wallet [app-name wallet-name wallet-password]
+(defn create-wallet
+  "Create a temporary wallet to use as part of a test suite."
+  [app-name wallet-name wallet-password]
   (go
-    (log/debug "creating-wallet: " wallet-name)
     (try
-      (let [w (<p! (wallet/init& app-name wallet-name wallet-password))]
-        (is true "wallet created")
-        w)
-      (catch js/Error err (do (is false err) err)))))
+      (let [wallet (<p! (wallet/init& app-name wallet-name wallet-password))
+            wallet-address (:wallet/address wallet)]
+        (log/debug {:log/msg "wallet created" :app/name app-name :wallet/name wallet-name :wallet/address wallet-address})
+        wallet)
+      (catch js/Error err
+        (do (is false err) err)))))
 
-(defn import-wallet [app-name wallet-name mnemonic wallet-password]
+(defn import-wallet
+  [app-name wallet-name mnemonic wallet-password]
   (go
-    (log/debug "importing-wallet: " wallet-name)
     (try
-      (let [{:keys [wallet/name]} (<p! (wallet/import& app-name wallet-name mnemonic wallet-password))]
+      (let [wallet (<p! (wallet/import& app-name wallet-name mnemonic wallet-password))
+            wallet-name (get wallet :wallet/name)
+            wallet-address (get wallet :wallet/address)]
+        (log/debug {:log/msg "imported wallet" :app/name app-name :wallet/name wallet-name :wallet/address wallet-address})
         name)
-      (catch js/Error err (do (is false err) err)))))
+      (catch js/Error err
+        (do (is false err) err)))))
 
-(defn delete-wallet [app-name wallet-name wallet-password & [silently]]
+(defn delete-wallet
+  [app-name wallet-name wallet-password & [silently]]
   (go
-    (log/debug "deleting-wallet: " wallet-name)
     (try
       (let [can-decrypt? (<p! (wallet/can-decrypt?& app-name wallet-name wallet-password))]
-        (log/debug "can-decrypt?: " can-decrypt?)
         (when can-decrypt?
           (let [deleted (<p! (wallet/delete!& app-name wallet-name))]
-            (log/debug :deleted deleted)
+            (log/debug {:log/msg "wallet deleted" :app/name app-name :wallet/name wallet-name :status/deleted deleted})
             true)))
-      (catch js/Error err (do (is (or false silently) err) err)))))
+      (catch js/Error err
+        (do (is (or false silently) err) err)))))
 
-(defn create-wallet-fixture [app-name wallet-name wallet-password]
+(defn create-wallet-fixture
+  [app-name wallet-name wallet-password]
   #(async
     done
     (go
@@ -48,7 +57,8 @@
         (catch js/Error err (js/console.log err))
         (finally (done))))))
 
-(defn import-wallet-fixture [app-name wallet-name mnemonic wallet-password]
+(defn import-wallet-fixture
+  [app-name wallet-name mnemonic wallet-password]
   #(async
     done
     (go
@@ -58,7 +68,8 @@
         (catch js/Error err (js/console.log err))
         (finally (done))))))
 
-(defn delete-wallet-fixture [app-name wallet-name wallet-password]
+(defn delete-wallet-fixture
+  [app-name wallet-name wallet-password]
   #(async
     done
     (go
@@ -72,6 +83,7 @@
     "./fix/openrpc/"
     "./../../../fix/openrpc/"))
 
-(defn read-local-edn&go [path]
+(defn read-local-edn&go
+  [path]
   (go
     (read-string (str (<p! (s.fs/read-file& (str json-path path)))))))

--- a/src/test/com/kubelt/rpc/auth_test.cljs
+++ b/src/test/com/kubelt/rpc/auth_test.cljs
@@ -14,24 +14,31 @@
 
 
 (use-fixtures :once
-  {:before  (lib.test-utils/create-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)
+  {:before (lib.test-utils/create-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)
    :after (lib.test-utils/delete-wallet-fixture t.commons/app-name t.commons/wallet-name t.commons/wallet-password)})
 
 (deftest rpc-core-auth-test
   (testing "rpc auth test"
     (async done
            (go
-              (try
-               (let [config (t.commons/oort-config)
+             (try
+               (let [wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
+                     address (:wallet/address wallet)
+                     config (assoc (t.commons/oort-config) :crypto/wallet wallet)
                      sys (<p! (sdk/init config))
-                     wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
-                     core (:wallet/address wallet)
-                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet) {}))]
-                 (is (= {} (-> sys :crypto/session :vault/tokens)))
-                 (is (map? (get-in kbt [:crypto/session :vault/tokens core])))
-                 (is (= :kubelt.type/vault (get-in kbt [:crypto/session :com.kubelt/type])))
-                 (is (string? (get-in kbt [:crypto/session :vault/tokens* core]))))
-               (catch js/Error err (do
-                                     (log/error err)
-                                     (is false err)))
+                     permissions {}
+                     network {:network/blockchain "ethereum"
+                              :network/chain "goerli"
+                              :network/chain-id 5}
+                     kbt (<p! (sdk.oort/authenticate& sys permissions network))]
+                 (is (= :kubelt.type/vault (get-in kbt [:crypto/session :com.kubelt/type]))
+                     "The stored token collection has expected type tag")
+                 (is (= {} (-> sys :crypto/session :vault/tokens))
+                     "SDK is created with no tokens")
+                 (is (map? (get-in kbt [:crypto/session :vault/tokens address]))
+                     "Stored JWT is available as a decomposed map")
+                 (is (string? (get-in kbt [:crypto/session :vault/tokens* address]))
+                     "Stored JWT is available as a string"))
+               (catch js/Error err
+                 (do (is false err)))
                (finally (done)))))))

--- a/src/test/com/kubelt/rpc/nfts_test.cljs
+++ b/src/test/com/kubelt/rpc/nfts_test.cljs
@@ -54,8 +54,13 @@
                (let [config (t.commons/oort-config)
                      sys (<p! (sdk/init config))
                      wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
+                     sys (assoc sys :crypto/wallet wallet)
                      core (:wallet/address wallet)
-                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet) {}))
+                     permissions {}
+                     network {:network/blockchain "ethereum"
+                              :network/chain "goerli"
+                              :network/chain-id 5}
+                     kbt (<p! (sdk.oort/authenticate& sys permissions network))
                      api (<p! (sdk.oort/rpc-api sys core))
                      nfts (-> (<p! (lib.rpc/rpc-call& kbt api
                                                       {:method  [:alchemy :get-nf-ts]
@@ -67,9 +72,8 @@
                  (is (= (set (keys (first (:owned-nfts nfts))))
                         #{:description :token-uri :contract :time-last-updated :title :balance :id :media :contract-metadata :metadata})))
 
-               (catch js/Error err (do
-                                     (log/error err)
-                                     (is false err)))
+               (catch js/Error err
+                 (do (is false err)))
                (finally (done)))))))
 
 (comment

--- a/src/test/com/kubelt/rpc/profile_test.cljs
+++ b/src/test/com/kubelt/rpc/profile_test.cljs
@@ -25,8 +25,13 @@
                (let [config (t.commons/oort-config)
                      sys (<p! (sdk/init config))
                      wallet (<p! (wallet/load& t.commons/app-name t.commons/wallet-name t.commons/wallet-password))
+                     sys (assoc sys :crypto/wallet wallet)
                      core (:wallet/address wallet)
-                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet) {}))
+                     permissions {}
+                     network {:network/blockchain "ethereum"
+                              :network/chain "goerli"
+                              :network/chain-id 5}
+                     kbt (<p! (sdk.oort/authenticate& sys permissions network))
                      api (<p! (sdk.oort/rpc-api sys core))
                      profile (-> (<p! (lib.rpc/rpc-call& kbt api {:method [:kb :get-profile]}))
                                  :http/body :result)]

--- a/src/test/com/kubelt/rpc/sdk_test.cljs
+++ b/src/test/com/kubelt/rpc/sdk_test.cljs
@@ -10,13 +10,13 @@
    [taoensso.timbre :as log])
   (:require
    [com.kubelt.lib.test-utils :as lib.test-utils]
-   [com.kubelt.lib.wallet.node :as wallet]
    [com.kubelt.lib.wallet :as lib.wallet]
+   [com.kubelt.lib.wallet.node :as wallet]
    [com.kubelt.rpc.test-commons :as t.commons]
    [com.kubelt.sdk.v1 :as sdk]
+   [com.kubelt.sdk.v1.oort :as sdk.oort]
    [com.kubelt.spec.config :as spec.config]
-   [com.kubelt.spec.vault :as spec.vault]
-   [com.kubelt.sdk.v1.oort :as sdk.oort]))
+   [com.kubelt.spec.vault :as spec.vault]))
 
 (use-fixtures :once
   {:before (lib.test-utils/import-wallet-fixture t.commons/app-name t.commons/test-wallet-name t.commons/test-wallet-mnemonic t.commons/test-wallet-password)
@@ -65,7 +65,12 @@
              (try
                (let [sys (<p! (sdk/init (t.commons/oort-config)))
                      wallet (<p! (wallet/load& t.commons/app-name t.commons/test-wallet-name t.commons/test-wallet-password))
-                     kbt (<p! (sdk.oort/authenticate& (assoc sys :crypto/wallet wallet) {}))
+                     sys (assoc sys :crypto/wallet wallet)
+                     permissions {}
+                     network {:network/blockchain "ethereum"
+                              :network/chain "goerli"
+                              :network/chain-id 5}
+                     kbt (<p! (sdk.oort/authenticate& sys permissions network))
                      result (-> (<p! (sdk.oort/call-rpc-js
                                       kbt
                                       #js ["kb" "get-profile"]

--- a/src/test/com/kubelt/rpc/test_commons.cljs
+++ b/src/test/com/kubelt/rpc/test_commons.cljs
@@ -2,7 +2,7 @@
   (:require
    [com.kubelt.lib.util :as lib.util :refer [node-env environment]]))
 
-(def app-name "com.kubelt.ddt.js")
+(def app-name "com.kubelt.test")
 (def wallet-name "auth_test")
 (def wallet-password "auth_foo_pw")
 
@@ -11,15 +11,21 @@
 (def test-wallet-mnemonic (get (environment) "METAMASKID_RECOVERY_PHRASE"))
 
 (defn ci-env
+  "Returns true if running in a GitHub Actions workflow, and false
+  otherwise."
   []
   (some? (get-in (node-env) [:environment "GITHUB_ACTIONS"])))
 
 (defn oort-config
-  "return p2p config based on env"
+  "Return oort config based on environment."
   []
   (if (ci-env)
-    {:app/name "kubelt-test"
+    {:app/name app-name
+     :log/level :debug
      :oort/scheme :https
-     :oort/host "oort-devnet.admin1337.workers.dev"
-     :oort/port  443}
-    {}))
+     :oort/host "oort-devnet.kubelt.com"
+     :oort/port 443}
+
+    ;; Other test against a locally running instance of oort.
+    {:app/name app-name
+     :log/level :debug}))


### PR DESCRIPTION
# Description

Adds `chain` and `chain-id` parameters to the SDK `v1.oort.authenticate` call. These values are injected as the `network` parameter of the `kb_getNonce` JSON-RPC call body, e.g.
```
{
  "method": "kb_getNonce",
  "params": [
    "0xcAA76924329206bBE87aF88B3240a3828D8b4399",
    {
      "3id.profile": [
        "read",
        "write"
      ],
      "3id.app": [
        "read",
        "write"
      ]
    },
    {
      "blockchain": "ethereum",
      "chain": "goerli",
      "chainId": 5
    }
  ],
  "id": 42,
  "jsonrpc": "2.0"
}
```

Updates `ddt` to accept `--blockchain` (default: `ethereum`), `--chain`, and `--chain-id` parameters:
```
$ ddt sdk core authenticate --wallet default --host localhost --port 8787 --chain eth --chain-id 5 --permission 3id.app/read -x 3id.app/write --log-level debug
```