### PR TITLE
bug(threeid): ens profile ownership check

### DIFF
--- a/apps/threeid/app/routes/$profile.tsx
+++ b/apps/threeid/app/routes/$profile.tsx
@@ -26,7 +26,8 @@ import ButtonLink from '~/components/buttons/ButtonLink'
 import { useEffect, useRef, useState } from 'react'
 
 import social from '~/assets/social.png'
-// import { datadogRum } from '@datadog/browser-rum'
+
+import { oortSend } from '~/utils/rpc.server'
 
 export function links() {
   return [...spinnerLinks(), ...nftCollLinks()]
@@ -71,7 +72,11 @@ export const loader: LoaderFunction = async (args) => {
   const jwt = session.get('jwt')
   const address = session.get('address')
 
-  if (address === params.profile) {
+  const addressLookup = await oortSend('ens_lookupAddress', [address], {
+    jwt,
+  })
+
+  if (address === params.profile || addressLookup?.result === params.profile) {
     isOwner = true
   }
 


### PR DESCRIPTION
# Description

- Closes #964 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Known issues

- Alchemy NFT querying doesn't work on Goerli with ENS name
- Throws exception on testnet when trying to get NFTs for ENS name

# How Has This Been Tested?

Manually, on local

![image](https://user-images.githubusercontent.com/635806/200556314-d9de5d3c-6f55-40d0-a8c0-81c222a470cf.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
