### PR TITLE
chore(gha): env var/secrets cleanup for Access, Account and Galaxy

### DIFF
--- a/.github/workflows/main-access.yaml
+++ b/.github/workflows/main-access.yaml
@@ -41,15 +41,8 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/access
           command: publish --env dev
           environment: dev
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/main-account.yaml
+++ b/.github/workflows/main-account.yaml
@@ -41,15 +41,8 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/account
           command: publish --env dev
           environment: dev
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/main-galaxy.yaml
+++ b/.github/workflows/main-galaxy.yaml
@@ -46,15 +46,14 @@ jobs:
       - name: Deploy Galaxy to Dev Worker
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'platform/galaxy'
           command: publish --env dev
           environment: 'dev'
           secrets: |
             APIKEY_ALCHEMY_ETH
             APIKEY_ALCHEMY_POLYGON
-
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           APIKEY_ALCHEMY_ETH: ${{ secrets.APIKEY_ALCHEMY_GALAXY_GOERLI }}
           APIKEY_ALCHEMY_POLYGON: ${{ secrets.APIKEY_ALCHEMY_POLYGON_MUMBAI }}

--- a/.github/workflows/next-access.yaml
+++ b/.github/workflows/next-access.yaml
@@ -41,15 +41,8 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/access
           command: publish --env next
           environment: next
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/next-account.yaml
+++ b/.github/workflows/next-account.yaml
@@ -41,15 +41,8 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/account
           command: publish --env next
           environment: next
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/next-galaxy.yaml
+++ b/.github/workflows/next-galaxy.yaml
@@ -45,7 +45,8 @@ jobs:
       - name: Deploy to Dev Worker
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'platform/galaxy'
           command: publish --env next
           environment: 'next'
@@ -53,8 +54,5 @@ jobs:
             APIKEY_ALCHEMY_ETH
             APIKEY_ALCHEMY_POLYGON
         env:
-          ADMIN_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           APIKEY_ALCHEMY_ETH: ${{ secrets.APIKEY_ALCHEMY_GALAXY_GOERLI }}
           APIKEY_ALCHEMY_POLYGON: ${{ secrets.APIKEY_ALCHEMY_POLYGON_MUMBAI }}

--- a/.github/workflows/release-access.yaml
+++ b/.github/workflows/release-access.yaml
@@ -41,14 +41,7 @@ jobs:
         uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/access
           command: publish --env current
           environment: current
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/release-account.yaml
+++ b/.github/workflows/release-account.yaml
@@ -40,15 +40,8 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: platform/account
           command: publish --env current
           environment: current
-          secrets: |
-            ENVIRONMENT
-            CLOUDFLARE_API_TOKEN
-            CLOUDFLARE_ACCOUNT_ID
-        env:
-          ENVIRONMENT: production
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}

--- a/.github/workflows/release-galaxy.yaml
+++ b/.github/workflows/release-galaxy.yaml
@@ -40,7 +40,8 @@ jobs:
       - name: Deploy to Dev Worker
         uses: cloudflare/wrangler-action@2.0.0
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
+          accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: 'platform/galaxy'
           command: publish --env current
           environment: 'current'
@@ -48,8 +49,5 @@ jobs:
             APIKEY_ALCHEMY_ETH
             APIKEY_ALCHEMY_POLYGON
         env:
-          ADMIN_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.ADMIN_ACCOUNT_ID }}
           APIKEY_ALCHEMY_ETH: ${{ secrets.APIKEY_ALCHEMY_GALAXY_MAINNET }}
           APIKEY_ALCHEMY_POLYGON: ${{ secrets.APIKEY_ALCHEMY_POLYGON_MAINNET }}


### PR DESCRIPTION
Further cleanup of env var references and GHA secrets for Account, Access and Galaxy pipelines.

Contributes to closure of #1121.

## Type of change

- Chore

# How Has This Been Tested?

It hasn't. Pipeline would have to execute to test.

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
