### PR TITLE
fix(icons): update workflows and auth provisioning

### DIFF
--- a/.github/workflows/main-icons.yaml
+++ b/.github/workflows/main-icons.yaml
@@ -40,10 +40,8 @@ jobs:
           # Each supplied name must be defined in the env: config stanza.
           secrets: |
             CLOUDFLARE_ACCOUNT_ID
-            CLOUDFLARE_AUTH_EMAIL
-            CLOUDFLARE_AUTH_KEY
+            CLOUDFLARE_IMAGES_KEY
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_AUTH_EMAIL: ${{ secrets.CLOUDFLARE_AUTH_EMAIL }}
-          CLOUDFLARE_AUTH_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}
+          CLOUDFLARE_IMAGES_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}

--- a/.github/workflows/next-icons.yaml
+++ b/.github/workflows/next-icons.yaml
@@ -40,10 +40,8 @@ jobs:
           # Each supplied name must be defined in the env: config stanza.
           secrets: |
             CLOUDFLARE_ACCOUNT_ID
-            CLOUDFLARE_AUTH_EMAIL
-            CLOUDFLARE_AUTH_KEY
+            CLOUDFLARE_IMAGES_KEY
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_AUTH_EMAIL: ${{ secrets.CLOUDFLARE_AUTH_EMAIL }}
-          CLOUDFLARE_AUTH_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}
+          CLOUDFLARE_IMAGES_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}

--- a/.github/workflows/release-icons.yaml
+++ b/.github/workflows/release-icons.yaml
@@ -36,10 +36,8 @@ jobs:
           # Each supplied name must be defined in the env: config stanza.
           secrets: |
             CLOUDFLARE_ACCOUNT_ID
-            CLOUDFLARE_AUTH_EMAIL
-            CLOUDFLARE_AUTH_KEY
+            CLOUDFLARE_IMAGES_KEY
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_AUTH_EMAIL: ${{ secrets.CLOUDFLARE_AUTH_EMAIL }}
-          CLOUDFLARE_AUTH_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}
+          CLOUDFLARE_IMAGES_KEY: ${{ secrets.CLOUDFLARE_IMAGES_KEY }}

--- a/platform/icons/.dev.vars.example
+++ b/platform/icons/.dev.vars.example
@@ -5,8 +5,5 @@
 # The account ID that owns uploaded images.
 CLOUDFLARE_ACCOUNT_ID = "<replace-me>"
 
-# The e-mail address associated with the owner account.
-CLOUDFLARE_AUTH_EMAIL = "<replace-me>"
-
 # A bearer token providing access to the Cloudflare Images API.
-CLOUDFLARE_AUTH_KEY = "<replace-me>"
+CLOUDFLARE_IMAGES_KEY = "<replace-me>"

--- a/platform/icons/bin/get_signed_url.sh
+++ b/platform/icons/bin/get_signed_url.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+dev_url="https://icons-dev.kubelt.com"
+next_url="https://icons-next.kubelt.com"
+prod_url="https://icons.kubelt.com"
+
+url="${dev_url}"
+
+# We can associate an arbitrary map of metadata with the uploaded image.
+image_metadata='{}'
+
+curl -X POST -H "Content-Type: application/json" -d "${image_metadata}" "${url}"

--- a/platform/icons/src/index.ts
+++ b/platform/icons/src/index.ts
@@ -28,11 +28,8 @@ export interface Env {
   // associated with.
   CLOUDFLARE_ACCOUNT_ID: string;
 
-  // The e-mail address associated with the owner account.
-  CLOUDFLARE_AUTH_EMAIL: string;
-
-  // A bearer token providing access to the Cloudflare Images API.
-  CLOUDFLARE_AUTH_KEY: string;
+  // An API token with write permissions for the Images service.
+  CLOUDFLARE_IMAGES_KEY: string;
 
   // Environment variables
   // ---------------------------------------------------------------------------
@@ -96,8 +93,7 @@ export default {
     const uploadRequest = new Request(url, {
       method: "POST",
       headers: {
-        "X-Auth-Email": env.CLOUDFLARE_AUTH_EMAIL,
-        "X-Auth-Key": env.CLOUDFLARE_AUTH_KEY,
+        "Authorization": `Bearer ${env.CLOUDFLARE_IMAGES_KEY}`,
       },
       // NB: do *not* explicitly set the Content-Type header to
       // "multipart/form-data"; this prevents the header from being set
@@ -136,10 +132,11 @@ export default {
     const result = JSON.stringify(direct_upload.result);
 
     return new Response(result, {
-       headers: {
-         "Content-Type": "application/json",
-       },
-       status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      status: 200,
     });
+
   },
 };

--- a/platform/icons/wrangler.toml
+++ b/platform/icons/wrangler.toml
@@ -6,44 +6,46 @@ compatibility_date = "2022-10-05"
 
 # We'll access these services through their external names.
 workers_dev = false
-route = { pattern = "icons-dev.kubelt.com/*", zone_name = "kubelt.com" }
 
 # Secrets are set via the dashboard, or using the wrangler CLI:
 # $ wrangler secret put <KEY> [--env]
 #
 # Required secrets:
-# - AUTH_EMAIL
-# - AUTH_KEY
-
-# NB: set the value for ACCOUNT_ID when publishing worker:
-# npx wrangler --var ACCOUNT_ID=<...>
+# - CLOUDFLARE_ACCOUNT_ID: the CF account ID of the uploaded image owner
+# - CLOUDFLARE_IMAGES_KEY: an API token with Images permissions
 
 [env.dev]
 name = "icons-dev"
-route = { pattern = "icons-dev.kubelt.com/*", zone_name = "kubelt.com" }
+routes = [
+  { pattern = "icons-dev.kubelt.com", custom_domain = true, zone_name = "kubelt.com" }
+]
 
 [env.dev.vars]
 # The duration in seconds that returned upload URL is good for.
-# - minimum: 2 minutes
-# - maximum: 6 hours
-UPLOAD_WINDOW_SECONDS = 15
+# - minimum: 2 minutes (120)
+# - maximum: 6 hours (21600)
+UPLOAD_WINDOW_SECONDS = 200
 
 [env.next]
 name = "icons-next"
-route = { pattern = "icons-next.kubelt.com/*", zone_name = "kubelt.com" }
+routes = [
+  { pattern = "icons-next.kubelt.com", custom_domain = true, zone_name = "kubelt.com" }
+]
 
 [env.next.vars]
 # The duration in seconds that returned upload URL is good for.
-# - minimum: 2 minutes
-# - maximum: 6 hours
-UPLOAD_WINDOW_SECONDS = 15
+# - minimum: 2 minutes (120)
+# - maximum: 6 hours (21600)
+UPLOAD_WINDOW_SECONDS = 200
 
 [env.current]
 name = "icons-prod"
-route = { pattern = "icons.kubelt.com/*", zone_name = "kubelt.com" }
+routes = [
+  { pattern = "icons.kubelt.com", custom_domain = true, zone_name = "kubelt.com" }
+]
 
 [env.current.vars]
 # The duration in seconds that returned upload URL is good for.
-# - minimum: 2 minutes
-# - maximum: 6 hours
-UPLOAD_WINDOW_SECONDS = 15
+# - minimum: 2 minutes (120)
+# - maximum: 6 hours (21600)
+UPLOAD_WINDOW_SECONDS = 200

--- a/yarn.lock
+++ b/yarn.lock
@@ -3946,11 +3946,11 @@ __metadata:
 
 "@kubelt/do.starbase-application@file:../component/application::locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker":
   version: 0.1.0
-  resolution: "@kubelt/do.starbase-application@file:../component/application#../component/application::hash=0c7767&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
+  resolution: "@kubelt/do.starbase-application@file:../component/application#../component/application::hash=adc091&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
   dependencies:
     "@kubelt/openrpc": "file:../../lib/openrpc"
     cross-env: 7.0.3
-  checksum: ce99cd47cff97c6e1d26cf61bc93e347e85e0984ccff796aed2ffa88fd8b8fcb2b05ad5d61d592d5fd092988e66a63721a92df1a8a291b2fc6f39332630dce64
+  checksum: e08cdb03a99232aeb70b6e0a9e382a2fdddb98d2a3fc1e3e9f4064b1afd67c79f91b3f9df56d6a6d62ea1f19102dbf2190ac7c12dc25baf37e2f13a0b61a09ea
   languageName: node
   linkType: hard
 
@@ -3965,11 +3965,11 @@ __metadata:
 
 "@kubelt/do.starbase-contract@file:../component/contract::locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker":
   version: 0.1.0
-  resolution: "@kubelt/do.starbase-contract@file:../component/contract#../component/contract::hash=a6cfc1&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
+  resolution: "@kubelt/do.starbase-contract@file:../component/contract#../component/contract::hash=d04920&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
   dependencies:
     "@kubelt/openrpc": "file:../../lib/openrpc"
     cross-env: 7.0.3
-  checksum: 1ea1ecbe0c962b37b0f318e542fc3002d1405cd466b148c8b1d347e9efef69dd6308ebe3b3bcac93fb802f21c986fcbc3be2d18988091ebbe3f04bf945dc0fcc
+  checksum: 00d12ff0b3d02c6f98d180711ffa5b886a5165e2963f8cbb74e2ef82b3d89cd07c89608f2038178ccc010b9cb245e7fdf5e27ff2695bead6a45ad0f882baa495
   languageName: node
   linkType: hard
 
@@ -3984,11 +3984,11 @@ __metadata:
 
 "@kubelt/do.starbase-user@file:../component/user::locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker":
   version: 0.1.0
-  resolution: "@kubelt/do.starbase-user@file:../component/user#../component/user::hash=7c07a8&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
+  resolution: "@kubelt/do.starbase-user@file:../component/user#../component/user::hash=8de8cc&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
   dependencies:
     "@kubelt/openrpc": "file:../../lib/openrpc"
     cross-env: 7.0.3
-  checksum: 0c476a568876f4dbaea265013b3e77bcec3842e1940df58eee78274542d90f66a1bc53ec313e2485d10174c9edba68c7d7c1ed2206ea81aa0b53d22da546413b
+  checksum: afe1892c7c2b3bf0613849d5bfcf50d3a5f66dbabfbb5d92fd5c33c9e9af2e4b4b0563d0cfbe44b87b226c634e808aa0f8eb682f1e8d02dfdb49c29ffc4ac980
   languageName: node
   linkType: hard
 
@@ -4001,9 +4001,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-application%40file%3A..%2Fcomponent%2Fapplication%23..%2Fcomponent%2Fapplication%3A%3Ahash%3D0c7767%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
+"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-application%40file%3A..%2Fcomponent%2Fapplication%23..%2Fcomponent%2Fapplication%3A%3Ahash%3Dadc091%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-application%40file%3A..%2Fcomponent%2Fapplication%23..%2Fcomponent%2Fapplication%3A%3Ahash%3D0c7767%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-application%40file%3A..%2Fcomponent%2Fapplication%23..%2Fcomponent%2Fapplication%3A%3Ahash%3Dadc091%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4014,13 +4014,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
 "@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-application%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fapplication":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-application%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fapplication"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-application%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fapplication"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4031,13 +4031,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
-"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-contract%40file%3A..%2Fcomponent%2Fcontract%23..%2Fcomponent%2Fcontract%3A%3Ahash%3Da6cfc1%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
+"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-contract%40file%3A..%2Fcomponent%2Fcontract%23..%2Fcomponent%2Fcontract%3A%3Ahash%3Dd04920%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-contract%40file%3A..%2Fcomponent%2Fcontract%23..%2Fcomponent%2Fcontract%3A%3Ahash%3Da6cfc1%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-contract%40file%3A..%2Fcomponent%2Fcontract%23..%2Fcomponent%2Fcontract%3A%3Ahash%3Dd04920%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4048,13 +4048,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
 "@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-contract%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fcontract":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-contract%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fcontract"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-contract%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fcontract"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4065,13 +4065,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
-"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-user%40file%3A..%2Fcomponent%2Fuser%23..%2Fcomponent%2Fuser%3A%3Ahash%3D7c07a8%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
+"@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-user%40file%3A..%2Fcomponent%2Fuser%23..%2Fcomponent%2Fuser%3A%3Ahash%3D8de8cc%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-user%40file%3A..%2Fcomponent%2Fuser%23..%2Fcomponent%2Fuser%3A%3Ahash%3D7c07a8%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-user%40file%3A..%2Fcomponent%2Fuser%23..%2Fcomponent%2Fuser%3A%3Ahash%3D8de8cc%26locator%3D%2540kubelt%252Fapp.starbase%2540workspace%253Aplatform%252Fstarbase%252Fworker"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4082,13 +4082,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
 "@kubelt/openrpc@file:../../lib/openrpc::locator=%40kubelt%2Fdo.starbase-user%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fuser":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=f91589&locator=%40kubelt%2Fdo.starbase-user%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fuser"
+  resolution: "@kubelt/openrpc@file:../../lib/openrpc#../../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fdo.starbase-user%40workspace%3Aplatform%2Fstarbase%2Fcomponent%2Fuser"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4099,13 +4099,13 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 
 "@kubelt/openrpc@file:../lib/openrpc::locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker":
   version: 0.1.0
-  resolution: "@kubelt/openrpc@file:../lib/openrpc#../lib/openrpc::hash=f91589&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
+  resolution: "@kubelt/openrpc@file:../lib/openrpc#../lib/openrpc::hash=1eb72c&locator=%40kubelt%2Fapp.starbase%40workspace%3Aplatform%2Fstarbase%2Fworker"
   dependencies:
     "@cfworker/json-schema": 1.12.5
     "@open-rpc/meta-schema": 1.14.2
@@ -4116,7 +4116,7 @@ __metadata:
     reflect-metadata: 0.1.13
     tiny-invariant: 1.3.1
     ts-set-utils: 0.2.0
-  checksum: 8a2c58ff08a92edf549f2b29be3c73a0b4bc1b7fd5b3fd18bd98828531a5966a5e86b3ec31d1b0e038555462d5c0d9a1b1570da3925c555fc2d5004886402936
+  checksum: bb671e94b0533b1657030e38c3df9271a70412a495a5fd45f683ab29fd96461f2b475f3abb8cfe4312bbc9839d408743f6fe291163b2468b200a054c84b5520e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

- [x] use Bearer token when calling CF Images API
- [x] update GitHub workflow to inject the necessary credential
- [x] add script to call `-dev` version of service for _ad hoc_ testing
- [x] update `wrangler.toml` to use `custom_domain` for service route
  - previous service configuration did not make it publicly routable