### PR TITLE
feat(nftar): Fix OG:Image Rendering

### DIFF
--- a/projects/nftar/Dockerfile
+++ b/projects/nftar/Dockerfile
@@ -1,42 +1,21 @@
 # nftar/Dockerfile
-FROM node:gallium-alpine
+FROM ubuntu:bionic
 
-RUN apk add --no-cache \
-      chromium \
-      nss \
-      freetype \
-      harfbuzz \
-      ca-certificates \
-      ttf-freefont \
-      nodejs \
-      yarn
+RUN apt update
 
-# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+# curl, plus Puppeteer Debian dependencies from https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix
+RUN apt install --yes curl ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
 
-# Puppeteer v13.5.0 works with Chromium 100.
-RUN yarn add puppeteer@13.5.0
-
-# # Add user so we don't need --no-sandbox.
-# RUN addgroup -S pptruser && adduser -S -G pptruser pptruser \
-#     && mkdir -p /home/pptruser/Downloads /app \
-#     && chown -R pptruser:pptruser /home/pptruser \
-#     && chown -R pptruser:pptruser /app
-
-# # Run everything after as non-privileged user.
-# USER pptruser
+# Need to install a better nodejs PPA than what's available via apt, and then yarn.
+RUN curl --silent --location https://deb.nodesource.com/setup_16.x | bash
+RUN apt install nodejs
+RUN npm install --global yarn
 
 ENV NODE_ENV=production
-
 ENV PORT=3000
-
 WORKDIR /api
 
 COPY ["package.json", "package-lock.json*", "./"]
-
 RUN yarn install --production
-
 COPY . .
-
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
# Description

GIFs, WEBP, PNG, SVGs, and JPGs now all render correctly as og:images. Dockerfile changed to run Chromium using Puppeteer locally, and in Cloud Run, as an image renderer.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local and Goerli service.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation website
- [na] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
