### PR TITLE
fix(gha): Fixing typo in secrets reference in GHA workflow for Address - next.

### DIFF
--- a/.github/workflows/next-address.yaml
+++ b/.github/workflows/next-address.yaml
@@ -49,4 +49,4 @@ jobs:
           secrets: |
             TOKEN_NFTAR
         env:
-          TOKEN_NFTAR: ${{ secrets.INTERNAL_NFTAR_TEST }}
+          TOKEN_NFTAR: ${{ secrets.TOKEN_NFTAR_TEST }}


### PR DESCRIPTION
Fixes typo in secrets reference for the NFTar key for the "next" workflow.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Has not. Pipeline run will test.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
