### PR TITLE
feat(sb): more edges integration, flesh out API methods

### DIFF
--- a/packages/openrpc/component/alarm.ts
+++ b/packages/openrpc/component/alarm.ts
@@ -11,7 +11,6 @@ import { add } from 'date-fns'
  * A utility class for setting an alarm time in a durable object.
  */
 export class RpcAlarm {
-
   private _timestamp: Date | undefined
 
   /**
@@ -55,5 +54,4 @@ export class RpcAlarm {
     this._timestamp = add(Date.now(), duration)
     return this._timestamp
   }
-
 }

--- a/packages/openrpc/component/index.ts
+++ b/packages/openrpc/component/index.ts
@@ -77,7 +77,7 @@ type RpcResult = any
 type RpcAlarmCallable = (
   input: Readonly<RpcInput>,
   output: RpcOutput,
-  alarm: RpcAlarm,
+  alarm: RpcAlarm
 ) => void
 
 // Defines the signature for an OpenRPC handler method defined on a Durable
@@ -94,7 +94,7 @@ type RpcCallable = (
   // A utility class for scheduling alarms on the component. The method
   // decorated with the @alarm decorator is invoked when the alarm
   // fires.
-  alarm: RpcAlarm,
+  alarm: RpcAlarm
 
   //context: Map<string, any>,
   //remote: Map<string, any>,
@@ -115,7 +115,7 @@ type FieldSpec = {
   // The default value of the field.
   defaultValue: any
   // The validation function to apply before updating the field.
-  validator?: ValidatorFn;
+  validator?: ValidatorFn
 }
 
 enum FieldAccess {
@@ -145,17 +145,9 @@ type Env = unknown
 // Exports
 // -----------------------------------------------------------------------------
 
-export type {
-  RpcAlarm,
-  RpcInput,
-  RpcOutput,
-  RpcParams,
-  RpcResult,
-}
+export type { RpcAlarm, RpcInput, RpcOutput, RpcParams, RpcResult }
 
-export {
-  FieldAccess,
-}
+export { FieldAccess }
 
 // Middleware
 // -----------------------------------------------------------------------------
@@ -390,7 +382,7 @@ export function component(schema: Readonly<RpcSchema>) {
               requestParams,
               fieldInput,
               fieldOutput,
-              alarm,
+              alarm
             )
 
             // TODO validate that the returned result conforms to the OpenRPC schema.
@@ -433,9 +425,7 @@ export function component(schema: Readonly<RpcSchema>) {
        * @param fieldSet - a Set of fields configured for a method
        * @returns the set of fields converted into a map
        */
-      private _makeFieldMap(
-        fieldSet: Readonly<FieldSet>,
-      ) {
+      private _makeFieldMap(fieldSet: Readonly<FieldSet>) {
         const fieldMap: FieldMap = new Map()
         for (const field of fieldSet) {
           fieldMap.set(field.name, field)
@@ -447,9 +437,7 @@ export function component(schema: Readonly<RpcSchema>) {
       /**
        * Schedule an invocation of the @alarm handler method.
        */
-      private _scheduleAlarm(
-        alarm: RpcAlarm,
-      ) {
+      private _scheduleAlarm(alarm: RpcAlarm) {
         if (alarm.timestamp) {
           this._state.storage.setAlarm(alarm.timestamp)
           console.log(`scheduled alarm for ${alarm.timestamp}`)
@@ -558,7 +546,7 @@ export function component(schema: Readonly<RpcSchema>) {
         const fieldKeys = new Set(fields.keys())
         const updateKeys = set.intersection(outputKeys, fieldKeys)
 
-        for (const [fieldName,] of output.entries()) {
+        for (const [fieldName] of output.entries()) {
           if (!updateKeys.has(Symbol.for(fieldName))) {
             console.warn(
               `tried storing output "${fieldName}" without declaration; ignored`
@@ -954,7 +942,8 @@ export function component(schema: Readonly<RpcSchema>) {
           // Set(1): {
           //   { name: Symbol(someField), perms: Set(2) { 'read', 'write' } }
           // }
-          const fieldSet: FieldSet = fieldsRequired?.get(Symbol.for(alarmMethod)) || new Set()
+          const fieldSet: FieldSet =
+            fieldsRequired?.get(Symbol.for(alarmMethod)) || new Set()
           // TODO this should be a utility method that is shared.
           const fieldMap: FieldMap = this._makeFieldMap(fieldSet)
           // Load any configured field values.
@@ -968,7 +957,7 @@ export function component(schema: Readonly<RpcSchema>) {
           const alarmOutput = await this._alarmFn(
             fieldInput,
             fieldOutput,
-            alarm,
+            alarm
           )
 
           // Keep outputs for which there is write permission and
@@ -980,12 +969,10 @@ export function component(schema: Readonly<RpcSchema>) {
 
           // Schedule the next alarm if requested.
           this._scheduleAlarm(alarm)
-
         } else {
           console.error(`alarm fired but no handler configured using @alarm`)
         }
       }
-
     }
   }
 }
@@ -1231,7 +1218,6 @@ export function requiredField(name: string, perms: Readonly<FieldPerms>) {
  * parameter, and updates collected from the "output" map.
  */
 export function alarm() {
-
   // TODO check if alarm already set; throw if so, there can only be one
   // alarm handler.
   function getAlarmHandler(target: any) {
@@ -1245,7 +1231,7 @@ export function alarm() {
   return function (
     target: unknown,
     propertyKey: string,
-    descriptor: PropertyDescriptor,
+    descriptor: PropertyDescriptor
   ) {
     if (getAlarmHandler(target) !== undefined) {
       throw new Error('there can be only one; alarm handler already configured')

--- a/packages/openrpc/impl/client.ts
+++ b/packages/openrpc/impl/client.ts
@@ -64,11 +64,11 @@ type RpcProperties = {
   // The URN representation of a Durable Object ID.
   urn?: string
   // These are the components of the parsed URN.
-  nid?: string,
-  nss?: string,
-  rc?: string,
-  qc?: string,
-  fc?: string,
+  nid?: string
+  nss?: string
+  rc?: string
+  qc?: string
+  fc?: string
 }
 
 // RpcRequestOptions
@@ -308,7 +308,7 @@ export class RpcClient {
     const urnStr = urn?.toString()
 
     let parts = {}
-    if (typeof(urn) === 'object') {
+    if (typeof urn === 'object') {
       // The various components of the URN (if present).
       parts = {
         nid: urn?.nid,
@@ -319,14 +319,17 @@ export class RpcClient {
       }
     }
 
-    return _.merge({
-      // The ID of the durable object as a string.
-      id: idStr,
-      // The platform namespace ('threeid') URN of the object, if provided.
-      name,
-      // A URN representation of the internal durable object ID.
-      urn: urnStr,
-    }, parts)
+    return _.merge(
+      {
+        // The ID of the durable object as a string.
+        id: idStr,
+        // The platform namespace ('threeid') URN of the object, if provided.
+        name,
+        // A URN representation of the internal durable object ID.
+        urn: urnStr,
+      },
+      parts
+    )
   }
 
   // Access the "internal" method table.

--- a/packages/openrpc/impl/context.ts
+++ b/packages/openrpc/impl/context.ts
@@ -34,13 +34,13 @@ import * as _ from 'lodash'
  */
 export class RpcContext extends Map<string | symbol, any> {
   get(k: string | symbol): any {
-    if (typeof(k) === 'symbol') {
+    if (typeof k === 'symbol') {
       k = k.toString()
     }
     return _.get(this, k)
   }
   set(k: string | symbol, v: any): this {
-    if (typeof(k) === 'symbol') {
+    if (typeof k === 'symbol') {
       k = k.toString()
     }
     _.set(this, k, v)

--- a/packages/openrpc/impl/index.ts
+++ b/packages/openrpc/impl/index.ts
@@ -180,7 +180,7 @@ export type OpenRpcHandler = (
  */
 const authPass: RpcAuthHandler = (
   request: Readonly<Request>,
-  context: Readonly<RpcContext>,
+  context: Readonly<RpcContext>
 ): MiddlewareResult => {
   // Resolves to nothing which indicates successful check.
   return Promise.resolve()

--- a/packages/openrpc/impl/utility.ts
+++ b/packages/openrpc/impl/utility.ts
@@ -49,7 +49,7 @@ export function idFromOptions(
   } else if (Object.hasOwn(options, 'urn')) {
     const urn: AnyURN | ParsedURN<string, string> = options.urn!
     let parsedURN
-    if (typeof(urn) === 'string') {
+    if (typeof urn === 'string') {
       parsedURN = urns.parseURN(urn)
     } else {
       parsedURN = urn

--- a/packages/urns/application.ts
+++ b/packages/urns/application.ts
@@ -1,0 +1,5 @@
+import { createThreeIdURNSpace, ThreeIdURN } from './index'
+
+export type ApplicationURN = ThreeIdURN<`application/${string}`>
+export const ApplicationURNSpace =
+  createThreeIdURNSpace<'application'>('application')

--- a/platform/edges/src/index.ts
+++ b/platform/edges/src/index.ts
@@ -132,13 +132,15 @@ const kb_makeEdge = openrpc.method(schema, {
 
       // TAG
 
-      const tag = _.get(request, ['params', 'tag'])
-      if (_.isUndefined(tag)) {
+      const edgeTag = _.get(request, ['params', 'tag'])
+      if (_.isUndefined(edgeTag)) {
         return openrpc.error(request, ErrorMissingEdgeTag)
       }
-
-      // Constructs a URN for the edge "type" given a string tag.
-      const edgeTag: EdgeTag = graph.edge(tag)
+      try {
+        urns.parseURN(edgeTag)
+      } catch (e) {
+        return openrpc.error(request, ErrorInvalidEdgeTag)
+      }
 
       const edgeId = await graph.link(g, srcURN, dstURN, edgeTag)
 
@@ -279,6 +281,8 @@ const kb_rmEdge = openrpc.method(schema, {
 
       // Unlink the edge (if it exists).
       const edgeId = await graph.unlink(g, srcId, dstId, edgeTag)
+
+      console.log(`deleted edge ${edgeId}: ${srcId} =[${edgeTag}]=> ${dstId}`)
 
       return openrpc.response(request, {
         removed: edgeId,

--- a/platform/starbase/curl/kb_appCreate.json
+++ b/platform/starbase/curl/kb_appCreate.json
@@ -3,6 +3,6 @@
   "id": 1,
   "method": "kb_appCreate",
   "params": {
-    "ownerId": "robert"
+    "clientName": "foobar App"
   }
 }

--- a/platform/starbase/curl/kb_appList.json
+++ b/platform/starbase/curl/kb_appList.json
@@ -3,6 +3,5 @@
   "id": 1,
   "method": "kb_appList",
   "params": {
-    "ownerId": "@kubelt"
   }
 }

--- a/platform/starbase/curl/kb_appRotateSecret.json
+++ b/platform/starbase/curl/kb_appRotateSecret.json
@@ -1,0 +1,8 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "kb_appRotateSecret",
+  "params": {
+    "clientId": "9300468a8b0d9ae54ee13e5aa0aad650"
+  }
+}

--- a/platform/starbase/package.json
+++ b/platform/starbase/package.json
@@ -44,6 +44,7 @@
     "@kubelt/openrpc": "workspace:*",
     "@kubelt/platform.commons": "workspace:*",
     "@kubelt/security": "workspace:*",
+    "@kubelt/urns": "workspace:*",
     "cross-env": "7.0.3",
     "itty-router": "2.6.6",
     "itty-router-extras": "0.4.2",

--- a/platform/starbase/src/edge.ts
+++ b/platform/starbase/src/edge.ts
@@ -1,0 +1,113 @@
+// @threeid/platform.starbase:src/edge.ts
+
+import * as _ from 'lodash'
+
+import * as jose from 'jose'
+
+import { HEADER_ACCESS_TOKEN } from '@kubelt/platform.commons/src/constants'
+
+import type { AccountURN } from '@kubelt/urns/account'
+
+import { AccountURNSpace } from '@kubelt/urns/account'
+
+// Definitions
+// -----------------------------------------------------------------------------
+
+const EDGES_URL = 'http://edges.dev/jsonrpc'
+
+// link()
+// -----------------------------------------------------------------------------
+
+/**
+ * Make a call to remote edges service to create a link between nodes.
+ */
+export async function link(
+  edges: Fetcher,
+  src: string,
+  dst: string,
+  tag: string
+) {
+  const kb_makeEdge = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'kb_makeEdge',
+    params: {
+      src,
+      dst,
+      tag,
+    },
+  }
+  const edgeReq = new Request(EDGES_URL, {
+    method: 'POST',
+    body: JSON.stringify(kb_makeEdge),
+  })
+
+  return edges.fetch(edgeReq)
+}
+
+// unlink()
+// -----------------------------------------------------------------------------
+
+/**
+ * Make a call to remote edges service to remove a link between nodes.
+ */
+export async function unlink(
+  edges: Fetcher,
+  src: string,
+  dst: string,
+  tag: string
+) {
+  const kb_rmEdge = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'kb_rmEdge',
+    params: {
+      src,
+      dst,
+      tag,
+    },
+  }
+  const edgeReq = new Request(EDGES_URL, {
+    method: 'POST',
+    body: JSON.stringify(kb_rmEdge),
+  })
+
+  return edges.fetch(edgeReq)
+}
+
+// edges()
+// -----------------------------------------------------------------------------
+
+/**
+ * Get a list of edges entering or leaving a node.
+ */
+export async function edges(edges: Fetcher, id: string, tag: string) {
+  const kb_getEdges = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'kb_getEdges',
+    params: {
+      id,
+    },
+  }
+  const edgeReq = new Request(EDGES_URL, {
+    method: 'POST',
+    body: JSON.stringify(kb_getEdges),
+  })
+
+  const response = await edges.fetch(edgeReq)
+  const json: object = (await response.json()) || {}
+  if (Object.hasOwn(json, 'error')) {
+    return _.get(json, 'error')
+  }
+
+  const edgeList = _.get(json, ['result', 'edges'])
+
+  // Filter on edge type.
+  // TODO move into edges service! It should accept additional parameters:
+  // - direction
+  // - tag
+  return _.filter(edgeList, (edge) => {
+    return _.get(edge, 'srcUrn') === id && _.get(edge, 'tag') === tag
+  })
+}

--- a/platform/starbase/src/nodes/application/index.ts
+++ b/platform/starbase/src/nodes/application/index.ts
@@ -82,6 +82,11 @@ import schema from './schema'
   }
   */
 })
+@field({
+  name: 'secret',
+  doc: 'The OAuth client secret for the application',
+  defaultValue: '',
+})
 export class StarbaseApplication {
   // init
   // -----------------------------------------------------------------------------
@@ -201,6 +206,24 @@ export class StarbaseApplication {
     }
 
     return Promise.resolve(profile)
+  }
+
+  // updateSecret
+  // -----------------------------------------------------------------------------
+
+  @method('rotateSecret')
+  //@requiredScope()
+  @requiredField('secret', [FieldAccess.Write])
+  rotateSecret(
+    params: RpcParams,
+    input: RpcInput,
+    output: RpcOutput
+  ): Promise<RpcResult> {
+    // The new hashed secret is provided in the request.
+    const secret = params.get('secret')
+    output.set('secret', secret)
+
+    return Promise.resolve(true)
   }
 
   // ---------------------------------------------------------------------------

--- a/platform/starbase/src/nodes/application/schema.ts
+++ b/platform/starbase/src/nodes/application/schema.ts
@@ -68,6 +68,25 @@ const rpcSchema: RpcSchema = {
       },
       errors: [],
     },
+    {
+      name: 'rotateSecret',
+      summary: 'Set a new (hashed) application OAuth secret',
+      params: [
+        {
+          name: 'secret',
+          description: 'A hashed application OAuth secret',
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'success',
+        schema: {
+          type: 'boolean',
+        },
+      },
+    },
   ],
   components: {
     contentDescriptors: {

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -20,7 +20,15 @@ const rpcSchema: RpcSchema = {
     {
       name: 'kb_appCreate',
       summary: 'Create a new application record',
-      params: [],
+      params: [
+        {
+          name: 'clientName',
+          description: 'A human-readable name for the application',
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
       result: {
         name: 'appId',
         description: 'The ID of the newly created application',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5551,6 +5551,7 @@ __metadata:
     "@kubelt/openrpc": "workspace:*"
     "@kubelt/platform.commons": "workspace:*"
     "@kubelt/security": "workspace:*"
+    "@kubelt/urns": "workspace:*"
     "@types/itty-router-extras": 0.4.0
     "@types/lodash": 4.14.189
     cross-env: 7.0.3


### PR DESCRIPTION
# Description

## @kubelt/platform.starbase

- [x] now depends on `@kubelt/urns` package

### kb_appCreate

- [x] extract ID of application owner from JWT `sub` claim
- [x] required `clientName` parameter when constructing a new application node 
- [x] no longer generates/returns the client secret
  - you must now call `kb_appRotateSecret` to generate the OAuth client secret
- [x] returns the `clientId` for the application
  - this is used in subsequent calls as the app identifier
- [x] calls the `edges` service to create a link between account node and app node

### kb_appDelete

- [x] removes lookup table entry (from client ID to app node ID)
- [x] removes edge linking account node to app node

### kb_appList

- [x] account to list applications for is determined by the JWT `sub` claim

### kb_appRotateSecret

- [x] generates an OAuth client secret
  - returns the plaintext secret _once_ in response to this call
  - secret is stored hashed, and never handled as plaintext in the system again
- [x] adds a separate `secret` field to the application node
  - this field stores the current hashed application secret
  - secret rotation is _destructive_, overwriting the stored secret
- [x] exposes a `rotateSecret` method from the application node
 
## @kubelt/platform.edges

- [x] expect to receive a full edge tag URN when making an edge

## @kubelt/urns

- [x] add `ApplicationURN` type
  - used to name a starbase application node
- [x] add `ApplicationURNSpace`
  - utility for working with application URNs (membership testing, construction)