### PR TITLE
chore(platform): check environment

### DIFF
--- a/platform/address/src/env.ts
+++ b/platform/address/src/env.ts
@@ -1,0 +1,9 @@
+export const required = [
+  'ENS_RESOLVER_URL',
+  'MINTPFP_CONTRACT_ADDRESS',
+  'NFTAR_CHAIN_ID',
+  'NFTAR_TOKEN',
+  'NFTAR_URL',
+]
+
+export default { required }

--- a/platform/address/src/index.ts
+++ b/platform/address/src/index.ts
@@ -2,13 +2,19 @@ import { Router } from 'itty-router'
 
 import { handleOptions } from '@kubelt/platform.commons/src/routers/cors'
 import { discoveryHandler } from '@kubelt/platform.commons/src/routers/openrpc'
+import checkEnv from '@kubelt/platform.commons/src/utils/checkEnv'
 
 import Core from './core'
 import CryptoCore from './crypto-core'
 import jsonRpcHandler from './jsonrpc'
 import serviceDescription from './openrpc.json'
 
+import { required as requiredEnv } from './env'
+
 const index = Router()
+  .all('*', (_: unknown, env: Record<string, unknown>) =>
+    checkEnv(requiredEnv, env)
+  )
   .get('/openrpc.json', discoveryHandler(serviceDescription))
   .options('/jsonrpc', handleOptions({ headers: ['Content-Type'] }))
   .post('/jsonrpc', jsonRpcHandler)

--- a/platform/commons/src/utils/checkEnv.ts
+++ b/platform/commons/src/utils/checkEnv.ts
@@ -1,0 +1,7 @@
+export default (required: string[] = [], env: Record<string, unknown>) => {
+  required.forEach((name) => {
+    if (env[name] == null) {
+      throw `missing ${name} in the environment`
+    }
+  })
+}

--- a/platform/galaxy/package.json
+++ b/platform/galaxy/package.json
@@ -23,6 +23,7 @@
     "@graphql-tools/schema": "9.0.4",
     "@graphql-tools/stitch": "8.7.13",
     "@graphql-yoga/common": "2.12.12",
+    "@kubelt/platform.commons": "workspace:*",
     "graphql": "16.6.0",
     "urn": "1.1.0"
   }

--- a/platform/galaxy/src/env.ts
+++ b/platform/galaxy/src/env.ts
@@ -16,3 +16,13 @@ export default interface Env {
   ALCHEMY_CHAIN: string
   ALCHEMY_NETWORK: string
 }
+
+export const required = [
+  'Oort',
+  'Account',
+  'Address',
+  'Icons',
+  'ALCHEMY_KEY',
+  'ALCHEMY_CHAIN',
+  'ALCHEMY_NETWORK',
+]

--- a/platform/galaxy/src/index.ts
+++ b/platform/galaxy/src/index.ts
@@ -1,6 +1,8 @@
 import { createServer } from '@graphql-yoga/common'
 
-import Env from './env'
+import checkEnv from '@kubelt/platform.commons/src/utils/checkEnv'
+
+import Env, { required as requiredEnv } from './env'
 import schema from './schema'
 
 const yoga = createServer<{ env: Env; ctx: ExecutionContext }>({
@@ -17,27 +19,7 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
-    if (!env.Oort) {
-      throw Error('Oort service bind not set')
-    }
-    if (!env.Account) {
-      throw Error('Account service bind not set')
-    }
-    if (!env.Address) {
-      throw Error('Address service bind not set')
-    }
-    if (!env.Icons) {
-      throw Error('Icons service bind not set')
-    }
-    if (!env.ALCHEMY_KEY) {
-      throw Error('ALCHEMY_KEY not set')
-    }
-    if (!env.ALCHEMY_CHAIN) {
-      throw Error('ALCHEMY_CHAIN not set')
-    }
-    if (!env.ALCHEMY_NETWORK) {
-      throw Error('ALCHEMY_NETWORK not set')
-    }
+    checkEnv(requiredEnv, env as unknown as Record<string, unknown>)
     return yoga.handleRequest(request, { env, ctx })
   },
 }

--- a/platform/icons/package.json
+++ b/platform/icons/package.json
@@ -16,6 +16,7 @@
     "deploy": "wrangler publish"
   },
   "dependencies": {
+    "@kubelt/platform.commons": "workspace:*",
     "date-fns": "2.29.3",
     "tiny-invariant": "1.3.1"
   }

--- a/platform/icons/src/env.ts
+++ b/platform/icons/src/env.ts
@@ -1,0 +1,5 @@
+export const required = [
+  'CLOUDFLARE_ACCOUNT_ID',
+  'CLOUDFLARE_IMAGES_KEY',
+  'UPLOAD_WINDOW_SECONDS',
+]

--- a/platform/icons/src/index.ts
+++ b/platform/icons/src/index.ts
@@ -15,6 +15,9 @@
 import { add as dateAdd, formatRFC3339 as dateFormat } from "date-fns";
 
 import invariant from "tiny-invariant";
+import checkEnv from '@kubelt/platform.commons/src/utils/checkEnv'
+
+import { required as requiredEnv } from './env'
 
 // Environment
 // -----------------------------------------------------------------------------
@@ -49,6 +52,7 @@ export default {
     env: Env,
     ctx: ExecutionContext
   ): Promise<Response> {
+    checkEnv(requiredEnv, env as unknown as Record<string, unknown>)
 
     const { headers } = request;
     const contentType = headers.get("content-type") || "";

--- a/platform/starbase/src/env.ts
+++ b/platform/starbase/src/env.ts
@@ -1,0 +1,11 @@
+export const required = [
+  'FIXTURES',
+  'LOOKUP',
+  'STARBASE_APP',
+  'STARBASE_CONTRACT',
+  'STARBASE_USER',
+  'Account',
+  'ENVIRONMENT',
+  'PLATFORM_OWNER',
+  'DATADOG_TOKEN',
+]

--- a/platform/starbase/src/index.ts
+++ b/platform/starbase/src/index.ts
@@ -15,6 +15,8 @@ import * as openrpc from '@kubelt/openrpc'
 
 import invariant from 'tiny-invariant'
 
+import checkEnv from '@kubelt/platform.commons/src/utils/checkEnv'
+
 import type {
   RpcAuthHandler,
   RpcContext,
@@ -33,6 +35,7 @@ import { StarbaseApplication } from '@kubelt/do.starbase-application'
 import { StarbaseContract } from '@kubelt/do.starbase-contract'
 import { StarbaseUser } from '@kubelt/do.starbase-user'
 
+import { required as requiredEnv } from './env'
 import * as oauth from './oauth'
 import * as secret from './secret'
 import * as tokenUtil from './token'
@@ -798,6 +801,8 @@ export default {
     // third-party extensions to avoid setting conflicting keys.
     //
     // NBB: secrets are set via the dashboard or using the wrangler CLI tool.
+
+    checkEnv(requiredEnv, env as unknown as Record<string, unknown>)
 
     // TODO allow context to be initialized in this function.
     const context = openrpc.context(request, env, ctx)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5448,6 +5448,7 @@ __metadata:
     "@graphql-tools/schema": 9.0.4
     "@graphql-tools/stitch": 8.7.13
     "@graphql-yoga/common": 2.12.12
+    "@kubelt/platform.commons": "workspace:*"
     concurrently: 7.5.0
     graphql: 16.6.0
     npm-run-all: 4.1.5
@@ -5462,6 +5463,7 @@ __metadata:
   resolution: "@kubelt/platform.icons@workspace:platform/icons"
   dependencies:
     "@cloudflare/workers-types": 3.18.0
+    "@kubelt/platform.commons": "workspace:*"
     date-fns: 2.29.3
     npm-run-all: 4.1.5
     tiny-invariant: 1.3.1


### PR DESCRIPTION
It is not possible to have a startup time check as the environment object is only present in the fetch context only. The best possibility is to declare required environment keys in a single place and have them looked up like middleware in the `fetch` handler. I think it'd be perhaps better to guard references to the environment keys instead of doing it like this.