### PR TITLE
feat(sb): misc improvements

### DIFF
--- a/packages/cores/application/index.ts
+++ b/packages/cores/application/index.ts
@@ -3,6 +3,8 @@
  * @file src/index.ts
  */
 
+import * as _ from "lodash";
+
 import * as openrpc from "@kubelt/openrpc";
 
 import type {
@@ -128,10 +130,33 @@ export class StarbaseApplication {
   ): Promise<RpcResult> {
     const app = input.get("app");
 
-    return Promise.resolve({
-      invoked: "app_fetch",
-      app,
-    });
+    return Promise.resolve(app);
+  }
+
+  // public_profile
+  // -----------------------------------------------------------------------------
+
+  @method("public_profile")
+  @requiredScope("starbase.read")
+  @requiredField("app", [FieldAccess.Read])
+  publicProfile(
+    params: RpcParams,
+    input: RpcInput,
+    output: RpcOutput,
+  ): Promise<RpcResult> {
+    const app = input.get("app")
+
+    // If the application is not published we shouldn't return any
+    // information.
+    let profile = {}
+    if (app?.published == true) {
+      profile = _.omit(app, [
+        'clientSecret',
+        'published',
+      ])
+    }
+
+    return Promise.resolve(profile)
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/cores/application/schema.ts
+++ b/packages/cores/application/schema.ts
@@ -38,6 +38,19 @@ const rpcSchema: RpcSchema = {
       },
       errors: [],
     },
+    {
+      name: "public_profile",
+      summary: "Return public view of application data",
+      params: [],
+      result: {
+        name: "profile",
+        description: "Public application data",
+        schema: {
+          type: "object"
+        }
+      },
+      errors: [],
+    },
   ],
   components: {
     contentDescriptors: {

--- a/packages/cores/user/index.ts
+++ b/packages/cores/user/index.ts
@@ -51,6 +51,11 @@ import schema from "./schema";
   validator: (x) => { return true },
   */
 })
+@field({
+  name: "index",
+  doc: "An index from app attributes into app IDs",
+  defaultValue: {},
+})
 export class StarbaseUser {
 
   // user_name
@@ -70,27 +75,6 @@ export class StarbaseUser {
     });
   }
 
-  // add_application
-  // ---------------------------------------------------------------------------
-
-  @method("add_application")
-  @requiredScope("starbase.user")
-  @requiredField("apps", [FieldAccess.Read, FieldAccess.Write])
-  addApplication(
-    params: RpcParams,
-    input: RpcInput,
-    output: RpcOutput,
-  ): Promise<RpcResult> {
-    const appSet = input.get("apps")
-    const appId = params.get("appId")
-    // Add the supplied application ID to the list of user's applications.
-    if (appId !== undefined) {
-      appSet.add(appId)
-      output.set("apps", appSet)
-    }
-    return Promise.resolve(appId);
-  }
-
   // list_applications
   // ---------------------------------------------------------------------------
 
@@ -105,6 +89,51 @@ export class StarbaseUser {
     const appList = Array.from(appSet)
 
     return Promise.resolve(appList)
+  }
+
+  // index_application
+  // ---------------------------------------------------------------------------
+
+  @method("index_application")
+  @requiredScope("starbase.user")
+  @requiredField("apps", [FieldAccess.Read, FieldAccess.Write])
+  @requiredField("index", [FieldAccess.Read, FieldAccess.Write])
+  appIndex(
+    params: RpcParams,
+    input: RpcInput,
+    output: RpcOutput,
+  ): Promise<RpcResult> {
+    // Unique identifier
+    const id = params.get("id")
+    console.log(`id = ${id}`)
+    const data = params.get("data")
+    console.log(`data = ${data}`)
+    const fields = params.get("fields")
+    console.log(`fields = ${fields}`)
+
+    // Store the application ID.
+    if (id !== undefined) {
+      const apps = input.get("apps")
+      apps.add(id)
+      output.set("apps", apps)
+    }
+
+    // Index the data by the request fields.
+
+    return Promise.resolve({fixme: true})
+  }
+
+  // lookup_application
+  // ---------------------------------------------------------------------------
+
+  @method("lookup_application")
+  @requiredScope("starbase.user")
+  @requiredField("apps", [FieldAccess.Read])
+  appLookup(
+    params: RpcParams,
+    input: RpcInput,
+  ): Promise<RpcResult> {
+    return Promise.resolve("")
   }
 
 } // END StarbaseUser

--- a/packages/cores/user/schema.ts
+++ b/packages/cores/user/schema.ts
@@ -26,29 +26,68 @@ const rpcSchema: RpcSchema = {
       errors: [],
     },
     {
-      name: "add_application",
-      summary: "Add an application ID to list of user's applications",
-      params: [
-        {
-          name: "appId",
-          schema: {
-            "$ref": "#/components/contentDescriptors/AppId",
-          },
-        },
-      ],
+      name: "list_applications",
+      summary: "Return a list of the user's application IDs",
+      params: [],
       result: {
-        name: "appId",
-        description: "The application ID that was added",
+        name: "appIds",
+        description: "The list of user's application IDs",
         schema: {
-          "$ref": "#components/contentDescriptors/AppId",
+          type: "array",
+          items: {
+            "$ref": "#components/contentDescriptors/AppId",
+          },
         },
       },
       errors: [],
     },
     {
-      name: "list_applications",
-      summary: "Return a list of the user's application IDs",
-      params: [],
+      name: "index_application",
+      summary: "Index an application to enable lookup",
+      params: [
+        {
+          name: "id",
+          summary: "The unique application identifier",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+        {
+          name: "data",
+          summary: "An application record",
+          required: true,
+          schema: {
+            type: "object"
+          }
+        },
+        {
+          name: "fields",
+          summary: "A list of field names to index",
+          required: true,
+          schema: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      ],
+      result: {
+        name: "appId",
+        description: "The ID of the indexed application",
+        schema: {
+          type: "string",
+        },
+      },
+      errors: [],
+    },
+    {
+      name: "lookup_application",
+      summary: "Find an application ID by indexed field(s)",
+      params: [
+
+      ],
       result: {
         name: "appIds",
         description: "The list of user's application IDs",

--- a/packages/openrpc/component/index.ts
+++ b/packages/openrpc/component/index.ts
@@ -850,7 +850,7 @@ export function component(schema: Readonly<RpcSchema>) {
         // - @rpcBucket: adds an R2 bucket to the context
         // - @rpcKV: adds a KV store to the context
         // etc.
-        const context = openrpc.context()
+        const context = openrpc.context(request)
 
         return await this._rpcHandler(request, context)
       }

--- a/packages/openrpc/constants.ts
+++ b/packages/openrpc/constants.ts
@@ -6,4 +6,13 @@
 //
 // TODO once extracted and validated, pass in the RpcRequest instance as
 // an additional handler parameter alongside request and context?
-export const REQUEST_CONTEXT_KEY = 'com.kubelt.openrpc/request'
+export const KEY_REQUEST_RAW = 'com.kubelt.openrpc/request.raw'
+
+// The parsed RPC request.
+export const KEY_REQUEST_RPC = 'com.kubelt.openrpc/request.rpc'
+
+// The location in the context map where we store the Environment.
+export const KEY_REQUEST_ENV = 'com.kubelt.openrpc/env'
+
+// The location in the context map where we store the ExecutionContext.
+export const KEY_REQUEST_CTX = 'com.kubelt.openrpc/context'

--- a/packages/openrpc/index.ts
+++ b/packages/openrpc/index.ts
@@ -12,6 +12,7 @@ import type { RpcContext } from './impl/context'
 
 import type {
   OpenRpcHandler,
+  RpcAuthHandler,
   RpcChain,
   RpcChainFn,
   RpcError,
@@ -43,6 +44,7 @@ export type {
   MiddlewareFn,
   MiddlewareResult,
   OpenRpcHandler,
+  RpcAuthHandler,
   RpcChain,
   RpcContext,
   RpcError,
@@ -73,8 +75,12 @@ export type {
 /**
  * Construct a new request context.
  */
-export function context(): RpcContext {
-  return impl.context()
+export function context<Env = unknown>(
+  request: Request,
+  env?: Env,
+  ctx?: ExecutionContext
+): RpcContext {
+  return impl.context(request, env, ctx)
 }
 
 // options
@@ -379,7 +385,7 @@ export function build(
 export function client(
   // TODO better type?
   durableObject: DurableObjectNamespace,
-  name: string,
+  name: string | undefined,
   schema: RpcSchema,
   options: RpcClientOptions = {}
 ): RpcClient {
@@ -403,7 +409,7 @@ export function client(
 export async function discover(
   // TODO better type?
   durableObject: DurableObjectNamespace,
-  name: string,
+  name: string | undefined,
   options: RpcClientOptions = {}
 ): Promise<RpcClient> {
   return impl.discover(durableObject, name, options)

--- a/platform/starbase/curl/kb_appAuthCheck.json
+++ b/platform/starbase/curl/kb_appAuthCheck.json
@@ -1,0 +1,12 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "kb_appAuthCheck",
+  "params": {
+    "appId": "@kubelt/console",
+    "redirectURL": "https://console.kubelt.com/dashboard",
+    "scopes": [],
+    "clientId": "f5f43b2354c644360f6ba49c9e7b5e5a",
+    "clientSecret": "secret:3a9d793f64b8a05a3905a729f16cb03ff29be10c"
+  }
+}

--- a/platform/starbase/curl/kb_appAuthCheck.json
+++ b/platform/starbase/curl/kb_appAuthCheck.json
@@ -4,7 +4,7 @@
   "method": "kb_appAuthCheck",
   "params": {
     "appId": "@kubelt/console",
-    "redirectURL": "https://console.kubelt.com/dashboard",
+    "redirectURI": "https://console.kubelt.com/dashboard",
     "scopes": [],
     "clientId": "f5f43b2354c644360f6ba49c9e7b5e5a",
     "clientSecret": "secret:3a9d793f64b8a05a3905a729f16cb03ff29be10c"

--- a/platform/starbase/curl/kb_appAuthCheck.json
+++ b/platform/starbase/curl/kb_appAuthCheck.json
@@ -5,7 +5,7 @@
   "params": {
     "appId": "@kubelt/console",
     "redirectURI": "https://console.kubelt.com/dashboard",
-    "scopes": [],
+    "scopes": ["app:admin"],
     "clientId": "f5f43b2354c644360f6ba49c9e7b5e5a",
     "clientSecret": "secret:3a9d793f64b8a05a3905a729f16cb03ff29be10c"
   }

--- a/platform/starbase/curl/kb_appAuthInfo.json
+++ b/platform/starbase/curl/kb_appAuthInfo.json
@@ -1,9 +1,0 @@
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "kb_appAuthInfo",
-  "params": {
-    "ownerId": "robert",
-    "appId": "81cc0dab-2c0a-412d-b82f-0a392823a15f"
-  }
-}

--- a/platform/starbase/curl/kb_appProfile.json
+++ b/platform/starbase/curl/kb_appProfile.json
@@ -1,0 +1,8 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "kb_appProfile",
+  "params": {
+    "appId": "@kubelt/console"
+  }
+}

--- a/platform/starbase/curl/kb_appStore.json
+++ b/platform/starbase/curl/kb_appStore.json
@@ -6,7 +6,7 @@
     "published": false,
     "clientId": "deadbeefdeadbeefdeadbeefdeadbeef",
     "clientSecret": "secret:0000000000000000000000000000000000000000",
-    "redirectURL": "https://example.com/auth/successful",
+    "redirectURI": "https://example.com/auth/successful",
     "domains": [],
     "scopes": [],
     "termsURL": "",

--- a/platform/starbase/curl/kb_appStore.json
+++ b/platform/starbase/curl/kb_appStore.json
@@ -3,25 +3,20 @@
   "id": 1,
   "method": "kb_appStore",
   "params": {
-    "ownerId": "robert",
-    "appId": "81cc0dab-2c0a-412d-b82f-0a392823a15f",
-    "app": {
-      "published": false,
-      "clientId": "deadbeefdeadbeefdeadbeefdeadbeef",
-      "clientSecret": "secret:0000000000000000000000000000000000000000",
-      "redirectURL": "https://example.com/auth/successful",
-      "domains": [],
-      "scopes": [],
-      "termsURL": "",
-      "websiteURL": "",
-      "mirrorURL": "",
-      "discordURL": "",
-      "mediumUser": "",
-      "twitterUser": "",
-      "id": "81cc0dab-2c0a-412d-b82f-0a392823a15f",
-      "createdDate": "Tue, 18 Oct 2022 19:34:07 GMT",
-      "name": "Cat Party",
-      "icon": "https://imagedelivery.net/GpF42-mqjMIqmRcX5aE9gQ/29ba0048-1c8e-44e5-23d2-2f61b7fb0100/icon"
-    }
+    "published": false,
+    "clientId": "deadbeefdeadbeefdeadbeefdeadbeef",
+    "clientSecret": "secret:0000000000000000000000000000000000000000",
+    "redirectURL": "https://example.com/auth/successful",
+    "domains": [],
+    "scopes": [],
+    "termsURL": "",
+    "websiteURL": "",
+    "mirrorURL": "",
+    "discordURL": "",
+    "mediumUser": "",
+    "twitterUser": "",
+    "createdDate": "Tue, 18 Oct 2022 19:34:07 GMT",
+    "name": "Cat Party",
+    "icon": "https://imagedelivery.net/GpF42-mqjMIqmRcX5aE9gQ/29ba0048-1c8e-44e5-23d2-2f61b7fb0100/icon"
   }
 }

--- a/platform/starbase/package.json
+++ b/platform/starbase/package.json
@@ -40,6 +40,7 @@
     "@kubelt/openrpc": "workspace:*",
     "@kubelt/platform.commons": "workspace:*",
     "cross-env": "7.0.3",
+    "jose": "4.11.0",
     "lodash": "4.17.21",
     "multiformats": "10.0.2"
   }

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -139,7 +139,7 @@ const rpcSchema: RpcSchema = {
           },
         },
         {
-          name: 'redirectURL',
+          name: 'redirectURI',
           schema: {
             type: 'string',
           },
@@ -295,10 +295,10 @@ const rpcSchema: RpcSchema = {
           clientSecret: {
             type: 'string',
           },
-          redirectURL: {
+          redirectURI: {
             type: 'string',
             format: 'uri',
-            pattern: '^https?://',
+            pattern: '^([a-z][a-z0-9\+\-\.])*://',
           },
           termsURL: {
             type: 'string',

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -18,6 +18,24 @@ const rpcSchema: RpcSchema = {
   ],
   methods: [
     {
+      name: 'kb_appCreate',
+      summary: 'Create a new application record',
+      params: [],
+      result: {
+        name: 'appId',
+        description: 'The ID of the newly created application',
+        schema: {
+          $ref: '#/components/contentDescriptors/AppId',
+        },
+      },
+      errors: [
+        {
+          code: 100,
+          message: 'Application ID already in use',
+        },
+      ],
+    },
+    {
       name: 'kb_appStore',
       summary: 'Store an application record',
       tags: [
@@ -111,36 +129,114 @@ const rpcSchema: RpcSchema = {
       },
     },
     {
-      name: 'kb_appAuthInfo',
-      summary: 'Return authorization details for an application',
+      name: 'kb_appAuthCheck',
+      summary: 'Check whether or not an access should be allowed',
       params: [
         {
-          $ref: '#/components/contentDescriptors/AppSelect',
+          name: 'appId',
+          schema: {
+            type: 'string',
+          },
         },
-      ],
-      result: {
-        name: 'authInfo',
-        description: 'OAuth details for the app',
-        schema: {
-          type: 'object',
-          required: [],
-          properties: {
-            clientId: {
-              type: 'string',
-            },
-            clientSecret: {
-              type: 'string',
-            },
-            redirectURI: {
-              type: 'string',
-              format: 'uri',
-            },
-            scope: {
+        {
+          name: 'redirectURL',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'scopes',
+          schema: {
+            type: 'array',
+            items: {
               type: 'string',
             },
           },
         },
+        {
+          name: 'clientId',
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'clientSecret',
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'allowed',
+        description: 'Is access allowed?',
+        schema: {
+          type: 'boolean',
+        },
       },
+    },
+    {
+      name: 'kb_appRotateSecret',
+      summary: 'Invalidate an old secret and replace it with a new value',
+      params: [
+        {
+          // TODO refer to a secret content descriptor
+          name: 'secret',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'success',
+        schema: {
+          type: 'boolean',
+        },
+      },
+      errors: [],
+    },
+    {
+      name: 'kb_appPublish',
+      summary: 'Set the publication status of an application',
+      params: [
+        {
+          name: 'published',
+          required: true,
+          schema: {
+            type: 'boolean',
+          },
+        },
+      ],
+      result: {
+        name: 'status',
+        summary: 'The new publication status',
+        schema: {
+          type: 'boolean',
+        },
+      },
+      errors: [],
+    },
+    {
+      name: 'kb_appProfile',
+      summary: 'Return the public application profile',
+      params: [
+        {
+          name: 'appId',
+          required: true,
+          schema: {
+            // TODO app core ID, needs better type here
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'status',
+        summary: 'The new publication status',
+        schema: {
+          $ref: '#/components/schema/AppProfile',
+        },
+      },
+      errors: [],
     },
   ],
   components: {

--- a/platform/starbase/src/token.ts
+++ b/platform/starbase/src/token.ts
@@ -1,0 +1,37 @@
+// @kubelt/platform.starbase:src/token.ts
+
+import * as jose from 'jose'
+
+import { HEADER_CORE_AUTHENTICATION } from '@kubelt/platform.commons/src/constants'
+
+// fromRequest()
+// -----------------------------------------------------------------------------
+
+/**
+ * Extract the JWT from an incoming request.
+ *
+ * @param request - an HTTP request
+ *
+ * @returns the JWT associated with the request
+ */
+export function fromRequest(request: Request): string {
+  return request.headers.get(HEADER_CORE_AUTHENTICATION) || ''
+}
+
+// getUserId()
+// -----------------------------------------------------------------------------
+
+/**
+ * Extract the user ID from a JWT token.
+ *
+ * @param token - A JWT token string
+ */
+export function getUserId(token: string): string {
+  if (token === '') {
+    return ''
+  }
+
+  const decoded = jose.decodeJwt(token)
+  // The unique user ID can be found in the JWT 'sub' field.
+  return decoded?.sub ? decoded.sub : ''
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,6 +5430,7 @@ __metadata:
     cross-env: 7.0.3
     esbuild: 0.15.12
     eslint-plugin-tsdoc: 0.2.17
+    jose: 4.11.0
     lodash: 4.17.21
     multiformats: 10.0.2
     npm-run-all: 4.1.5


### PR DESCRIPTION
# Description

- [x] make auth checks fine-grained
  - when creating an `openrpc.method()` an `auth` fn can be supplied
  - this is effectively a middleware that is executed for that specific RPC method invocation
  - if it returns `void`, the auth check has succeeded
  - if it returns a `Response`, the request handling is short-circuited and the response is returned
- [x] wraps the commons `isAuthenticated()` check in a middleware for `platform/starbase`
- [x] applies the auth checking for every `starbase` service method except for:
  - `kb_initPlatform`
  - `kb_appProfile`
  -  `kb_appAuthCheck`
- [x] adds skeleton methods:
  - `kb_appRotateSecret`
  - `kb_appPublish`
  - `kb_appAuthCheck` (replaces `kb_appAuthInfo`)
- [x] initial work on app indexing for listing and lookup 