### PR TITLE
feat(galaxy|starbase): API key validation

### DIFF
--- a/packages/openrpc/middleware/local.ts
+++ b/packages/openrpc/middleware/local.ts
@@ -16,6 +16,8 @@ import type { RpcContext } from '@kubelt/openrpc'
 
 import * as openrpc from '@kubelt/openrpc'
 
+import { isFromCFBinding } from '@kubelt/utils'
+
 // local
 // -----------------------------------------------------------------------------
 
@@ -43,17 +45,11 @@ export default openrpc.middleware(
     //const realIP = request.headers.get("x-real-ip");
 
     // E.g. "127.0.0.1"
-    const connectingIP = request.headers.get('cf-connecting-ip')
-
-    //console.log(forwardedProto, hostIP, realIP, connectingIP);
-
-    const allowedOrigin = '127.0.0.1'
-
-    if (!connectingIP || connectingIP === allowedOrigin) {
+    if (isFromCFBinding(request))
       // Allow middleware chain to continue.
       return context
-    }
-
+      
+    const connectingIP = request.headers.get('cf-connecting-ip')
     const message = `rejecting request from non-local address: ${connectingIP}`
     console.warn(message)
 

--- a/packages/platform-clients/starbase.ts
+++ b/packages/platform-clients/starbase.ts
@@ -6,7 +6,7 @@ import type {
   AppRotateSecretResult,
   AppClearSecretResult,
   AppAPIKeyValidityRequest,
-  AppAPIKeyValidityResult
+  AppAPIKeyValidityResult,
 } from '@kubelt/platform.starbase/src/types'
 
 import { BaseApi } from './base'

--- a/packages/platform-clients/starbase.ts
+++ b/packages/platform-clients/starbase.ts
@@ -5,6 +5,8 @@ import type {
   AppAuthCheckParams,
   AppRotateSecretResult,
   AppClearSecretResult,
+  AppAPIKeyValidityRequest,
+  AppAPIKeyValidityResult
 } from '@kubelt/platform.starbase/src/types'
 
 import { BaseApi } from './base'
@@ -19,6 +21,7 @@ export interface StarbaseApi extends BaseApi {
   kb_initPlatform(): Promise<string[]>
   kb_appClearSecret(clientId: string): Promise<AppClearSecretResult>
   kb_appRotateSecret(clientId: string): Promise<AppRotateSecretResult>
+  kb_appApiKeyCheck(keyObj: AppAPIKeyValidityRequest): Promise<AppAPIKeyValidityResult>
 }
 
 export default (

--- a/packages/platform-clients/starbase.ts
+++ b/packages/platform-clients/starbase.ts
@@ -21,7 +21,9 @@ export interface StarbaseApi extends BaseApi {
   kb_initPlatform(): Promise<string[]>
   kb_appClearSecret(clientId: string): Promise<AppClearSecretResult>
   kb_appRotateSecret(clientId: string): Promise<AppRotateSecretResult>
-  kb_appApiKeyCheck(keyObj: AppAPIKeyValidityRequest): Promise<AppAPIKeyValidityResult>
+  kb_appApiKeyCheck(
+    keyObj: AppAPIKeyValidityRequest
+  ): Promise<AppAPIKeyValidityResult>
 }
 
 export default (

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,3 +1,4 @@
 import checkEnv from './checkEnv'
+import isFromCFBinding from './isFromCFBinding'
 
-export { checkEnv }
+export { checkEnv, isFromCFBinding }

--- a/packages/utils/isFromCFBinding.ts
+++ b/packages/utils/isFromCFBinding.ts
@@ -1,7 +1,7 @@
 export default (request: Request): boolean => {
-    const connectingIP = request.headers.get('cf-connecting-ip')
+  const connectingIP = request.headers.get('cf-connecting-ip')
 
-    const allowedOrigin = '127.0.0.1'
+  const allowedOrigin = '127.0.0.1'
 
-    return (!connectingIP || connectingIP === allowedOrigin)
+  return !connectingIP || connectingIP === allowedOrigin
 }

--- a/packages/utils/isFromCFBinding.ts
+++ b/packages/utils/isFromCFBinding.ts
@@ -1,0 +1,7 @@
+export default (request: Request): boolean => {
+    const connectingIP = request.headers.get('cf-connecting-ip')
+
+    const allowedOrigin = '127.0.0.1'
+
+    return (!connectingIP || connectingIP === allowedOrigin)
+}

--- a/platform/galaxy/src/env.ts
+++ b/platform/galaxy/src/env.ts
@@ -10,6 +10,7 @@ export default interface Env {
 
   Account: Fetcher
   Address: Fetcher
+  Starbase: Fetcher
   APIKEY_ALCHEMY_ETH: string
   ALCHEMY_ETH_NETWORK: string
   APIKEY_ALCHEMY_POLYGON: string
@@ -19,6 +20,7 @@ export default interface Env {
 export const required = [
   'Account',
   'Address',
+  'Starbase',
   'APIKEY_ALCHEMY_ETH',
   'ALCHEMY_ETH_NETWORK',
   'APIKEY_ALCHEMY_POLYGON',

--- a/platform/galaxy/src/schema/resolvers/address.ts
+++ b/platform/galaxy/src/schema/resolvers/address.ts
@@ -2,7 +2,7 @@ import { composeResolvers } from '@graphql-tools/resolvers-composition'
 import ENSUtils from '@kubelt/platform-clients/ens-utils'
 import { Resolvers } from './typedefs'
 
-import { setupContext } from './utils'
+import { hasApiKey, setupContext } from './utils'
 
 const addressResolvers: Resolvers = {
   Query: {
@@ -17,9 +17,9 @@ const addressResolvers: Resolvers = {
 }
 
 const AddressResolverComposition = {
-  'Query.ensDisplayName': [setupContext()],
-  'Query.ensAddress': [setupContext()],
-  'Query.ensAddressAvatar': [setupContext()],
+  'Query.ensDisplayName': [setupContext(), hasApiKey()],
+  'Query.ensAddress': [setupContext(), hasApiKey()],
+  'Query.ensAddressAvatar': [setupContext(), hasApiKey()],
 }
 
 export default composeResolvers(addressResolvers, AddressResolverComposition)

--- a/platform/galaxy/src/schema/resolvers/nfts.ts
+++ b/platform/galaxy/src/schema/resolvers/nfts.ts
@@ -11,7 +11,7 @@ import {
   NFTPropertyMapper,
 } from '../../../../../packages/alchemy-client'
 
-import { setupContext, sliceIntoChunks } from './utils'
+import { hasApiKey, setupContext, sliceIntoChunks } from './utils'
 import { print } from 'graphql'
 
 type ResolverContext = {
@@ -281,8 +281,8 @@ const nftsResolvers: Resolvers = {
 }
 
 const NFTsResolverComposition = {
-  'Query.nftsForAddress': [setupContext()],
-  'Query.contractsForAddress': [setupContext()],
+  'Query.nftsForAddress': [setupContext(), hasApiKey()],
+  'Query.contractsForAddress': [setupContext(), hasApiKey()],
 }
 
 export default composeResolvers(nftsResolvers, NFTsResolverComposition)

--- a/platform/galaxy/src/schema/resolvers/profile.ts
+++ b/platform/galaxy/src/schema/resolvers/profile.ts
@@ -4,7 +4,7 @@ import { composeResolvers } from '@graphql-tools/resolvers-composition'
 import createAccountClient from '@kubelt/platform-clients/account'
 import createAddressClient from '@kubelt/platform-clients/address'
 
-import { setupContext, isAuthorized } from './utils'
+import { setupContext, isAuthorized, hasApiKey } from './utils'
 
 import Env from '../../env'
 import { Resolvers } from './typedefs'
@@ -16,6 +16,7 @@ import { AddressURN, AddressURNSpace } from '@kubelt/urns/address'
 type ResolverContext = {
   env: Env
   jwt: string
+  apiKey: string
   accountURN: AccountURN
 }
 
@@ -127,7 +128,7 @@ const threeIDResolvers: Resolvers = {
 
 const ThreeIDResolverComposition = {
   'Query.profile': [setupContext()],
-  'Query.profileFromAddress': [setupContext()],
+  'Query.profileFromAddress': [setupContext(), hasApiKey()],
   'Mutation.updateThreeIDProfile': [setupContext(), isAuthorized()],
 }
 

--- a/platform/galaxy/src/schema/resolvers/profile.ts
+++ b/platform/galaxy/src/schema/resolvers/profile.ts
@@ -127,9 +127,9 @@ const threeIDResolvers: Resolvers = {
 }
 
 const ThreeIDResolverComposition = {
-  'Query.profile': [setupContext()],
+  'Query.profile': [setupContext(), hasApiKey()],
   'Query.profileFromAddress': [setupContext(), hasApiKey()],
-  'Mutation.updateThreeIDProfile': [setupContext(), isAuthorized()],
+  'Mutation.updateThreeIDProfile': [setupContext(), hasApiKey(), isAuthorized()],
 }
 
 export default composeResolvers(threeIDResolvers, ThreeIDResolverComposition)

--- a/platform/galaxy/wrangler.toml
+++ b/platform/galaxy/wrangler.toml
@@ -8,6 +8,7 @@ wrangler_dev = false
 services = [
   { binding = "Account", service = "account" },
   { binding = "Address", service = "address" },
+  { binding = "Starbase", service = "starbase"}
 ]
 
 [dev]
@@ -23,6 +24,7 @@ route = { pattern = "galaxy-dev.threeid.xyz", custom_domain = true, zone_name = 
 services = [
   { binding = "Account", service = "account-dev" },
   { binding = "Address", service = "address-dev" },
+  { binding = "Starbase", service = "starbase-dev" },
 ]
 
 [env.dev.vars]
@@ -34,6 +36,7 @@ route = { pattern = "galaxy-next.threeid.xyz", custom_domain = true, zone_name =
 services = [
   { binding = "Account", service = "account-next" },
   { binding = "Address", service = "address-next" },
+  { binding = "Starbase", service = "starbase-next" },
 ]
 
 [env.next.vars]
@@ -45,6 +48,7 @@ route = { pattern = "galaxy.threeid.xyz", custom_domain = true, zone_name = "thr
 services = [
   { binding = "Account", service = "account-current" },
   { binding = "Address", service = "address-current" },
+  { binding = "Starbase", service = "starbase-current" },
 ]
 
 [env.current.vars]

--- a/platform/starbase/src/constants.ts
+++ b/platform/starbase/src/constants.ts
@@ -1,1 +1,3 @@
 export const HEADER_ACCESS_TOKEN = 'KBT-Access-JWT-Assertion'
+//TODO: this should be converted to a platform-level urn, eg. com.kubelt/platform:starbase
+export const STARBASE_API_KEY_ISSUER = 'starbase-app'

--- a/platform/starbase/src/index.ts
+++ b/platform/starbase/src/index.ts
@@ -70,6 +70,7 @@ import {
 // Import the OpenRPC schema for this API.
 import schema from './schema'
 import { ParamsArray } from '@kubelt/openrpc/impl/jsonrpc'
+import { AppApiKeyCheckParams } from './types'
 
 // Durable Objects
 // -----------------------------------------------------------------------------
@@ -573,8 +574,7 @@ const kb_appApiKeyCheck = openrpc.method(schema, {
       request: Readonly<RpcRequest>,
       context: Readonly<RpcContext>
     ) => {
-      //TODO: add error checking for buffer overflows: overall body payload and the decoded JWT sizes
-      const apiKey = _.get(request, ['params', 'apiKey'])
+      const [{ apiKey }] = request.params as AppApiKeyCheckParams
       const jwtSub = decodeJwt(apiKey).sub as ApplicationURN
       const clientId = ApplicationURNSpace.parse(jwtSub).decoded
 

--- a/platform/starbase/src/nodes/application/apiKeyUtils.ts
+++ b/platform/starbase/src/nodes/application/apiKeyUtils.ts
@@ -49,7 +49,7 @@ export async function generateAndStore(
   return apiKey
 }
 
-export async function verify (
+export async function verify(
   params: RpcParams,
   input: RpcInput,
   output: RpcOutput
@@ -62,7 +62,7 @@ export async function verify (
     await jwtVerify(token, key, options)
     return true
   } catch (e) {
-    console.error("Error verifying API key validity.", e)
+    console.error('Error verifying API key validity.', e)
     return false
   }
 }

--- a/platform/starbase/src/nodes/application/index.ts
+++ b/platform/starbase/src/nodes/application/index.ts
@@ -330,6 +330,18 @@ export class StarbaseApplication {
     return apiKey
   }
 
+  @method('validateApiKey')
+  //@requiredScope()
+  @requiredField('apiKeySigningKeyPair', [FieldAccess.Read])
+  async validateApiKey(
+    params: RpcParams,
+    input: RpcInput,
+    output: RpcOutput
+  ): Promise<RpcResult> {
+    const validResult = await apiKeyUtils.verify(params, input, output)
+    return validResult
+  }
+
   // publish
   // ---------------------------------------------------------------------------
   // Note that this method simply sets the publication flag as

--- a/platform/starbase/src/nodes/application/schema.ts
+++ b/platform/starbase/src/nodes/application/schema.ts
@@ -136,6 +136,26 @@ const rpcSchema: RpcSchema = {
         },
       },
     },
+    {
+      name: 'validateApiKey',
+      summary: 'Validate API key',
+      params: [
+        {
+          name: 'apiKey',
+          description: 'API key',
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'valid',
+        description: 'Validity result',
+        schema: {
+          type: 'boolean',
+        },
+      },
+    },
 
     {
       name: 'publish',

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -244,6 +244,26 @@ const rpcSchema: RpcSchema = {
       },
       errors: [],
     },
+    {
+      name: 'kb_appApiKeyCheck',
+      summary: 'Validates given API key',
+      params: [
+        {
+          name: 'apiKey',
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        },
+      ],
+      result: {
+        name: 'valid',
+        schema: {
+          type: 'boolean',
+        },
+      },
+      errors: [],
+    },
 
     {
       name: 'kb_appPublish',

--- a/platform/starbase/src/types.ts
+++ b/platform/starbase/src/types.ts
@@ -27,3 +27,13 @@ export type AppClearSecretResult = {
 export type AppRotateSecretResult = {
   secret: string
 }
+
+export type AppApiKeyCheckParams = [key: AppAPIKeyValidityRequest]
+
+export type AppAPIKeyValidityResult = {
+  valid: boolean
+}
+
+export type AppAPIKeyValidityRequest = {
+  apiKey: string
+}


### PR DESCRIPTION
# Description
Adds API key validation functionality to starbase and implements a API key check in Galaxy only for non-bound service requests.

Contributes to closure of #1190 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
// Starbase
curl -X POST \
     -H 'Content-Type: application/json' \
     localhost:9090/jsonrpc \
     -d '{ "jsonrpc": "2.0", "method": "kb_appApiKeyCheck", "params": [{ "apiKey": "(API key)"}] }'

// Galaxy
curl -X POST \
     -H 'Content-Type: application/json' \
     -H 'x-galaxy-key: (API key)' \
     localhost:8787 \
     -d '{ "query": "{ profileFromAddress(addressURN: \"(some address URN)\"){ displayName }}" }'

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
