### PR TITLE
FIX(Yarn): Checksum behavior

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,7 @@
 defaultSemverRangePrefix: ""
 
+checksumBehavior: update
+
 nodeLinker: node-modules
 
 plugins:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12610,7 +12610,7 @@ __metadata:
   dependencies:
     bn.js: ^4.11.8
     ethereumjs-util: ^6.0.0
-  checksum: ae074be0bb012857ab5d3ae644d1163b908a48dd724b7d2567cfde309dc72222d460438f2411936a70dc949dc604ce1ef7118f7273bd525815579143c907e336
+  checksum: 03127d09960e5f8a44167463faf25b2894db2f746376dbb8195b789ed11762f93db9c574eaa7c498c400063508e9dfc1c80de2edf5f0e1406b25c87d860ff2f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Fixes error on Windows when Yarn tries to install packages by github checksum and it's mismatched.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Wasn't working. Now it works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
