### PR TITLE
fix(nftar): Fix Cryptopunks 403 Error

### DIFF
--- a/projects/nftar/src/app.js
+++ b/projects/nftar/src/app.js
@@ -16,16 +16,15 @@ const streamToBlob = require('stream-to-blob');
 const fabric = require('fabric').fabric;
 const storage = require('nft.storage');
 const Web3 = require('web3');
-const imageDataURI = require('image-data-uri');
 const { convert } = require('convert-svg-to-png');
 const FormData = require('form-data');
 
 const {
-    isPFPOwner,
     calculateNFTWeight,
     calculateSpecialWeight,
     calculateBalanceWeight,
-    generateTraits
+    generateTraits,
+    encodeDataURI
 } = require('./utils.js');
 
 const {
@@ -33,6 +32,7 @@ const {
 } = require('./traits.js');
 
 const canvas = require('./canvas/canvas.js');
+const { encode } = require('node:punycode');
 
 // const {
 //     animationViewer
@@ -477,15 +477,8 @@ router.post('/api/v0/og-image', async (ctx, next) => {
 
         // Images that are remote need to be converted to Data URIs so that we can
         // render the SVG without triggering a cross-origin security violation.
-        const bkgURI = await imageDataURI.encodeFromURL(bkgURL.href).catch((e) => {
-            console.log(filename, 'failed to encode background image');
-            ctx.throw(500, `Image encoding error: ${JSON.stringify(e)}`);
-        });
-
-        const hexURI = await imageDataURI.encodeFromURL(hexURL.href).catch((e) => {
-            console.log(filename, 'failed to encode hexagon image');
-            ctx.throw(500, `Image encoding error: ${JSON.stringify(e)}`);
-        });
+        const hexURI = await encodeDataURI(hexURL.href)
+        const bkgURI = await encodeDataURI(bkgURL.href)
 
         // Constants for populating the SVG (optional).
         const OG_WIDTH = 1200;

--- a/projects/nftar/tests/datauri.js
+++ b/projects/nftar/tests/datauri.js
@@ -1,7 +1,6 @@
 // Tests for various Data URI libraries to see their image support.
 const fs = require('fs')
 const imageDataURI = require('image-data-uri')
-const sharp = require('sharp')
 const chromiumConverter = require('convert-svg-to-png')
 
 // Constants for populating the SVG (optional).
@@ -43,8 +42,6 @@ const test = async (hexURL, outfile) => {
 
     fs.writeFileSync(`${outfile}.svg`, svg)
     await chromiumConverter.convertFile(`${outfile}.svg`)
-
-    //await sharp(Buffer.from(svg)).toFormat('png').toFile(outfile);
 }
 
 const path = '/mnt/c/projects/images/'
@@ -64,3 +61,6 @@ test('https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg',
 
 // WEBP
 test('https://www.silverdisc.co.uk/sites/default/files/sd_importer/lion_webp_10.webp', `${path}test-webp.png`)
+
+// Cryptopunks are tricky.
+test('https://cryptopunks.app/cryptopunks/cryptopunk0294.png?customColor=638596', `${path}test-punk.png`)

--- a/projects/nftar/tests/utils.test.js
+++ b/projects/nftar/tests/utils.test.js
@@ -640,10 +640,10 @@ const ALCHEMY_NFTS_FIXTURE = {
 describe('Utilities', () => {
 
   test('getContractAddress return is expected', () => {
-	const CONTRACT_ADDRESSES_FIXTURE = ["0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d","0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb","0x60e4d786628fea6478f785a6d7e704777c86a7c6","0x23581767a106ae21c074b2276d25e5c3e136a68b","0x49cf6f5d44e70224e2e23fdcdd2c053f30ada28b","0x8a90cab2b38dba80c64b7734e58ee1db38b8992e","0xed5af388653567af2f388e6224dc7c4b3241c544","0xa3aee8bce55beea1951ef834b99f3ac60d1abeeb","0xe785e82358879f061bc3dcac6f0444462d4b5330","0xd4ac3ce8e1e14cd60666d49ac34ff2d2937cf6fa","0xcd79de06dd12b09c5beb567f83b2e9a51a4aafd6","0x92ce069c08e39bca867d45d2bdc4ebe94e28321a"]
-	const contractAddresses = traits.getContractAddresses();
-	expect(contractAddresses).toEqual(expect.arrayContaining(CONTRACT_ADDRESSES_FIXTURE));
-	expect(contractAddresses.length).toEqual(CONTRACT_ADDRESSES_FIXTURE.length);
+    const CONTRACT_ADDRESSES_FIXTURE = ["0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d","0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb","0x60e4d786628fea6478f785a6d7e704777c86a7c6","0x23581767a106ae21c074b2276d25e5c3e136a68b","0x49cf6f5d44e70224e2e23fdcdd2c053f30ada28b","0x8a90cab2b38dba80c64b7734e58ee1db38b8992e","0xed5af388653567af2f388e6224dc7c4b3241c544","0xa3aee8bce55beea1951ef834b99f3ac60d1abeeb","0xe785e82358879f061bc3dcac6f0444462d4b5330","0xd4ac3ce8e1e14cd60666d49ac34ff2d2937cf6fa","0xcd79de06dd12b09c5beb567f83b2e9a51a4aafd6","0x92ce069c08e39bca867d45d2bdc4ebe94e28321a"]
+    const contractAddresses = traits.getContractAddresses();
+    expect(contractAddresses).toEqual(expect.arrayContaining(CONTRACT_ADDRESSES_FIXTURE));
+    expect(contractAddresses.length).toEqual(CONTRACT_ADDRESSES_FIXTURE.length);
   });
 
   test('calculateNFTWeight null test', () => {


### PR DESCRIPTION
# Description

Fixes broken OpenGraph tags for people with Cryptopunks PFPs.

For some unclear reason (user agent?) the Cryptopunks app responds with a `403` when called from GCP with the legacy `Request` API. Fix is to use the contemporary `fetch` API to get the byte stream of the image and then convert _that_ to a data URI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local and Goerli

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation website
- [na] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
