### PR TITLE
fix(threeid): sort nfts on server

### DIFF
--- a/apps/profile/app/components/nft-collection/ProfileNftCollection.tsx
+++ b/apps/profile/app/components/nft-collection/ProfileNftCollection.tsx
@@ -8,6 +8,8 @@ import superrare from '~/assets/partners/superrare.svg'
 import polygon from '~/assets/partners/polygon.svg'
 import book from '~/assets/book.svg'
 
+import { mergeSortedNfts } from '~/helpers/nfts'
+
 import noNfts from '~/assets/No_NFT_Found.svg'
 import noFilter from '~/assets/no-filter.svg'
 
@@ -158,7 +160,7 @@ const ProfileNftCollection = ({
       }, []),
     ])
 
-    setLoadedNfts([...loadedNfts, ...nftRes.ownedNfts])
+    setLoadedNfts(mergeSortedNfts(loadedNfts, nftRes.ownedNfts))
     setPageLink(nftRes.pageKey ?? null)
 
     if (refresh) {
@@ -447,43 +449,33 @@ const ProfileNftCollection = ({
               className="my-masonry-grid"
               columnClassName="my-masonry-grid_column"
             >
-              {filteredLoadedNfts
-                .sort((a, b) => {
-                  if (b.collectionTitle === null) {
-                    return -1
-                  } else {
-                    return (
-                      a.collectionTitle?.localeCompare(b.collectionTitle) || 1
-                    )
-                  }
-                })
-                .map((nft, index) => {
-                  return (
-                    <div
-                      key={`${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`}
-                      className="flex
+              {filteredLoadedNfts.map((nft, index) => {
+                return (
+                  <div
+                    key={`${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`}
+                    className="flex
                       justify-center
                       pl-[10%]
                       w-[90%]
                       "
-                    >
-                      {nftRenderer(
-                        nft,
-                        selectedNft ===
-                          `${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`,
-                        (selectedNft: any) => {
-                          setSelectedNft(
-                            `${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`
-                          )
+                  >
+                    {nftRenderer(
+                      nft,
+                      selectedNft ===
+                        `${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`,
+                      (selectedNft: any) => {
+                        setSelectedNft(
+                          `${nft.collectionTitle}_${nft.title}_${nft.url}_${index}`
+                        )
 
-                          if (handleSelectedNft) {
-                            handleSelectedNft(selectedNft)
-                          }
+                        if (handleSelectedNft) {
+                          handleSelectedNft(selectedNft)
                         }
-                      )}
-                    </div>
-                  )
-                })}
+                      }
+                    )}
+                  </div>
+                )
+              })}
             </Masonry>
           </InfiniteScroll>
         </>

--- a/apps/profile/app/helpers/nfts.ts
+++ b/apps/profile/app/helpers/nfts.ts
@@ -1,0 +1,29 @@
+export const mergeSortedNfts = (a: any, b: any) => {
+  var sorted = [],
+    indexA = 0,
+    indexB = 0
+
+  while (indexA < a.length && indexB < b.length) {
+    if (sortNftsFn(a[indexA], b[indexB]) > 0) {
+      sorted.push(b[indexB++])
+    } else {
+      sorted.push(a[indexA++])
+    }
+  }
+
+  if (indexB < b.length) {
+    sorted = sorted.concat(b.slice(indexB))
+  } else {
+    sorted = sorted.concat(a.slice(indexA))
+  }
+
+  return sorted
+}
+
+export const sortNftsFn = (a: any, b: any) => {
+  if (b.collectionTitle === null) {
+    return -1
+  } else {
+    return a.collectionTitle?.localeCompare(b.collectionTitle) || 1
+  }
+}

--- a/apps/profile/app/routes/nfts/collection.tsx
+++ b/apps/profile/app/routes/nfts/collection.tsx
@@ -1,6 +1,7 @@
 import { LoaderFunction, json } from '@remix-run/cloudflare'
 import { gatewayFromIpfs } from '~/helpers'
 import { getGalaxyClient } from '~/helpers/clients'
+import { sortNftsFn } from '~/helpers/nfts'
 
 export const loader: LoaderFunction = async ({ request }) => {
   const srcUrl = new URL(request.url)
@@ -62,7 +63,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   const filteredNfts =
     ownedNfts?.filter((n: any) => !n.error && n.thumbnailUrl) || []
 
+  const sortedNfts = filteredNfts.sort(sortNftsFn)
+
   return json({
-    ownedNfts: filteredNfts,
+    ownedNfts: sortedNfts,
   })
 }

--- a/apps/profile/app/routes/nfts/index.tsx
+++ b/apps/profile/app/routes/nfts/index.tsx
@@ -1,6 +1,7 @@
 import { LoaderFunction, json } from '@remix-run/cloudflare'
 import { gatewayFromIpfs } from '~/helpers'
 import { getGalaxyClient } from '~/helpers/clients'
+import { sortNftsFn } from '~/helpers/nfts'
 
 export const loader: LoaderFunction = async ({ request }) => {
   const srcUrl = new URL(request.url)
@@ -10,36 +11,12 @@ export const loader: LoaderFunction = async ({ request }) => {
     throw new Error('Owner required')
   }
   const galaxyClient = await getGalaxyClient()
-  // const { nftsForAddress: res } = await galaxyClient.getNftsForAddress({
-  //   owner,
-  // })
+
   const { contractsForAddress: resColl } =
     await galaxyClient.getNftsPerCollection({
       owner,
       excludeFilters: ['SPAM'],
     })
-  // const ownedNfts = res?.ownedNfts.map((nft) => {
-  //   const media = Array.isArray(nft.media) ? nft.media[0] : nft.media
-  //   let error = false
-  //   if (nft.error) {
-  //     error = true
-  //   }
-  //   return {
-  //     url: gatewayFromIpfs(media?.raw),
-  //     thumbnailUrl: gatewayFromIpfs(media?.thumbnail ?? media?.raw),
-  //     error: error,
-  //     title: nft.title,
-  //     collectionTitle: nft.contractMetadata?.name,
-  //     properties: nft.metadata?.properties,
-  //     details: [
-  //       {
-  //         name: 'NFT Contract',
-  //         value: nft.contract?.address,
-  //       },
-  //       { name: 'NFT Standard', value: nft.contractMetadata?.tokenType },
-  //     ],
-  //   }
-  // })
 
   const ownedNfts = resColl?.contracts.map((contract) => {
     const nft: any = contract?.ownedNfts ? contract.ownedNfts[0] : {}
@@ -83,7 +60,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   const filteredNfts =
     ownedNfts?.filter((n) => !n.error && n.thumbnailUrl) || []
 
+  const sortedNfts = filteredNfts.sort(sortNftsFn)
+
   return json({
-    ownedNfts: filteredNfts,
+    ownedNfts: sortedNfts,
   })
 }


### PR DESCRIPTION
# Description

Sorting NFTs now is done on server. Sorting filters is completely relying on that so that fixes the issue.
Plus adding greedy merge of two sorted NFT which increases speed.

- Closes #1233

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
