### PR TITLE
feat(sb): bind to passport service to authenticate calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,5 @@
     "auto": "10.37.6",
     "yarn-run-all": "3.1.1"
   },
-  "packageManager": "yarn@3.2.4",
-  "dependencies": {
-    "classnames": "2.3.2",
-    "wagmi": "0.8.1"
-  }
+  "packageManager": "yarn@3.2.4"
 }

--- a/platform/starbase/package.json
+++ b/platform/starbase/package.json
@@ -6,6 +6,7 @@
     "build": "node build.js",
     "deploy": "wrangler publish",
     "deploy:dev": "wrangler publish --env dev",
+    "dev": "run-s dev:local",
     "dev:local": "run-s types:check build wrangler:local",
     "dev:remote": "run-s types:check build wrangler:remote",
     "format": "run-s format:src",
@@ -36,6 +37,7 @@
     "@kubelt/do.starbase-contract": "workspace:*",
     "@kubelt/do.starbase-user": "workspace:*",
     "@kubelt/openrpc": "workspace:*",
+    "@kubelt/platform.commons": "workspace:*",
     "cross-env": "7.0.3",
     "lodash": "4.17.21",
     "multiformats": "10.0.2"

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -14,11 +14,11 @@ workers_dev = false
 
 # Services
 # -----------------------------------------------------------------------------
-
 # A list of other Clouflare services bound to this service.
-# services = [
-#   { binding = "AUTH", service = "auth", environment = "production" },
-# ]
+
+services = [
+  { binding = "Account", service = "account" }
+]
 
 # Secrets
 # -----------------------------------------------------------------------------
@@ -65,6 +65,10 @@ new_classes = [
 
 [env.dev]
 
+services = [
+  { binding = "Account", service = "account-dev", environment = "production" }
+]
+
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },
   { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
@@ -84,6 +88,10 @@ PLATFORM_OWNER = "@kubelt"
 
 [env.next]
 
+services = [
+  { binding = "Account", service = "account-next", environment = "production" }
+]
+
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },
   { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
@@ -102,6 +110,10 @@ PLATFORM_OWNER = "@kubelt"
 # -----------------------------------------------------------------------------
 
 [env.current]
+
+services = [
+  { binding = "Account", service = "account-current", environment = "production" }
+]
 
 durable_objects.bindings = [
   { name = "STARBASE_APP", class_name = "StarbaseApplication" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5307,7 +5307,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kubelt/platform.commons@*, @kubelt/platform.commons@workspace:platform/commons":
+"@kubelt/platform.commons@*, @kubelt/platform.commons@workspace:*, @kubelt/platform.commons@workspace:platform/commons":
   version: 0.0.0-use.local
   resolution: "@kubelt/platform.commons@workspace:platform/commons"
   dependencies:
@@ -5445,6 +5445,7 @@ __metadata:
     "@kubelt/do.starbase-contract": "workspace:*"
     "@kubelt/do.starbase-user": "workspace:*"
     "@kubelt/openrpc": "workspace:*"
+    "@kubelt/platform.commons": "workspace:*"
     "@types/itty-router-extras": 0.4.0
     "@types/lodash": 4.14.187
     cross-env: 7.0.3
@@ -27491,8 +27492,6 @@ __metadata:
   resolution: "kubelt@workspace:."
   dependencies:
     auto: 10.37.6
-    classnames: 2.3.2
-    wagmi: 0.8.1
     yarn-run-all: 3.1.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Description

Use `@kubelt/platform.commons` utility `isAuthenticated()` from starbase worker to authenticate requests.

Incidental:
- remove a couple of legacy dependencies from root `package.json`:
  - `classnames`: not used with tailwind
  - `wagmi`: should be required by specific workspaces that require it