### PR TITLE
chore: save changes to .yarnrc.yml after using upgrade-interactive

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,17 +1,22 @@
-defaultSemverRangePrefix: ''
+defaultSemverRangePrefix: ""
 
 nodeLinker: node-modules
 
+# - "workspaces": don't hoist packages past workspace that depends on them
+# - "dependencies": packages aren't hoisted past the direct dependencies for each workspace
+# - "none": [default] packages are hoisted as much as possible
 # nmHoistingLimits: workspaces
+
+npmScopes:
+  kubelt-ui:
+    npmRegistryServer: "https://node.bit.cloud"
+  teambit:
+    npmRegistryServer: "https://node.bit.cloud"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: '@yarnpkg/plugin-workspace-tools'
+    spec: "@yarnpkg/plugin-workspace-tools"
+  - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
+    spec: "@yarnpkg/plugin-interactive-tools"
 
 yarnPath: .yarn/releases/yarn-3.2.4.cjs
-
-npmScopes:
-  teambit:
-    npmRegistryServer: https://node.bit.cloud
-  kubelt-ui:
-    npmRegistryServer: https://node.bit.cloud


### PR DESCRIPTION
# Description

After installing the yarn plugin `interactive-tools` and running the included `upgrade-interactive` tools, the following changes (less the comments) were made to the `.yarnrc.yml` file. Sharing here in case they make sense to keep.

```
$ npx yarn plugin import interactive-tools
$ npx yarn upgrade-interactive
```