### PR TITLE
feat(console): API key rolling implementation

### DIFF
--- a/apps/console/app/utilities/platform.server.tsx
+++ b/apps/console/app/utilities/platform.server.tsx
@@ -1,9 +1,11 @@
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 
-export function getStarbaseClient(jwt: string) {
+export function getStarbaseClient(jwt: string): StarbaseClient {
   return createStarbaseClient(Starbase, {
     headers: {
       'KBT-Access-JWT-Assertion': jwt,
     },
   })
 }
+
+export type StarbaseClient = ReturnType<typeof createStarbaseClient>

--- a/packages/platform-clients/starbase.ts
+++ b/packages/platform-clients/starbase.ts
@@ -4,9 +4,9 @@ import type {
   AppScopesResult,
   AppAuthCheckParams,
   AppRotateSecretResult,
-  AppClearSecretResult,
   AppAPIKeyValidityRequest,
   AppAPIKeyValidityResult,
+  AppAPIKeyResult,
 } from '@kubelt/platform.starbase/src/types'
 
 import { BaseApi } from './base'
@@ -19,8 +19,10 @@ export interface StarbaseApi extends BaseApi {
   kb_appProfile(clientId: string): Promise<AppProfileResult>
   kb_appScopes(): Promise<AppScopesResult>
   kb_initPlatform(): Promise<string[]>
-  kb_appClearSecret(clientId: string): Promise<AppClearSecretResult>
   kb_appRotateSecret(clientId: string): Promise<AppRotateSecretResult>
+  kb_appRotateApiKey(clientIdObj: {
+    clientId: string
+  }): Promise<AppAPIKeyResult>
   kb_appApiKeyCheck(
     keyObj: AppAPIKeyValidityRequest
   ): Promise<AppAPIKeyValidityResult>

--- a/platform/starbase/src/nodes/application/index.ts
+++ b/platform/starbase/src/nodes/application/index.ts
@@ -216,6 +216,7 @@ export class StarbaseApplication {
   @requiredField('app', [FieldAccess.Read])
   @requiredField('clientId', [FieldAccess.Read])
   @requiredField('secretTimestamp', [FieldAccess.Read])
+  @requiredField('apiKeyTimestamp', [FieldAccess.Read])
   appFetch(
     params: RpcParams,
     input: RpcInput,
@@ -224,11 +225,13 @@ export class StarbaseApplication {
     const clientId = input.get('clientId')
     const app = input.get('app')
     const secretTimestamp = input.get('secretTimestamp')
+    const apiKeyTimestamp = input.get('apiKeyTimestamp')
 
     return Promise.resolve({
       clientId,
       app,
       secretTimestamp,
+      apiKeyTimestamp,
     })
   }
 
@@ -276,23 +279,6 @@ export class StarbaseApplication {
     return Promise.resolve(exists)
   }
 
-  // clearSecret
-  // ---------------------------------------------------------------------------
-  @method('clearSecret')
-  //@requiredScope()
-  @requiredField('secret', [FieldAccess.Write])
-  @requiredField('secretTimestamp', [FieldAccess.Write])
-  clearSecret(
-    params: RpcParams,
-    input: RpcInput,
-    output: RpcOutput
-  ): Promise<RpcResult> {
-    output.set('secret', null)
-    output.set('secretTimestamp', null)
-
-    return Promise.resolve(true)
-  }
-
   // rotateSecret
   // ---------------------------------------------------------------------------
 
@@ -320,6 +306,7 @@ export class StarbaseApplication {
   //@requiredScope()
   @requiredField('apiKey', [FieldAccess.Read, FieldAccess.Write])
   @requiredField('apiKeySigningKeyPair', [FieldAccess.Read, FieldAccess.Write])
+  @requiredField('apiKeyTimestamp', [FieldAccess.Write])
   async rotateApiKey(
     params: RpcParams,
     input: RpcInput,
@@ -327,6 +314,7 @@ export class StarbaseApplication {
   ): Promise<RpcResult> {
     const apiKey = await apiKeyUtils.generateAndStore(params, input, output)
     output.set('apiKey', apiKey)
+    output.set('apiKeyTimestamp', Date.now())
     return apiKey
   }
 

--- a/platform/starbase/src/nodes/application/schema.ts
+++ b/platform/starbase/src/nodes/application/schema.ts
@@ -69,17 +69,6 @@ const rpcSchema: RpcSchema = {
       errors: [],
     },
     {
-      name: 'clearSecret',
-      summary: 'Clear currently stored secret',
-      params: [],
-      result: {
-        name: 'success',
-        schema: {
-          type: 'boolean',
-        },
-      },
-    },
-    {
       name: 'rotateSecret',
       summary: 'Set a new (hashed) application OAuth secret',
       params: [

--- a/platform/starbase/src/schema.ts
+++ b/platform/starbase/src/schema.ts
@@ -183,27 +183,6 @@ const rpcSchema: RpcSchema = {
       },
     },
     {
-      name: 'kb_appClearSecret',
-      summary: 'Clear current secret',
-      params: [
-        {
-          name: 'clientId',
-          description: 'The application OAuth client ID',
-          required: true,
-          schema: {
-            $ref: '#/components/contentDescriptors/ClientId',
-          },
-        },
-      ],
-      result: {
-        name: 'success',
-        schema: {
-          type: 'boolean',
-        },
-      },
-      errors: [],
-    },
-    {
       name: 'kb_appRotateSecret',
       summary: 'Invalidate an old secret and replace it with a new value',
       params: [

--- a/platform/starbase/src/types.ts
+++ b/platform/starbase/src/types.ts
@@ -20,10 +20,6 @@ export type AppAuthCheckParams = {
   clientSecret?: string
 }
 
-export type AppClearSecretResult = {
-  success: boolean
-}
-
 export type AppRotateSecretResult = {
   secret: string
 }
@@ -35,5 +31,9 @@ export type AppAPIKeyValidityResult = {
 }
 
 export type AppAPIKeyValidityRequest = {
+  apiKey: string
+}
+
+export type AppAPIKeyResult = {
   apiKey: string
 }


### PR DESCRIPTION
# Description

Implements user-facing feature of being able to roll the API key. Also includes refactorings to remove need for worker method to clear the secrets to make it work in Remix.

- Closes #1190 

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Create new app -> Both secrets show up and date is set to current
- [x] Load app -> No secrets show up but timestamps reflect last rolled datetime
- [x] Roll API key -> New API key shows up and its timestamp gets updated
- [x] Roll Client Secret -> New Client Secret shows up and its timestamp gets updated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
