### PR TITLE
fix(gha): fix wrangler auth error in edges workflow

### DIFF
--- a/.github/workflows/main-edges.yaml
+++ b/.github/workflows/main-edges.yaml
@@ -45,7 +45,7 @@ jobs:
           accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: '2.6.2'
           workingDirectory: 'platform/edges'
-          command: d1 delete --env dev edges-dev
+          command: d1 --env dev delete edges-dev
           environment: 'dev'
 
       - name: Deploy edges D1 Database
@@ -55,7 +55,7 @@ jobs:
           accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
           wranglerVersion: '2.6.2'
           workingDirectory: 'platform/edges'
-          command: d1 execute --env dev edges-dev --file=./edges.sql
+          command: d1 --env dev execute edges-dev --file=./edges.sql
           environment: 'dev'
 
       - name: Deploy edges dev Worker

--- a/.github/workflows/main-edges.yaml
+++ b/.github/workflows/main-edges.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - fix/gha-edges
 
 defaults:
   run:
@@ -42,6 +43,7 @@ jobs:
         with:
           apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
           accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '2.6.2'
           workingDirectory: 'platform/edges'
           command: d1 delete --env dev edges-dev
           environment: 'dev'
@@ -51,6 +53,7 @@ jobs:
         with:
           apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
           accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '2.6.2'
           workingDirectory: 'platform/edges'
           command: d1 execute --env dev edges-dev --file=./edges.sql
           environment: 'dev'
@@ -60,6 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.TOKEN_CLOUDFLARE_API }}
           accountId: ${{ secrets.INTERNAL_CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: '2.6.2'
           workingDirectory: 'platform/edges'
           command: publish --env dev
           environment: 'dev'

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-galaxy.yaml/badge.svg)
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-console.yaml/badge.svg)
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-passport.yaml/badge.svg)
+![](https://github.com/kubelt/kubelt/actions/workflows/main-edges.yaml/badge.svg)
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-icons.yaml/badge.svg)
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-starbase.yaml/badge.svg)
 ![](https://github.com/kubelt/kubelt/actions/workflows/main-access.yaml/badge.svg)


### PR DESCRIPTION
# Description

The following error is occurring the in the `main-edges` workflow when invoking `wrangler d1` commands using the [cloudflare/wrangler-action](https://github.com/cloudflare/wrangler-action):

```
[ERROR] A request to the Cloudflare API (/accounts/***/d1/database/7e2bb4f6-9a3e-4136-aa71-d634db545b4d/query) failed.

  Authentication error [code: 10000]
```

Things tried:
- [x] pinning `wrangler` version to `2.6.2` using `wranglerVersion` attribute of the action
- [x] adding `Account.D1.Read`, `Account.D1.Write` permission on the GitHub token
- [x] doing the above on the other token in use, in case the wrong token secret was being used
- [x] removing the restriction on the token to a single zone
