### PR TITLE
fix(galaxy): remove alchemy env vars

### DIFF
--- a/.github/workflows/main-galaxy.yaml
+++ b/.github/workflows/main-galaxy.yaml
@@ -46,7 +46,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_API_KEY
             ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
@@ -59,5 +58,4 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_API_KEY: ${{ secrets.GALAXY_ALCHEMY_GOERLI_API_KEY}}
           ALCHEMY_NETWORK: 'goerli'

--- a/.github/workflows/main-galaxy.yaml
+++ b/.github/workflows/main-galaxy.yaml
@@ -46,7 +46,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
@@ -58,4 +57,3 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_NETWORK: 'goerli'

--- a/.github/workflows/next-galaxy.yaml
+++ b/.github/workflows/next-galaxy.yaml
@@ -45,7 +45,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_API_KEY
             ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
@@ -58,5 +57,4 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_API_KEY: ${{ secrets.GALAXY_ALCHEMY_GOERLI_API_KEY}}
           ALCHEMY_NETWORK: 'goerli'

--- a/.github/workflows/next-galaxy.yaml
+++ b/.github/workflows/next-galaxy.yaml
@@ -45,7 +45,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
           DATADOG_CLIENT_TOKEN: ${{ secrets.DATADOG_CLIENT_TOKEN }}
@@ -57,4 +56,3 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_NETWORK: 'goerli'

--- a/.github/workflows/release-galaxy.yaml
+++ b/.github/workflows/release-galaxy.yaml
@@ -40,7 +40,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_API_KEY
             ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
@@ -54,5 +53,4 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_API_KEY: ${{ secrets.GALAXY_ALCHEMY_API_KEY}}
           ALCHEMY_NETWORK: 'homestead'

--- a/.github/workflows/release-galaxy.yaml
+++ b/.github/workflows/release-galaxy.yaml
@@ -40,7 +40,6 @@ jobs:
             DATADOG_SERVICE_NAME
             NFTAR_URL
             NFTAR_AUTHORIZATION
-            ALCHEMY_NETWORK
         env:
           SESSION_SECRET: 'secret'
           ADMIN_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
@@ -53,4 +52,3 @@ jobs:
           NFTAR_URL: ${{ secrets.NFTAR_TEST_URL }}
           NFTAR_AUTHORIZATION: ${{ secrets.NFTAR_TEST_AUTHORIZATION }}
           MINTPFP_CONTRACT_ADDRESS: ${{ secrets.MINT_PFP_TEST_CONTRACT_ADDRESS }}
-          ALCHEMY_NETWORK: 'homestead'

--- a/platform/galaxy/src/env.ts
+++ b/platform/galaxy/src/env.ts
@@ -11,5 +11,4 @@ export default interface Env {
   // MY_BUCKET: R2Bucket;
 
   OORT: OortBinding
-  ALCHEMY_NETWORK: string
 }

--- a/platform/galaxy/src/env.ts
+++ b/platform/galaxy/src/env.ts
@@ -11,6 +11,5 @@ export default interface Env {
   // MY_BUCKET: R2Bucket;
 
   OORT: OortBinding
-  ALCHEMY_API_KEY: string
   ALCHEMY_NETWORK: string
 }

--- a/platform/galaxy/src/index.ts
+++ b/platform/galaxy/src/index.ts
@@ -20,9 +20,6 @@ export default {
     if (!env.OORT) {
       throw Error('OORT service bind not set')
     }
-    if (!env.ALCHEMY_API_KEY) {
-      throw Error('ALCHEMY_API_URL not set')
-    }
     if (!env.ALCHEMY_NETWORK) {
       throw Error('ALCHEMY_NETWORK not set')
     }

--- a/platform/galaxy/src/index.ts
+++ b/platform/galaxy/src/index.ts
@@ -20,9 +20,6 @@ export default {
     if (!env.OORT) {
       throw Error('OORT service bind not set')
     }
-    if (!env.ALCHEMY_NETWORK) {
-      throw Error('ALCHEMY_NETWORK not set')
-    }
     return yoga.handleRequest(request, { env, ctx })
   },
 }


### PR DESCRIPTION
# Description

It's not clear to me whether these are used anywhere. Groking the source it doesn't seem like it and it throws an exception for not finding the environment variables.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It threw an exception when starting the ThreeID app and making the first request to service bound Galaxy; it no longer throws an exception and generally works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
