### PR TITLE
fix(threeid): expand modal real estate

### DIFF
--- a/apps/threeid/app/components/modal/Modal.tsx
+++ b/apps/threeid/app/components/modal/Modal.tsx
@@ -1,6 +1,8 @@
 import { Dialog, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
 
+import { HiOutlineX } from 'react-icons/hi'
+
 export type ModalProps = {
   children: any
 
@@ -38,7 +40,7 @@ const Modal = ({
         </Transition.Child>
 
         <div className="fixed inset-0 z-[101] overflow-y-auto">
-          <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
+          <div className="flex min-h-full items-center justify-center p-2 text-center sm:p-0">
             <Transition.Child
               as={Fragment}
               enter="ease-out duration-300"
@@ -48,14 +50,29 @@ const Modal = ({
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel
-                className={`relative transform rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:p-6 overflow-y-auto ${
-                  fixed
-                    ? `w-[75vw] lg:w-[50vw] h-[75vh]`
-                    : `max-w-[75vw] lg:max-w-[50vw] max-h-[75vh]`
-                }`}
-              >
-                {children}
+              <Dialog.Panel>
+                <div
+                  className={`flex flex-col ${
+                    fixed
+                      ? `w-[96vw] lg:w-[50vw] h-[96vh] lg:h-[76vh]`
+                      : `max-w-[96vw] lg:max-w-[50vw] max-h-[89vh] lg:max-h-76vh`
+                  }`}
+                >
+                  <div className="flex flex-row justify-end p-3">
+                    <div
+                      className="bg-white rounded-full p-2 text-3xl cursor-pointer"
+                      onClick={() => {
+                        if (handleClose) handleClose(false)
+                      }}
+                    >
+                      <HiOutlineX />
+                    </div>
+                  </div>
+
+                  <div className="flex-1 relative transform rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:p-6 overflow-y-auto">
+                    {children}
+                  </div>
+                </div>
               </Dialog.Panel>
             </Transition.Child>
           </div>

--- a/apps/threeid/app/components/nft-collection/ModaledNft.tsx
+++ b/apps/threeid/app/components/nft-collection/ModaledNft.tsx
@@ -32,7 +32,7 @@ const ModaledNft = ({ nft }: any) => {
               setShowModal(true)
             }
           }}
-          className="absolute left-0 right-0 top-0 bottom-0 p-4 flex flex-col justify-end transition-all duration-300 rounded-lg"
+          className="absolute left-0 right-0 top-0 bottom-0 p-0 lg:p-4 flex flex-col justify-end transition-all duration-300 rounded-lg"
         >
           <Text
             size={TextSize.SM}

--- a/apps/threeid/app/components/nft-collection/NftModal.tsx
+++ b/apps/threeid/app/components/nft-collection/NftModal.tsx
@@ -21,12 +21,12 @@ const NftModal = ({
       <div className="flex flex-col lg:flex-row max-w-full">
         <div className="max-w-full lg:max-w-sm flex justify-center items-center">
           <img
-            className="object-cover rounded"
+            className="object-cover rounded-lg"
             src={gatewayFromIpfs(nft?.url)}
           />
         </div>
 
-        <div className="p-4 max-w-full lg:max-w-md">
+        <div className="p-0 lg:p-4 max-w-full lg:max-w-md mt-3">
           <Text
             className="mb-2"
             size={TextSize.LG}

--- a/apps/threeid/app/components/nft-collection/NftModal.tsx
+++ b/apps/threeid/app/components/nft-collection/NftModal.tsx
@@ -36,7 +36,7 @@ const NftModal = ({
             {nft?.collectionTitle}
           </Text>
           <Text
-            className="mb-10"
+            className="mb-5 lg:mb-10"
             size={TextSize.XL4}
             weight={TextWeight.SemiBold600}
             color={TextColor.Gray900}
@@ -47,7 +47,7 @@ const NftModal = ({
           <hr />
 
           {nft?.properties?.length > 0 && (
-            <div className="mt-8">
+            <div className="mt-4 lg:mt-8">
               <Text
                 className="ml-1 mb-4"
                 size={TextSize.LG}


### PR DESCRIPTION
# Description

Small tweaks to the modal component to support larger screen real estate. Should hold more information per line now while not being too different.

![image](https://user-images.githubusercontent.com/635806/201346419-e8e12a4e-db8d-4bed-8ec9-c120a9c7512e.png)

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Visually, by comparison to Figma

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
