### PR TITLE
bug(threeid): nft load fail placeholder

### DIFF
--- a/apps/threeid/app/assets/missing-nft.svg
+++ b/apps/threeid/app/assets/missing-nft.svg
@@ -1,0 +1,15 @@
+<svg width="457" height="457" viewBox="0 0 457 457" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="457" height="457" fill="#F9FAFB"/>
+<g clip-path="url(#clip0_5432_16558)">
+<path d="M253.829 194.728H253.914" stroke="#E5E7EB" stroke-width="8.443" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M236.943 296.044H186.285C179.567 296.044 173.125 293.375 168.375 288.625C163.625 283.875 160.956 277.433 160.956 270.715V186.285C160.956 179.567 163.625 173.125 168.375 168.375C173.125 163.625 179.567 160.956 186.285 160.956H270.715C277.433 160.956 283.875 163.625 288.625 168.375C293.376 173.125 296.044 179.567 296.044 186.285V236.943" stroke="#E5E7EB" stroke-width="8.443" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M160.956 253.829L194.728 220.057C202.563 212.518 212.222 212.518 220.057 220.057L241.165 241.165" stroke="#E5E7EB" stroke-width="8.443" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M308.708 308.709L266.493 266.494" stroke="#E5E7EB" stroke-width="8.443" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M266.493 308.709L308.708 266.494" stroke="#E5E7EB" stroke-width="8.443" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_5432_16558">
+<rect width="202.632" height="202.632" fill="white" transform="translate(127.184 127.184)"/>
+</clipPath>
+</defs>
+</svg>

--- a/apps/threeid/app/components/nft-collection/ModaledNft.tsx
+++ b/apps/threeid/app/components/nft-collection/ModaledNft.tsx
@@ -7,10 +7,15 @@ import Text, {
   TextSize,
   TextWeight,
 } from '~/components/typography/Text'
+
 import { gatewayFromIpfs } from '~/helpers/gateway-from-ipfs'
+
+import missingNftSvg from '~/assets/missing-nft.svg'
 
 const ModaledNft = ({ nft }: any) => {
   const [showModal, setShowModal] = useState(false)
+
+  const [loadFail, setLoadFail] = useState(false)
 
   return (
     <>
@@ -23,7 +28,9 @@ const ModaledNft = ({ nft }: any) => {
       <div className="relative overlay-img-wrapper">
         <div
           onClick={() => {
-            setShowModal(true)
+            if (!loadFail) {
+              setShowModal(true)
+            }
           }}
           className="absolute left-0 right-0 top-0 bottom-0 p-4 flex flex-col justify-end transition-all duration-300"
         >
@@ -43,7 +50,11 @@ const ModaledNft = ({ nft }: any) => {
           </Text>
         </div>
 
-        <img className="w-full" src={gatewayFromIpfs(nft.url)} />
+        <img
+          className="w-full"
+          src={loadFail ? missingNftSvg : gatewayFromIpfs(nft.url)}
+          onError={(e) => setLoadFail(true)}
+        />
       </div>
     </>
   )

--- a/apps/threeid/app/components/nft-collection/SelectableNft.tsx
+++ b/apps/threeid/app/components/nft-collection/SelectableNft.tsx
@@ -3,17 +3,31 @@ import Text, {
   TextSize,
   TextWeight,
 } from '~/components/typography/Text'
+
 import { gatewayFromIpfs } from '~/helpers/gateway-from-ipfs'
 
+import missingNftSvg from '~/assets/missing-nft.svg'
+import { useState } from 'react'
+
 const SelectableNft = ({ nft, selected, handleSelectedNft }: any) => {
+  const [loadFail, setLoadFail] = useState(false)
+
   return (
     <div
-      className={`relative border cursor-pointer hover:scale-105 ${
-        selected ? 'scale-105' : ''
-      }`}
-      onClick={() => handleSelectedNft(nft)}
+      className={`relative border ${
+        loadFail ? '' : 'cursor-pointer'
+      } hover:scale-105 ${selected ? 'scale-105' : ''}`}
+      onClick={() => {
+        if (!loadFail) {
+          handleSelectedNft(nft)
+        }
+      }}
     >
-      <img className="w-full" src={gatewayFromIpfs(nft.url)} />
+      <img
+        className="w-full"
+        src={loadFail ? missingNftSvg : gatewayFromIpfs(nft.url)}
+        onError={(e) => setLoadFail(true)}
+      />
 
       <Text
         className="my-2.5 mx-2 bg-white"


### PR DESCRIPTION
# Description

Added an `onError` handler to NFT renderers which replace failed NFT loads with a placeholder graphic.

- Closes #965 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visually, locally

![image](https://user-images.githubusercontent.com/635806/200569567-64e3532b-66b8-4686-a186-4d27fc4a1f37.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
