### PR TITLE
feat(threeid): nft modal skeleton

### DIFF
--- a/apps/threeid/app/components/nft-collection/NftModal.tsx
+++ b/apps/threeid/app/components/nft-collection/NftModal.tsx
@@ -17,16 +17,20 @@ const NftModal = ({
   nft: any
   handleClose: (evt: any) => void
 }) => {
-  const [imgLoaded, setImgLoaded] = useState(false);
+  const [imgLoaded, setImgLoaded] = useState(false)
 
   return (
     <Modal isOpen={isOpen} handleClose={handleClose}>
       <div className="flex flex-col lg:flex-row max-w-full">
         <div className="max-w-full lg:max-w-sm flex justify-center items-center">
-          {!imgLoaded && <div className="w-[24rem] h-[24rem] bg-gray-100 rounded-lg animate-pulse"></div>}
+          {!imgLoaded && (
+            <div className="w-[24rem] h-[24rem] bg-gray-100 rounded-lg animate-pulse"></div>
+          )}
 
           <img
-            className={`object-cover rounded-lg ${imgLoaded ? "visible" : "invisible absolute w-3 h-3"}`}
+            className={`object-cover rounded-lg ${
+              imgLoaded ? 'visible' : 'invisible absolute w-3 h-3'
+            }`}
             src={gatewayFromIpfs(nft?.url)}
             onLoad={() => setImgLoaded(true)}
           />

--- a/apps/threeid/app/components/nft-collection/NftModal.tsx
+++ b/apps/threeid/app/components/nft-collection/NftModal.tsx
@@ -6,6 +6,7 @@ import Text, {
 
 import Modal from '~/components/modal/Modal'
 import { gatewayFromIpfs } from '~/helpers/gateway-from-ipfs'
+import { useState } from 'react'
 
 const NftModal = ({
   isOpen,
@@ -16,13 +17,18 @@ const NftModal = ({
   nft: any
   handleClose: (evt: any) => void
 }) => {
+  const [imgLoaded, setImgLoaded] = useState(false);
+
   return (
     <Modal isOpen={isOpen} handleClose={handleClose}>
       <div className="flex flex-col lg:flex-row max-w-full">
         <div className="max-w-full lg:max-w-sm flex justify-center items-center">
+          {!imgLoaded && <div className="w-[24rem] h-[24rem] bg-gray-100 rounded-lg animate-pulse"></div>}
+
           <img
-            className="object-cover rounded-lg"
+            className={`object-cover rounded-lg ${imgLoaded ? "visible" : "invisible absolute w-3 h-3"}`}
             src={gatewayFromIpfs(nft?.url)}
+            onLoad={() => setImgLoaded(true)}
           />
         </div>
 


### PR DESCRIPTION
# Description

Added an animated-pulsing 24remx24rem skeleton for nft modals.

![image](https://user-images.githubusercontent.com/635806/201664548-affde1db-d2af-4a57-b86f-80b7f6e0345a.png)
![image](https://user-images.githubusercontent.com/635806/201664700-5c0162ef-5780-4f4e-b1e0-3190dc7f3870.png)

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Visually

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
