### PR TITLE
chore(sb): workflows

### DIFF
--- a/.github/workflows/main-starbase.yaml
+++ b/.github/workflows/main-starbase.yaml
@@ -1,0 +1,42 @@
+# .github/workflows/main-starbase.yaml
+---
+name: Starbase
+
+on:
+  push:
+    branches:
+      - main
+
+defaults:
+  run:
+    working-directory: ./platform
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - run: nix-build platform.nix
+
+      - name: Install
+        run: yarn workspaces focus -A
+
+      - name: Test
+        run: yarn workspaces foreach -i -v -t --include starbase run test
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: "platform/starbase"
+          command: publish --env dev
+          environment: "dev"
+          secrets:
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/next-starbase.yaml
+++ b/.github/workflows/next-starbase.yaml
@@ -1,0 +1,42 @@
+# .github/workflows/next-starbase.yaml
+---
+name: Next Starbase
+
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: ./platform
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - run: nix-build platform.nix
+
+      - name: Install
+        run: yarn workspaces focus --all
+
+      - name: Test
+        run: yarn workspaces foreach -i -v -t --include starbase run test
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: "platform/starbase"
+          command: publish --env next
+          environment: "next"
+          secrets:
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/release-starbase.yaml
+++ b/.github/workflows/release-starbase.yaml
@@ -1,0 +1,41 @@
+# .github/workflows/release-starbase.yaml
+---
+name: Release Starbase
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    working-directory: ./platform
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - run: nix-build platform.nix
+
+      - name: Install
+        run: yarn workspaces focus --all
+
+      - name: Test
+        run: yarn workspaces foreach -i -v -t --include starbase run test
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@2.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: "platform/starbase"
+          command: publish --env current
+          environment: "current"
+          secrets:
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/apps/console/wrangler.toml
+++ b/apps/console/wrangler.toml
@@ -46,7 +46,6 @@ local_protocol = "http"
 # -----------------------------------------------------------------------------
 
 [env.dev]
-name = "console-dev"
 
 services = [
   { binding = "STARBASE", service = "starbase-dev", environment = "production" }
@@ -70,7 +69,6 @@ STORAGE_NAMESPACE = "starbase"
 # -----------------------------------------------------------------------------
 
 [env.next]
-name = "console-next"
 
 services = [
   { binding = "STARBASE", service = "starbase-next", environment = "production" }
@@ -94,7 +92,6 @@ STORAGE_NAMESPACE = "starbase"
 # -----------------------------------------------------------------------------
 
 [env.current]
-name = "console-current"
 
 services = [
   { binding = "STARBASE", service = "starbase", environment = "production" }

--- a/apps/console/wrangler.toml
+++ b/apps/console/wrangler.toml
@@ -6,20 +6,14 @@ workers_dev = true
 main = "./build/index.js"
 compatibility_date = "2022-04-05"
 
+# TODO make service bindings work for local development using miniflare.
+
 # development
 # -----------------------------------------------------------------------------
 
 [dev]
 port = 9898
 local_protocol = "http"
-
-# Service Bindings
-# -----------------------------------------------------------------------------
-# TODO make service bindings work for local development using miniflare.
-
-# services = [
-#   { binding = "OORT", service = "oort-devnet" }
-# ]
 
 # Secrets
 # -----------------------------------------------------------------------------
@@ -35,7 +29,6 @@ local_protocol = "http"
 # independently for each environment.
 
 [vars]
-
 
 # Site
 # -----------------------------------------------------------------------------
@@ -54,6 +47,10 @@ local_protocol = "http"
 
 [env.dev]
 name = "console-dev"
+
+services = [
+  { binding = "STARBASE", service = "starbase-dev", environment = "production" }
+]
 
 # kv_namespaces = [
 #   { binding = "SESSIONS", id = "719906291cbf4079a0c30cbed684208d", preview_id = "ded590c8008d4a77a42ba53a1ce23003" },
@@ -74,9 +71,15 @@ STORAGE_NAMESPACE = "starbase"
 
 [env.next]
 name = "console-next"
+
+services = [
+  { binding = "STARBASE", service = "starbase-next", environment = "production" }
+]
+
 # kv_namespaces = [
 #   { binding = "SESSIONS", id = "6c6ca075005747e3873043cdf346f438" },
 # ]
+
 routes = [
   { pattern = "console-next.kubelt.com", custom_domain = true, zone_name = "kubelt.com" }
 ]
@@ -92,9 +95,15 @@ STORAGE_NAMESPACE = "starbase"
 
 [env.current]
 name = "console-current"
+
+services = [
+  { binding = "STARBASE", service = "starbase", environment = "production" }
+]
+
 # kv_namespaces = [
 #   { binding = "SESSIONS", id = "593c81a8b57347a4b30368eabee072ef" },
 # ]
+
 routes = [
   { pattern = "console.kubelt.com", custom_domain = true, zone_name = "kubelt.com" }
 ]

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -46,7 +46,6 @@ new_classes = [
 # -----------------------------------------------------------------------------
 
 [env.dev]
-name = "starbase-dev"
 
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },
@@ -60,7 +59,6 @@ durable_objects.bindings = [
 # -----------------------------------------------------------------------------
 
 [env.next]
-name = "starbase-next"
 
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },
@@ -74,7 +72,6 @@ durable_objects.bindings = [
 # -----------------------------------------------------------------------------
 
 [env.current]
-name = "starbase-current"
 
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -3,28 +3,36 @@ name = "starbase"
 main = "src/index.ts"
 compatibility_date = "2022-09-14"
 
-# Don't automatically expose this service at <worker-name>.<account-name>.workers.dev.
+# #############################################################################
+# NB: we don't supply an external route for this service as it is
+# intended to be service-bound.
+# #############################################################################
+
+# Don't automatically expose this service at:
+# <worker-name>.<account-name>.workers.dev.
 workers_dev = false
+
+# Services
+# -----------------------------------------------------------------------------
 
 # A list of other Clouflare services bound to this service.
 # services = [
-#   { binding = "RELAY", service = "kubelt-svc-relay", environment = "production" },
+#   { binding = "AUTH", service = "auth", environment = "production" },
 # ]
+
+# Secrets
+# -----------------------------------------------------------------------------
 
 # Secrets are set via the dashboard, or using the wrangler CLI:
 # $ wrangler secret put <KEY> [--env]
 #
 # Required secrets:
-# - DATADOG_TOKEN
-[vars]
-USER_NAME = "Robert"
+# N/A
 
-[durable_objects]
-bindings = [
-  { name = "STARBASE_APP", class_name = "StarbaseApplication" },
-  { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
-  { name = "STARBASE_USER", class_name = "StarbaseUser" },
-]
+# Durable Objects
+# -----------------------------------------------------------------------------
+
+[dev]
 
 [[migrations]]
 tag = "v1"
@@ -33,3 +41,45 @@ new_classes = [
   "StarbaseContract",
   "StarbaseUser",
 ]
+
+# Environment: dev
+# -----------------------------------------------------------------------------
+
+[env.dev]
+name = "starbase-dev"
+
+durable_objects.bindings = [
+  { name = "STARBASE_APP", class_name = "StarbaseApplication" },
+  { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
+  { name = "STARBASE_USER", class_name = "StarbaseUser" },
+]
+
+[env.dev.vars]
+
+# Environment: next
+# -----------------------------------------------------------------------------
+
+[env.next]
+name = "starbase-next"
+
+durable_objects.bindings = [
+  { name = "STARBASE_APP", class_name = "StarbaseApplication" },
+  { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
+  { name = "STARBASE_USER", class_name = "StarbaseUser" },
+]
+
+[env.next.vars]
+
+# Environment: current
+# -----------------------------------------------------------------------------
+
+[env.current]
+name = "starbase-current"
+
+durable_objects.bindings = [
+  { name = "STARBASE_APP", class_name = "StarbaseApplication" },
+  { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
+  { name = "STARBASE_USER", class_name = "StarbaseUser" },
+]
+
+[env.current.vars]


### PR DESCRIPTION
# Description

Adds GHA workflows for starbase.

- `main-starbase`
- `next-starbase`
- `release-starbase`
- sets up service binding for `console-{dev,next,current}` to `starbase-{dev,next,current}`

## note

I did some experimentation with dependency caching; the `actions/cache@v3` action doesn't appear to care about the default `working-directory` setting, relative paths in the `path:` configuration and `hashFiles()` argument result in an error message.