### PR TITLE
fix(threeid): update imports

### DIFF
--- a/threeid/app/routes/auth.tsx
+++ b/threeid/app/routes/auth.tsx
@@ -24,7 +24,7 @@ import logo from "../assets/three-id-logo.svg";
 
 import { getUserSession } from "~/utils/session.server";
 
-import { links as spinnerLinks } from "~/components/spinner";
+import { links as spinnerLinks } from "~/components/spinner/index";
 
 
 export function links() {

--- a/threeid/app/routes/auth/index.tsx
+++ b/threeid/app/routes/auth/index.tsx
@@ -6,7 +6,7 @@ import {
 import { useEffect } from "react";
 import { useNavigate } from "@remix-run/react";
 
-import Spinner from "~/components/spinner";
+import Spinner from "~/components/spinner/index";
 import MetamaskSVG from '~/components/metamask-svg';
 
 export default function AuthIndex() {

--- a/threeid/app/routes/auth/sign/$address.tsx
+++ b/threeid/app/routes/auth/sign/$address.tsx
@@ -15,7 +15,7 @@ import {
  import { createUserSession } from "~/utils/session.server";
 
  import BaseButton, { links as buttonLinks } from "~/components/base-button";
- import Spinner from "~/components/spinner";
+ import Spinner from "~/components/spinner/index";
 
 
  export const links = () => [


### PR DESCRIPTION
# Description

For some reason remix doesn't import by default spinner from index.tsx. Instead it imports index.css from the same folder.
Is this bug persists not only for me?

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
