### PR TITLE
chore(dx): Removed yarn limit on parallel invocations.

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -11,7 +11,7 @@
     "gql": "run-p 'gql:*'",
     "dev:gql": "run-p 'gql:* -- --watch'",
     "storybook": "yarn workspaces foreach -i -v -p -t run storybook",
-    "start": "yarn workspaces foreach -i -v -p -t run start",
+    "start": "yarn workspaces foreach -i -v -p -t -j unlimited run start",
     "build": "yarn workspaces foreach -p -v -i -t run build",
     "test": "yarn workspaces foreach -p -v -i -t run test"
   },

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "gql": "yarn workspaces foreach -p -v -i run gql",
     "dev:gql": "run-p 'gql:* -- --watch'",
-    "dev": "yarn workspaces foreach -i -v -p run dev",
-    "start": "echo \"Run each frontend applications individually\"",
+    "start": "echo \"Run yarn dev in the platform folder, and run yarn start in apps folder.\"",
     "build": "yarn workspaces foreach -p -v -i run build",
     "test": "yarn workspaces foreach -p -v -i run test"
   },

--- a/platform/package.json
+++ b/platform/package.json
@@ -10,7 +10,7 @@
     "gql:galaxy": "graphql-codegen --config graphql.config.js --project galaxy --aggregate-output -n -l",
     "gql": "run-p 'gql:*'",
     "dev:gql": "run-p 'gql:* -- --watch'",
-    "dev": "yarn workspaces foreach -i -v -p run dev",
+    "dev": "yarn workspaces foreach -i -v -p -j unlimited run dev",
     "build": "yarn workspaces foreach -p -v -i run build",
     "test": "yarn workspaces foreach -p -v -i run test"
   },


### PR DESCRIPTION
# Description

Removed limitation that yarn applies by default for parallel invocations, so that we're able to run all workers/apps locally, using a single command (yarn dev for workers, yarn start for apps)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran the commands locally in appropriate folders.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
