### PR TITLE
feat(nftar): Add Multiple Contract Types, Add Deprecations, Fix Dates

### DIFF
--- a/nftar/.gitignore
+++ b/nftar/.gitignore
@@ -1,1 +1,2 @@
 outputs
+bin/*.sh

--- a/nftar/bin/local_smoke.sh
+++ b/nftar/bin/local_smoke.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -ex
-
-echo "Testing with development bearer:"
-curl localhost:3000/api?skipImage=true -s -H 'Accept: application/json' -H 'Content-type: application/json' -X POST -d '{"jsonrpc": "2.0", "id": 1, "method": "3id_genPFP", "params": { "blockchain": { "name": "ethereum", "chainId": 1}, "account": "0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52" }}' -H 'Authorization: Bearer GET_DEV_KEY_FROM_1PASS' | jq
-
-echo "Testing with staging bearer (expect duplicate PFP failure):"
-curl localhost:3000/api -s -H 'Accept: application/json' -H 'Content-type: application/json' -X POST -d '{"jsonrpc": "2.0", "id": 1, "method": "3id_genPFP", "params": { "blockchain": { "name": "ethereum", "chainId": 1}, "account": "0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52" }}' -H 'Authorization: Bearer GET_STAGE_KEY_FROM_1PASS' | jq

--- a/nftar/index.js
+++ b/nftar/index.js
@@ -1,5 +1,8 @@
 // nftar/index.js
 
+// Load environment variables from .env file.
+require('dotenv').config();
+
 const app = require('./src/app');
 const { createAlchemyWeb3 } = require("@alch/alchemy-web3");
 const {
@@ -9,9 +12,6 @@ const {
 const http = require('http');
 const process = require('process');
 const storage = require('nft.storage');
-
-// Load environment variables from .env file.
-require('dotenv').config();
 
 const main = async (api) => {
     // Inject client for our storage service into the context. We read the
@@ -40,6 +40,8 @@ const main = async (api) => {
 
     // The Ethereum minting contract address.
     api.context.contract = process.env.CONTRACT_ADDRESS;
+    api.context.pfp_contract = process.env.PFP_CONTRACT_ADDRESS;
+    api.context.invite_contract = process.env.INVITE_CONTRACT_ADDRESS;
 
     // set the app api key
     api.context.apiKey = process.env.NFTAR_API_KEY;

--- a/nftar/index.js
+++ b/nftar/index.js
@@ -39,7 +39,6 @@ const main = async (api) => {
     });
 
     // The Ethereum minting contract address.
-    api.context.contract = process.env.CONTRACT_ADDRESS;
     api.context.pfp_contract = process.env.PFP_CONTRACT_ADDRESS;
     api.context.invite_contract = process.env.INVITE_CONTRACT_ADDRESS;
 

--- a/nftar/src/app.js
+++ b/nftar/src/app.js
@@ -328,7 +328,7 @@ const genInvite = async (ctx, next) => {
     
     let inviteId = ctx.jsonrpc.params['inviteId'];
     const inviteTier = ctx.jsonrpc.params['inviteTier'];
-    const issueDate = ctx.jsonrpc.params['issueDate'];
+    const issueDate = Intl.DateTimeFormat('en-GB-u-ca-iso8601').format(Date.now());
     const assetFile = "./assets/3ID_NFT_CARD_NO_BG.svg"
     const OUTPUT_DIR = path.resolve("outputs");
     

--- a/nftar/src/utils.js
+++ b/nftar/src/utils.js
@@ -9,22 +9,6 @@ const {
     SPECIAL_COLLECTIONS
 } = require('./traits.js');
 
-// Does the user own any NFTs of the passed contract address?
-// const isPFPOwner = function(nfts, _contractAddress) {
-//     if (typeof _contractAddress !== 'string') return false;
-//     if (nfts.constructor !== Array) return false;
-    
-//     const contractAddress = _contractAddress.toLowerCase();
-//     for (const i in nfts) {
-//         const nft = nfts[i];
-//         // console.log(nft.contract.address, contractAddress, contractAddress == nft.contract.address);
-//         if (nft.contract.address == contractAddress) {
-//             return true;
-//         }
-//     }
-//     return false;
-// }
-
 const calculateNFTWeight = function(nfts) {
     const weights = {
         "EPIC": 0,

--- a/nftar/src/utils.js
+++ b/nftar/src/utils.js
@@ -10,20 +10,20 @@ const {
 } = require('./traits.js');
 
 // Does the user own any NFTs of the passed contract address?
-const isPFPOwner = function(nfts, _contractAddress) {
-    if (typeof _contractAddress !== 'string') return false;
-    if (nfts.constructor !== Array) return false;
+// const isPFPOwner = function(nfts, _contractAddress) {
+//     if (typeof _contractAddress !== 'string') return false;
+//     if (nfts.constructor !== Array) return false;
     
-    const contractAddress = _contractAddress.toLowerCase();
-    for (const i in nfts) {
-        const nft = nfts[i];
-        // console.log(nft.contract.address, contractAddress, contractAddress == nft.contract.address);
-        if (nft.contract.address == contractAddress) {
-            return true;
-        }
-    }
-    return false;
-}
+//     const contractAddress = _contractAddress.toLowerCase();
+//     for (const i in nfts) {
+//         const nft = nfts[i];
+//         // console.log(nft.contract.address, contractAddress, contractAddress == nft.contract.address);
+//         if (nft.contract.address == contractAddress) {
+//             return true;
+//         }
+//     }
+//     return false;
+// }
 
 const calculateNFTWeight = function(nfts) {
     const weights = {
@@ -177,7 +177,6 @@ const generateTraits = function(weightInc) {
 }
 
 module.exports = {
-    isPFPOwner,
     calculateNFTWeight,
     calculateSpecialWeight,
     calculateBalanceWeight,

--- a/nftar/tests/utils.test.js
+++ b/nftar/tests/utils.test.js
@@ -638,27 +638,27 @@ const ALCHEMY_NFTS_FIXTURE = {
 
 describe('Utilities', () => {
 
-  test('isPFPOwner null tests', () => {
-    const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
-    let result = utils.isPFPOwner();
-    expect(result).toStrictEqual(false);
-    result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts);
-    expect(result).toStrictEqual(false);
-    result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
-    expect(result).toStrictEqual(false);
-  });
+//   test('isPFPOwner null tests', () => {
+//     const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
+//     let result = utils.isPFPOwner();
+//     expect(result).toStrictEqual(false);
+//     result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts);
+//     expect(result).toStrictEqual(false);
+//     result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
+//     expect(result).toStrictEqual(false);
+//   });
 
-  test('isPFPOwner falsy test', () => {
-    const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
-    let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
-    expect(result).toStrictEqual(false);
-  });
+//   test('isPFPOwner falsy test', () => {
+//     const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
+//     let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
+//     expect(result).toStrictEqual(false);
+//   });
 
-  test('isPFPOwner truthy test', () => {
-    const IS_A_CONTRACT_ADDRESS = '0xf8496fe24cdeb4b769e5a617b3a6159a031446d2';
-    let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, IS_A_CONTRACT_ADDRESS);
-    expect(result).toStrictEqual(true);
-  });
+//   test('isPFPOwner truthy test', () => {
+//     const IS_A_CONTRACT_ADDRESS = '0xf8496fe24cdeb4b769e5a617b3a6159a031446d2';
+//     let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, IS_A_CONTRACT_ADDRESS);
+//     expect(result).toStrictEqual(true);
+//   });
 
   test('calculateNFTWeight null test', () => {
     const nfts = [];

--- a/nftar/tests/utils.test.js
+++ b/nftar/tests/utils.test.js
@@ -638,28 +638,6 @@ const ALCHEMY_NFTS_FIXTURE = {
 
 describe('Utilities', () => {
 
-//   test('isPFPOwner null tests', () => {
-//     const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
-//     let result = utils.isPFPOwner();
-//     expect(result).toStrictEqual(false);
-//     result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts);
-//     expect(result).toStrictEqual(false);
-//     result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
-//     expect(result).toStrictEqual(false);
-//   });
-
-//   test('isPFPOwner falsy test', () => {
-//     const NOT_A_CONTRACT_ADDRESS = '0x3DaC36FE079e311489c6cF5CC456a6f38FE01A52';
-//     let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, NOT_A_CONTRACT_ADDRESS);
-//     expect(result).toStrictEqual(false);
-//   });
-
-//   test('isPFPOwner truthy test', () => {
-//     const IS_A_CONTRACT_ADDRESS = '0xf8496fe24cdeb4b769e5a617b3a6159a031446d2';
-//     let result = utils.isPFPOwner(ALCHEMY_NFTS_FIXTURE.ownedNfts, IS_A_CONTRACT_ADDRESS);
-//     expect(result).toStrictEqual(true);
-//   });
-
   test('calculateNFTWeight null test', () => {
     const nfts = [];
     const result = utils.calculateNFTWeight(nfts);


### PR DESCRIPTION
# Description

This was blocked by the `jayson` + DO issue on Friday, which is now resolved. Catches up with what's in the Goerli NFTar service:

- Adds the invite contract environment variable and PFP contract environment variables to NFTar so that we can work with both kinds of NFT.
- Changes how we look for NFT ownership so it's more efficient and eliminates a utility function. Better use of the Alchemy API.
- Adds API key, DEV key, and 409 test to `genInvite`.
- Cleans up invite method metadata to match actual.
- Adds `recipient` param to `genInvite`.
- Adds basic debug and performance logging to `genInvite` (and removes some old logging).
- Sets up deprecating `3iD_genInvite` in favour of `3id_genInvite` (ie lowering the 'd').
- Updates date formatting so we don't have to trust client locales.
- Deprecates the `issueDate` param for now (ignores it).

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Local and Goerli. Need to validate on testnet before mainnet deployment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
