### PR TITLE
chore: ignore nested .yarn directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,5 +224,8 @@ act.secrets
 !.yarn/sdks
 !.yarn/versions
 
+# Only keep contents of top-level .yarn/
+**/.yarn
+
 # api-extractor
 temp


### PR DESCRIPTION
# Description

Update `.gitignore` to ignore subsidiary `.yarn` directories, e.g. `platform/.yarn`, `app/.yarn`, etc.