### PR TITLE
feat(sb): store and retrieve application IDs for users

### DIFF
--- a/packages/cores/user/index.ts
+++ b/packages/cores/user/index.ts
@@ -13,10 +13,13 @@ import type {
 } from "@kubelt/openrpc/component";
 
 import {
+  FieldAccess,
   component,
-  scopes,
+  field,
   method,
+  requiredField,
   requiredScope,
+  scopes,
 } from "@kubelt/openrpc/component";
 
 // The OpenRPC schema that defines the RPC API provided by the Durable Object.
@@ -36,6 +39,18 @@ import schema from "./schema";
   "owner",
   "starbase.user",
 ])
+@field({
+  name: "apps",
+  doc: "A set of user application IDs",
+  defaultValue: new Set(),
+  /*
+  scopes: {
+    read: ["starbase.read"],
+    write: ["starbase.write"],
+  },
+  validator: (x) => { return true },
+  */
+})
 export class StarbaseUser {
 
   // user_name
@@ -53,6 +68,43 @@ export class StarbaseUser {
       invoked: "user_name",
       context: "StarbaseUser",
     });
+  }
+
+  // add_application
+  // ---------------------------------------------------------------------------
+
+  @method("add_application")
+  @requiredScope("starbase.user")
+  @requiredField("apps", [FieldAccess.Read, FieldAccess.Write])
+  addApplication(
+    params: RpcParams,
+    input: RpcInput,
+    output: RpcOutput,
+  ): Promise<RpcResult> {
+    const appSet = input.get("apps")
+    const appId = params.get("appId")
+    // Add the supplied application ID to the list of user's applications.
+    if (appId !== undefined) {
+      appSet.add(appId)
+      output.set("apps", appSet)
+    }
+    return Promise.resolve(appId);
+  }
+
+  // list_applications
+  // ---------------------------------------------------------------------------
+
+  @method("list_applications")
+  @requiredScope("starbase.user")
+  @requiredField("apps", [FieldAccess.Read])
+  listApps(
+    params: RpcParams,
+    input: RpcInput,
+  ): Promise<RpcResult> {
+    const appSet = input.get("apps")
+    const appList = Array.from(appSet)
+
+    return Promise.resolve(appList)
   }
 
 } // END StarbaseUser

--- a/packages/cores/user/schema.ts
+++ b/packages/cores/user/schema.ts
@@ -25,9 +25,53 @@ const rpcSchema: RpcSchema = {
       },
       errors: [],
     },
+    {
+      name: "add_application",
+      summary: "Add an application ID to list of user's applications",
+      params: [
+        {
+          name: "appId",
+          schema: {
+            "$ref": "#/components/contentDescriptors/AppId",
+          },
+        },
+      ],
+      result: {
+        name: "appId",
+        description: "The application ID that was added",
+        schema: {
+          "$ref": "#components/contentDescriptors/AppId",
+        },
+      },
+      errors: [],
+    },
+    {
+      name: "list_applications",
+      summary: "Return a list of the user's application IDs",
+      params: [],
+      result: {
+        name: "appIds",
+        description: "The list of user's application IDs",
+        schema: {
+          type: "array",
+          items: {
+            "$ref": "#components/contentDescriptors/AppId",
+          },
+        },
+      },
+      errors: [],
+    },
   ],
   components: {
     contentDescriptors: {
+      "AppId": {
+        name: "appId",
+        required: true,
+        description: "An application ID",
+        schema: {
+          "$ref": "#/components/schema/AppId",
+        },
+      },
       "UserName": {
         name: "userName",
         required: true,
@@ -38,6 +82,9 @@ const rpcSchema: RpcSchema = {
       },
     },
     schemas: {
+      "AppId": {
+        type: "string",
+      },
       "UserName": {
         type: "string",
       },

--- a/platform/starbase/curl/kb_appList.json
+++ b/platform/starbase/curl/kb_appList.json
@@ -3,5 +3,6 @@
   "id": 1,
   "method": "kb_appList",
   "params": {
+    "ownerId": "@kubelt"
   }
 }

--- a/platform/starbase/package.json
+++ b/platform/starbase/package.json
@@ -19,7 +19,7 @@
     "lint:check": "run-s lint:check:*",
     "lint:check:src": "eslint src",
     "types:check": "tsc --project tsconfig.json --noEmit",
-    "wrangler:local": "wrangler dev --env dev --local --persist",
+    "wrangler:local": "wrangler dev --local --persist",
     "wrangler:remote": "wrangler dev --env dev"
   },
   "devDependencies": {

--- a/platform/starbase/wrangler.toml
+++ b/platform/starbase/wrangler.toml
@@ -20,6 +20,22 @@ services = [
   { binding = "Account", service = "account" }
 ]
 
+# Durable Objects
+# -----------------------------------------------------------------------------
+
+durable_objects.bindings = [
+  { name = "STARBASE_APP", class_name = "StarbaseApplication" },
+  { name = "STARBASE_CONTRACT", class_name = "StarbaseContract" },
+  { name = "STARBASE_USER", class_name = "StarbaseUser" },
+]
+
+# KV
+# -----------------------------------------------------------------------------
+
+kv_namespaces = [
+  { binding = "FIXTURES", id = "29bcce9f29d9499688da216bcc3dbb49", preview_id = "afbd7707df58426c9926a483c979b9a5" }
+]
+
 # Secrets
 # -----------------------------------------------------------------------------
 
@@ -29,7 +45,11 @@ services = [
 # Required secrets:
 # N/A
 
-# Durable Objects
+[vars]
+ENVIRONMENT = "local"
+PLATFORM_OWNER = "@kubelt"
+
+# Dev: Migrations
 # -----------------------------------------------------------------------------
 
 [dev]
@@ -41,6 +61,12 @@ new_classes = [
   "StarbaseContract",
   "StarbaseUser",
 ]
+# renamed_classes = [
+#   { from = "OldName", to = "NewName" }
+# ]
+# deleted_classes = [
+#   "DeprecatedClass"
+# ]
 
 # KV
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Description

- [x] forward JWT to components when making RPC calls to DOs
- [x] add methods to `StarbaseUser` core:
  - [x] `add_application` - to record an application ID as belonging to user
  - [x] `list_applications` - to retrieve a list of the user's applications
- [x] update `kb_initPlatform` call to create User component 
- [x] fixes for local wrangler configuration   