### PR TITLE
fix(nftar): Add proper Alchemy API KEY envvar name.

### DIFF
--- a/nftar/index.js
+++ b/nftar/index.js
@@ -33,7 +33,7 @@ const main = async (api) => {
 
     // An Alchemy API client.
     api.context.alchemy = new Alchemy({
-        apiKey: process.env.ALCHEMY_KEY,
+        apiKey: process.env.ALCHEMY_API_KEY,
         network: Network[process.env.ALCHEMY_NETWORK],
         maxRetries: 10,
     });


### PR DESCRIPTION
# Description

Fix for the `ALCHEMY_KEY` naming issue from this morning.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

local/goerli/mainnet
