### PR TITLE
feat(sb): all applications to be published

### DIFF
--- a/platform/starbase/curl/kb_appPublish.json
+++ b/platform/starbase/curl/kb_appPublish.json
@@ -1,0 +1,9 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "kb_appPublish",
+  "params": {
+    "clientId": "53ab56010b446e62746309dba44c35c2",
+    "published": true
+  }
+}

--- a/platform/starbase/curl/kb_appRotateSecret.json
+++ b/platform/starbase/curl/kb_appRotateSecret.json
@@ -3,6 +3,6 @@
   "id": 1,
   "method": "kb_appRotateSecret",
   "params": {
-    "clientId": "9300468a8b0d9ae54ee13e5aa0aad650"
+    "clientId": "53ab56010b446e62746309dba44c35c2"
   }
 }

--- a/platform/starbase/curl/kb_appUpdate.json
+++ b/platform/starbase/curl/kb_appUpdate.json
@@ -3,7 +3,7 @@
   "id": 1,
   "method": "kb_appUpdate",
   "params": {
-    "clientId": "f5f43b2354c644360f6ba49c9e7b5e5a",
+    "clientId": "53ab56010b446e62746309dba44c35c2",
     "profile": {
       "redirectURI": "https://example.com/auth/successful",
       "domains": [],

--- a/platform/starbase/src/error.ts
+++ b/platform/starbase/src/error.ts
@@ -1,0 +1,26 @@
+// @kubelt/platform.starbase:src/error.ts
+
+/**
+ * Define the errors returned by the service.
+ */
+
+// Error Codes
+// -----------------------------------------------------------------------------
+
+export enum ErrorCode {
+  MissingClientName = -100,
+  MissingClientSecret = -200,
+}
+
+// JSON-RPC Errors
+// -----------------------------------------------------------------------------
+
+export const ErrorMissingClientName = {
+  code: ErrorCode.MissingClientName,
+  message: 'client name not set',
+}
+
+export const ErrorMissingClientSecret = {
+  code: ErrorCode.MissingClientSecret,
+  message: 'oauth secret not set',
+}

--- a/platform/starbase/src/nodes/application/schema.ts
+++ b/platform/starbase/src/nodes/application/schema.ts
@@ -61,7 +61,7 @@ const rpcSchema: RpcSchema = {
       params: [],
       result: {
         name: 'profile',
-        description: 'Public application data',
+        description: 'Public (published) application data',
         schema: {
           type: 'object',
         },
@@ -82,6 +82,29 @@ const rpcSchema: RpcSchema = {
       ],
       result: {
         name: 'success',
+        schema: {
+          type: 'boolean',
+        },
+      },
+    },
+    {
+      name: 'hasSecret',
+      summary: 'Returns whether or not the application OAuth secret is set',
+      params: [],
+      result: {
+        name: 'exists',
+        schema: {
+          type: 'boolean',
+        },
+      },
+    },
+    {
+      name: 'publish',
+      summary: 'Set the publication flag status',
+      params: [],
+      result: {
+        name: 'published',
+        description: 'The new publication status',
         schema: {
           type: 'boolean',
         },

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -125,7 +125,7 @@ const rpcSchema: RpcSchema = {
       summary: 'Delete an application',
       params: [
         {
-          $ref: '#/components/contentDescriptors/AppSelect',
+          $ref: '#/components/contentDescriptors/ClientId',
         },
       ],
       result: {
@@ -164,7 +164,7 @@ const rpcSchema: RpcSchema = {
         {
           name: 'clientId',
           schema: {
-            type: 'string',
+            $ref: '#/components/contentDescriptors/ClientId',
           },
         },
         {
@@ -208,6 +208,9 @@ const rpcSchema: RpcSchema = {
       summary: 'Set the publication status of an application',
       params: [
         {
+          $ref: '#/components/contentDescriptors/ClientId',
+        },
+        {
           name: 'published',
           required: true,
           schema: {
@@ -229,17 +232,12 @@ const rpcSchema: RpcSchema = {
       summary: 'Return the public application profile',
       params: [
         {
-          name: 'clientId',
-          required: true,
-          schema: {
-            // TODO app core ID, needs better type here
-            type: 'string',
-          },
+          $ref: '#/components/contentDescriptors/ClientId',
         },
       ],
       result: {
         name: 'status',
-        summary: 'The new publication status',
+        summary: 'The public (published) application data',
         schema: {
           $ref: '#/components/schema/AppProfile',
         },
@@ -256,6 +254,14 @@ const rpcSchema: RpcSchema = {
           'The information required to uniquely identify an application',
         schema: {
           $ref: '#/components/schemas/AppSelect',
+        },
+      },
+      ClientId: {
+        name: 'clientId',
+        required: true,
+        description: 'An OAuth client ID, used to identify an application',
+        schema: {
+          $ref: '#/components/schemas/ClientId',
         },
       },
       Profile: {


### PR DESCRIPTION
# Description

Allow applications to be "published" using the `kb_appPublish` RPC method of `@kubelt/platform.starbase` service.

## @kubelt/platform.starbase

- [x] split out RPC service error definitions into separate `error` module
- [x] add methods on application node
  - [x] `hasSecret` returns true iff application secret is not empty
  - [x] `publish` sets the publication state of application to true or false
- [x] comments out application of `@requiredScope()` decorator in application node until it's better defined

### kb_appCreate

- [x] rename `clientName` parameter to `name` to match already-stored field

### kb_initPlatform

- [x] hash the secret provided in fixture data
- [x] update application node `init` method to store the hashed secret
  - this is only used for the case where loading fixture data, and should be removed once fixture objects are no longer necessary

### kb_appPublish

- [x] update parameters to include `clientId` (to identify app being published)
- [x] update parameters to include `published` flag (to indicate whether app is published or not)
- [x] adds app data validity check before allowing app to be published
  - the app secret must be set
  - the app name must be set