### PR TITLE
fix(threeid): profile shape

### DIFF
--- a/apps/threeid/app/routes/$profile.tsx
+++ b/apps/threeid/app/routes/$profile.tsx
@@ -96,6 +96,8 @@ export const loader: LoaderFunction = async (args) => {
     isOwner = true
   }
 
+  profileJson = (profileJson as any)?.profile ?? profileJson
+
   // Setup og tag data
   let hex = gatewayFromIpfs(profileJson?.pfp?.image)
   let bkg = gatewayFromIpfs(profileJson?.cover)


### PR DESCRIPTION
# Description

Profile result can be either the parsed object, or be an object with the `profile` key within the parsed object. This seems to run into some situations where properties that are required are found at a different level in the object and as such OG generation and pfp displaying fails.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, with the terminal

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
