### PR TITLE
fix(threeid): computed tailwind classes

### DIFF
--- a/apps/threeid/app/components/inputs/InputText.tsx
+++ b/apps/threeid/app/components/inputs/InputText.tsx
@@ -51,17 +51,17 @@ const InputText = ({
       <div className="mt-1 text-base flex">
         {addon && (
           <span
-            className={`inline-flex items-center rounded-l-md border border-r-0 border-${
-              error ? 'red-500' : 'gray-300'
-            } shadow-sm focus:border-${
-              error ? 'red' : 'indigo'
-            }-500 focus:ring-${
-              error ? 'red' : 'indigo'
-            }-500 disabled:cursor-not-allowed disabled:border-${
-              error ? 'red' : 'gray'
-            }-200 disabled:bg-${error ? 'red' : 'gray'}-50 placeholder-${
-              error ? 'red' : 'gray'
-            }-400 bg-gray-50 px-3`}
+            className={`inline-flex items-center rounded-l-md border border-r-0 ${
+              error ? 'border-red-500' : 'border-gray-300'
+            } shadow-sm ${
+              error ? 'focus:border-red-500' : 'focus:border-indigo-500'
+            } ${
+              error ? 'focus:ring-red-500' : 'focus:ring-indigo-500'
+            } disabled:cursor-not-allowed ${
+              error ? 'disabled:border-red-200' : 'disabled:border-gray-200'
+            } ${error ? 'disabled:bg-red-50' : 'disabled:bg-gray-50'} ${
+              error ? 'placeholder-red-400' : 'placeholder-gray-400'
+            } bg-gray-50 px-3`}
           >
             <Text
               size="sm"
@@ -73,7 +73,9 @@ const InputText = ({
           </span>
         )}
         <div
-          className={`relative text-${error ? 'red' : 'gray'}-900 flex flex-1`}
+          className={`relative ${
+            error ? 'text-red-900' : 'text-gray-900'
+          } flex flex-1`}
         >
           {Icon && (
             <div
@@ -81,13 +83,13 @@ const InputText = ({
                 // Seems to be a problem with the `pr-3` class not adding padding
                 paddingRight: iconPosition === 'trailing' ? '0.75rem' : 0,
               }}
-              className={`text-${
-                error ? 'red' : 'gray'
-              }-400 pointer-events-none absolute inset-y-0 ${
+              className={`${
+                error ? 'text-red-400' : 'text-gray-400'
+              } pointer-events-none absolute inset-y-0 ${
                 iconPosition === 'trailing' ? 'right-0' : 'left-0'
-              } flex items-center p${
-                iconPosition === 'trailing' ? 'r' : 'l'
-              }-3`}
+              } flex items-center ${
+                iconPosition === 'trailing' ? 'pr-3' : 'pl-3'
+              }`}
             >
               <Icon
                 style={{
@@ -109,18 +111,18 @@ const InputText = ({
             }}
             defaultValue={defaultValue}
             disabled={disabled ?? false}
-            className={`${
-              addon ? 'rounded-none rounded-r-md' : 'rounded-md'
-            } border-${error ? 'red-500' : 'gray-300'} shadow-sm focus:border-${
-              error ? 'red' : 'indigo'
-            }-500 focus:ring-${
-              error ? 'red' : 'indigo'
-            }-500 disabled:cursor-not-allowed disabled:border-${
-              error ? 'red' : 'gray'
-            }-200 disabled:bg-${error ? 'red' : 'gray'}-50 placeholder-${
-              error ? 'red' : 'gray'
-            }-400 ${
-              Icon ? `p${iconPosition === 'trailing' ? 'r' : 'l'}-10` : ''
+            className={`${addon ? 'rounded-none rounded-r-md' : 'rounded-md'} ${
+              error ? 'border-red-500' : 'border-gray-300'
+            } shadow-sm ${
+              error ? 'focus:border-red-500' : 'focus:border-indigo-500'
+            } ${
+              error ? 'focus:ring-red-500' : 'focus:ring-indigo-500'
+            } disabled:cursor-not-allowed ${
+              error ? 'disabled:border-red-200' : 'disabled:border-gray-200'
+            } ${error ? 'disabled:bg-red-50' : 'disabled:bg-gray-50'} ${
+              error ? 'placeholder-red-400' : 'placeholder-gray-400'
+            } ${
+              Icon ? `${iconPosition === 'trailing' ? 'pr-10' : 'pl-10'}` : ''
             } w-full`}
             maxLength={maxChars}
             placeholder={placeholder}

--- a/apps/threeid/app/components/inputs/InputTextarea.tsx
+++ b/apps/threeid/app/components/inputs/InputTextarea.tsx
@@ -57,9 +57,9 @@ const InputTextarea = ({
 
       <div className="mt-1 text-base flex">
         <div
-          className={`relative text-${
-            computedError ? 'red' : 'gray'
-          }-900 flex flex-1`}
+          className={`relative ${
+            computedError ? 'text-red-900' : 'text-gray-900'
+          } flex flex-1`}
         >
           <textarea
             name={computedName}
@@ -72,19 +72,19 @@ const InputTextarea = ({
             rows={rows}
             defaultValue={defaultValue}
             disabled={disabled ?? false}
-            className={`border-${
-              computedError ? 'red-500' : 'gray-300'
-            } shadow-sm focus:border-${
-              computedError ? 'red' : 'indigo'
-            }-500 focus:ring-${
-              computedError ? 'red' : 'indigo'
-            }-500 disabled:cursor-not-allowed disabled:border-${
-              computedError ? 'red' : 'gray'
-            }-200 disabled:bg-${
-              computedError ? 'red' : 'gray'
-            }-50 placeholder-${
-              computedError ? 'red' : 'gray'
-            }-400 w-full rounded-md`}
+            className={`${
+              computedError ? 'border-red-500' : 'border-gray-300'
+            } shadow-sm ${
+              computedError ? 'focus:border-red-500' : 'focus:border-indigo-500'
+            } ${
+              computedError ? 'focus:ring-red-500' : 'focus:ring-indigo-500'
+            } disabled:cursor-not-allowed ${
+              computedError
+                ? 'disabled:border-red-200'
+                : 'disabled:border-gray-200'
+            } ${computedError ? 'disabled:bg-red-50' : 'disabled:bg-gray-50'} ${
+              computedError ? 'placeholder-red-400' : 'placeholder-gray-400'
+            } w-full rounded-md`}
             placeholder={placeholder}
             required={required}
           />


### PR DESCRIPTION
# Description

Tailwind doesn't know how to handle computed classes like 'p' + 'l' + '-3' `pl-3` so we must be specific about them. Inputs will be refactored and moved to design system in the future and proper twcss will be used.

![image](https://user-images.githubusercontent.com/635806/206153694-49befcba-696a-451a-bb64-6ef1b9ef60dd.png)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visually

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
