### PR TITLE
FIX(3iD): Use oort object package

### DIFF
--- a/threeid/app/routes/account.tsx
+++ b/threeid/app/routes/account.tsx
@@ -54,12 +54,12 @@ export const loader = async ({ request }) => {
       oortOptions,
     ),
     oortSend(
-      "kb_getData",
+      "kb_getObject",
       ["3id.profile", "pfp"],
       oortOptions,
     ),
     oortSend(
-      "kb_getData",
+      "kb_getObject",
       ["3id.profile", "displayname"],
       oortOptions,
     )

--- a/threeid/app/routes/account.tsx
+++ b/threeid/app/routes/account.tsx
@@ -55,12 +55,12 @@ export const loader = async ({ request }) => {
     ),
     oortSend(
       "kb_getObject",
-      ["3id.profile", "pfp"],
+      ["3id_profile", "pfp"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id.profile", "displayname"],
+      ["3id_profile", "displayname"],
       oortOptions,
     )
   ]);

--- a/threeid/app/routes/account.tsx
+++ b/threeid/app/routes/account.tsx
@@ -55,12 +55,12 @@ export const loader = async ({ request }) => {
     ),
     oortSend(
       "kb_getObject",
-      ["3id_profile", "pfp"],
+      ["3id.profile", "pfp"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id_profile", "displayname"],
+      ["3id.profile", "displayname"],
       oortOptions,
     )
   ]);

--- a/threeid/app/routes/account/index.tsx
+++ b/threeid/app/routes/account/index.tsx
@@ -48,17 +48,17 @@ export const loader = async ({ request, params }) => {
     ),
     oortSend(
       "kb_getObject",
-      ["3id_app", "feature_vote_count"],
+      ["3id.app", "feature_vote_count"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id_profile", "pfp"],
+      ["3id.profile", "pfp"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id_profile", "displayname"],
+      ["3id.profile", "displayname"],
       oortOptions,
     ),
     oortSend(
@@ -100,8 +100,10 @@ export const action = async ({ request }: any) => {
   const jwt = session.get("jwt");
 
   oortSend(
-    "kb_setObject",
-    ["3id_app", "feature_vote_count", votes],
+    "kb_putObject",
+    ["3id.app", "feature_vote_count", votes, {
+      visibility: "private"
+    }],
     {
       jwt, cookie: request.headers.get("Cookie")
     }

--- a/threeid/app/routes/account/index.tsx
+++ b/threeid/app/routes/account/index.tsx
@@ -48,17 +48,17 @@ export const loader = async ({ request, params }) => {
     ),
     oortSend(
       "kb_getObject",
-      ["3id.app", "feature_vote_count"],
+      ["3id_app", "feature_vote_count"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id.profile", "pfp"],
+      ["3id_profile", "pfp"],
       oortOptions,
     ),
     oortSend(
       "kb_getObject",
-      ["3id.profile", "displayname"],
+      ["3id_profile", "displayname"],
       oortOptions,
     ),
     oortSend(
@@ -101,7 +101,7 @@ export const action = async ({ request }: any) => {
 
   oortSend(
     "kb_setObject",
-    ["3id.app", "feature_vote_count", votes],
+    ["3id_app", "feature_vote_count", votes],
     {
       jwt, cookie: request.headers.get("Cookie")
     }

--- a/threeid/app/routes/account/index.tsx
+++ b/threeid/app/routes/account/index.tsx
@@ -47,17 +47,17 @@ export const loader = async ({ request, params }) => {
       oortOptions,
     ),
     oortSend(
-      "kb_getData",
+      "kb_getObject",
       ["3id.app", "feature_vote_count"],
       oortOptions,
     ),
     oortSend(
-      "kb_getData",
+      "kb_getObject",
       ["3id.profile", "pfp"],
       oortOptions,
     ),
     oortSend(
-      "kb_getData",
+      "kb_getObject",
       ["3id.profile", "displayname"],
       oortOptions,
     ),
@@ -100,7 +100,7 @@ export const action = async ({ request }: any) => {
   const jwt = session.get("jwt");
 
   oortSend(
-    "kb_setData",
+    "kb_setObject",
     ["3id.app", "feature_vote_count", votes],
     {
       jwt, cookie: request.headers.get("Cookie")

--- a/threeid/app/routes/auth/nonce/$address.tsx
+++ b/threeid/app/routes/auth/nonce/$address.tsx
@@ -22,7 +22,7 @@ export const loader = async ({ request, params }) => {
     const nonceRes = await oortSend("kb_getNonce", [
             params.address,
             signMessageTemplate,
-            {"3id_profile": ["read", "write"], "3id_app": ["read", "write"]},
+            {"3id.profile": ["read", "write"], "3id.app": ["read", "write"]},
             // TODO: add support for { "blockchain": "ethereum", "chain": "goerli", "chainId": 5 } in JWT
         ], {address: params.address})
     

--- a/threeid/app/routes/auth/nonce/$address.tsx
+++ b/threeid/app/routes/auth/nonce/$address.tsx
@@ -22,7 +22,7 @@ export const loader = async ({ request, params }) => {
     const nonceRes = await oortSend("kb_getNonce", [
             params.address,
             signMessageTemplate,
-            {"3id.profile": ["read", "write"], "3id.app": ["read", "write"]},
+            {"3id_profile": ["read", "write"], "3id_app": ["read", "write"]},
             // TODO: add support for { "blockchain": "ethereum", "chain": "goerli", "chainId": 5 } in JWT
         ], {address: params.address})
     

--- a/threeid/app/routes/onboard/mint/index.tsx
+++ b/threeid/app/routes/onboard/mint/index.tsx
@@ -44,7 +44,7 @@ export const action: ActionFunction = async ({ request }) => {
   await oortSend(
     "kb_setObject",
     [
-      "3id.profile",
+      "3id_profile",
       "pfp",
       {
         url: imgUrl,

--- a/threeid/app/routes/onboard/mint/index.tsx
+++ b/threeid/app/routes/onboard/mint/index.tsx
@@ -42,7 +42,7 @@ export const action: ActionFunction = async ({ request }) => {
   const contractAddress = formData.get("contractAddress");
 
   await oortSend(
-    "kb_setData",
+    "kb_setObject",
     [
       "3id.profile",
       "pfp",
@@ -51,6 +51,9 @@ export const action: ActionFunction = async ({ request }) => {
         contractAddress: contractAddress,
         isToken: true,
       },
+      {
+        visibility: "public"
+      }
     ],
     {
       jwt,

--- a/threeid/app/routes/onboard/mint/index.tsx
+++ b/threeid/app/routes/onboard/mint/index.tsx
@@ -42,9 +42,9 @@ export const action: ActionFunction = async ({ request }) => {
   const contractAddress = formData.get("contractAddress");
 
   await oortSend(
-    "kb_setObject",
+    "kb_putObject",
     [
-      "3id_profile",
+      "3id.profile",
       "pfp",
       {
         url: imgUrl,

--- a/threeid/app/routes/onboard/mint/load-voucher.tsx
+++ b/threeid/app/routes/onboard/mint/load-voucher.tsx
@@ -109,7 +109,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       const data = await oortSend(
         "kb_setObject",
         [
-          "3id.profile",
+          "3id_profile",
           "pfp",
           {
             url: voucher.metadata.image,

--- a/threeid/app/routes/onboard/mint/load-voucher.tsx
+++ b/threeid/app/routes/onboard/mint/load-voucher.tsx
@@ -107,9 +107,9 @@ export const loader: LoaderFunction = async ({ request }) => {
       await VOUCHER_CACHE.put(address, JSON.stringify(voucher));
 
       const data = await oortSend(
-        "kb_setObject",
+        "kb_putObject",
         [
-          "3id_profile",
+          "3id.profile",
           "pfp",
           {
             url: voucher.metadata.image,

--- a/threeid/app/routes/onboard/mint/load-voucher.tsx
+++ b/threeid/app/routes/onboard/mint/load-voucher.tsx
@@ -107,7 +107,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       await VOUCHER_CACHE.put(address, JSON.stringify(voucher));
 
       const data = await oortSend(
-        "kb_setData",
+        "kb_setObject",
         [
           "3id.profile",
           "pfp",
@@ -118,6 +118,9 @@ export const loader: LoaderFunction = async ({ request }) => {
             contractAddress: MINTPFP_CONTRACT_ADDRESS,
             isToken: false,
           },
+          {
+            visibility: "public"
+          }
         ],
         {
           jwt,

--- a/threeid/app/routes/onboard/name.tsx
+++ b/threeid/app/routes/onboard/name.tsx
@@ -31,7 +31,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   const session = await getUserSession(request);
   const jwt = session.get("jwt");
 
-  const data = await oortSend("kb_getObject", ["3id_profile", "displayname"], {
+  const data = await oortSend("kb_getObject", ["3id.profile", "displayname"], {
     jwt,
     cookie: request.headers.get("Cookie") as string | undefined,
   });
@@ -58,8 +58,8 @@ export const action: ActionFunction = async ({ request }) => {
   }
 
   const data = await oortSend(
-    "kb_setObject",
-    ["3id_profile", "displayname", displayname, {
+    "kb_putObject",
+    ["3id.profile", "displayname", displayname, {
       visibility: "public"
     }],
     {

--- a/threeid/app/routes/onboard/name.tsx
+++ b/threeid/app/routes/onboard/name.tsx
@@ -31,7 +31,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   const session = await getUserSession(request);
   const jwt = session.get("jwt");
 
-  const data = await oortSend("kb_getObject", ["3id.profile", "displayname"], {
+  const data = await oortSend("kb_getObject", ["3id_profile", "displayname"], {
     jwt,
     cookie: request.headers.get("Cookie") as string | undefined,
   });
@@ -59,7 +59,7 @@ export const action: ActionFunction = async ({ request }) => {
 
   const data = await oortSend(
     "kb_setObject",
-    ["3id.profile", "displayname", displayname, {
+    ["3id_profile", "displayname", displayname, {
       visibility: "public"
     }],
     {

--- a/threeid/app/routes/onboard/name.tsx
+++ b/threeid/app/routes/onboard/name.tsx
@@ -31,7 +31,7 @@ export const loader: LoaderFunction = async ({ request }) => {
   const session = await getUserSession(request);
   const jwt = session.get("jwt");
 
-  const data = await oortSend("kb_getData", ["3id.profile", "displayname"], {
+  const data = await oortSend("kb_getObject", ["3id.profile", "displayname"], {
     jwt,
     cookie: request.headers.get("Cookie") as string | undefined,
   });
@@ -58,8 +58,10 @@ export const action: ActionFunction = async ({ request }) => {
   }
 
   const data = await oortSend(
-    "kb_setData",
-    ["3id.profile", "displayname", displayname],
+    "kb_setObject",
+    ["3id.profile", "displayname", displayname, {
+      visibility: "public"
+    }],
     {
       jwt,
       cookie: request.headers.get("Cookie") as string | undefined,


### PR DESCRIPTION
# Description

As part of recent changes to Oort, we're moving away towards an object package for storing user data. As such, the current `kb_(get/set)Data` endpoints should be transformed to the new package, matching the instructions from https://github.com/kubelt/kubelt-oort/pull/243#issuecomment-1273308343

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Not at all

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
