### PR TITLE
feat(console): Display button to copy secrets on reveal 

### DIFF
--- a/apps/console/app/components/Applications/Auth/ApplicationAuth.stories.tsx
+++ b/apps/console/app/components/Applications/Auth/ApplicationAuth.stories.tsx
@@ -13,6 +13,13 @@ const Template = () => (
       createdAt: new Date(),
       onKeyRoll: () => {},
     }}
+    onDelete={() => {}}
+    appDetails={{
+      app: {
+        name: 'Foo',
+      },
+      published: true,
+    }}
   />
 )
 

--- a/apps/console/app/components/Applications/Auth/ApplicationAuth.tsx
+++ b/apps/console/app/components/Applications/Auth/ApplicationAuth.tsx
@@ -8,8 +8,7 @@ import { Button } from '@kubelt/design-system/src/atoms/buttons/Button'
 import IconPicker from '~/components/IconPicker'
 import { useState } from 'react'
 import { RotateCredsModal } from '~/components/RotateCredsModal/RotateCredsModal'
-import { FaCopy } from 'react-icons/fa'
-import { Toaster, toast } from 'react-hot-toast'
+import toast, { Toaster } from 'react-hot-toast'
 
 type ApplicationAuthProps = {
   appDetails: {
@@ -53,14 +52,15 @@ export const ApplicationAuth = ({
           Save
         </Button>
       </div>
-    <Toaster position="top-right" reverseOrder={false} />
-    <RotateCredsModal
+      <Toaster position="top-right" reverseOrder={false} />
+      <RotateCredsModal
         isOpen={rollKeyModalOpen}
         rotateCallback={() => {
           setRollKeyModalOpen(false)
           oAuth.onKeyRoll()
         }}
-        closeCallback={() => setRollKeyModalOpen(false)} />
+        closeCallback={() => setRollKeyModalOpen(false)}
+      />
 
       <div className="flex flex-col md:flex-row space-y-5 lg:space-y-0 lg:space-x-5">
         <div className="flex-1">
@@ -76,24 +76,17 @@ export const ApplicationAuth = ({
               </div>
 
               <div className="flex-1">
-              <div className='flex justify-end' >
-                <Text size='sm'
-                  weight="medium"
-                  className={(!oAuth.appSecret ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-1'}
-                  onClick={() => {
-                    navigator.clipboard.writeText(oAuth.appSecret || '')
-                    toast.success("Client secret copied to clipboard!", { duration: 2000 })
-                  }}
-                >
-                  <FaCopy className='mr-3'></FaCopy>
-                </Text>
-              </div>
-
                 <ReadOnlyInput
                   id="oAuthAppSecret"
                   label="Application Secret"
                   value={oAuth.appSecret ?? 's3cr3t-l337-h4x0r5'}
                   hidden={oAuth.appSecret ? false : true}
+                  copyable={oAuth.appSecret ? true : false}
+                  onCopy={() =>
+                    toast.success('Client secret copied to clipboard!', {
+                      duration: 2000,
+                    })
+                  }
                   disabled
                 />
               </div>
@@ -149,20 +142,32 @@ export const ApplicationAuth = ({
             </div>
 
             <div className="flex-1">
-              <ReadOnlyInput id="appScopes" label="Scopes" value="User profile" />
+              <ReadOnlyInput
+                id="appScopes"
+                label="Scopes"
+                value="User profile"
+              />
             </div>
           </div>
 
           <div className="my-8 md:my-0">
-            <ReadOnlyInput id="appDomains" label="Domain(s)" value="" required />
+            <ReadOnlyInput
+              id="appDomains"
+              label="Domain(s)"
+              value=""
+              required
+            />
             <Text
-                    type="span"
-                    size="xs"
-                    weight="medium"
-                    className="text-gray-400"
-                    ><a className="text-indigo-500" href="https://discord.gg/threeid">
-                    Contact us
-                  </a> to enable this feature</Text>
+              type="span"
+              size="xs"
+              weight="medium"
+              className="text-gray-400"
+            >
+              <a className="text-indigo-500" href="https://discord.gg/threeid">
+                Contact us
+              </a>{' '}
+              to enable this feature
+            </Text>
           </div>
 
           <div className="flex flex-col md:flex-row space-y-8 md:space-y-0 md:space-x-8 md:items-end">

--- a/apps/console/app/components/Applications/Auth/ApplicationAuth.tsx
+++ b/apps/console/app/components/Applications/Auth/ApplicationAuth.tsx
@@ -8,6 +8,8 @@ import { Button } from '@kubelt/design-system/src/atoms/buttons/Button'
 import IconPicker from '~/components/IconPicker'
 import { useState } from 'react'
 import { RotateCredsModal } from '~/components/RotateCredsModal/RotateCredsModal'
+import { FaCopy } from 'react-icons/fa'
+import { Toaster, toast } from 'react-hot-toast'
 
 type ApplicationAuthProps = {
   appDetails: {
@@ -51,7 +53,7 @@ export const ApplicationAuth = ({
           Save
         </Button>
       </div>
-
+    <Toaster position="top-right" reverseOrder={false} />
     <RotateCredsModal
         isOpen={rollKeyModalOpen}
         rotateCallback={() => {
@@ -74,6 +76,19 @@ export const ApplicationAuth = ({
               </div>
 
               <div className="flex-1">
+              <div className='flex justify-end' >
+                <Text size='sm'
+                  weight="medium"
+                  className={(!oAuth.appSecret ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-1'}
+                  onClick={() => {
+                    navigator.clipboard.writeText(oAuth.appSecret || '')
+                    toast.success("Client secret copied to clipboard!", { duration: 2000 })
+                  }}
+                >
+                  <FaCopy className='mr-3'></FaCopy>
+                </Text>
+              </div>
+
                 <ReadOnlyInput
                   id="oAuthAppSecret"
                   label="Application Secret"

--- a/apps/console/app/components/Applications/Dashboard/ApplicationDashboard.tsx
+++ b/apps/console/app/components/Applications/Dashboard/ApplicationDashboard.tsx
@@ -23,14 +23,13 @@ type ApplicationDashboardProps = {
   logins?: any[]
 }
 
-
 export const ApplicationDashboard = ({
   galaxyGql,
   oAuth,
 }: ApplicationDashboardProps) => {
-
   const [apiKeyRollModalOpen, setApiKeyRollModalOpen] = useState(false)
-  const [clientSecretRollModalOpen, setClientSecretRollModalOpen] = useState(false)
+  const [clientSecretRollModalOpen, setClientSecretRollModalOpen] =
+    useState(false)
 
   return (
     <section>
@@ -45,14 +44,16 @@ export const ApplicationDashboard = ({
           setApiKeyRollModalOpen(false)
           galaxyGql.onKeyRoll()
         }}
-        closeCallback={() => setApiKeyRollModalOpen(false)} />
+        closeCallback={() => setApiKeyRollModalOpen(false)}
+      />
       <RotateCredsModal
         isOpen={clientSecretRollModalOpen}
         rotateCallback={() => {
           setClientSecretRollModalOpen(false)
           oAuth.onKeyRoll()
         }}
-        closeCallback={() => setClientSecretRollModalOpen(false)} />
+        closeCallback={() => setClientSecretRollModalOpen(false)}
+      />
 
       <div className="flex flex-col md:flex-row space-y-5 md:space-y-0 md:space-x-5">
         <div className="flex-1 flex flex-col space-y-5">
@@ -77,23 +78,17 @@ export const ApplicationDashboard = ({
               </div>
             }
           >
-            <div className='flex justify-end' >
-              <Text size='sm' 
-                weight="medium"
-                className={(!galaxyGql.apiKey ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-1'}
-                onClick={() => {
-                  navigator.clipboard.writeText(galaxyGql.apiKey || '')
-                  toast.success("API key copied to clipboard!", { duration: 2000 })
-                }}
-                >
-                  <FaCopy className='mr-3'></FaCopy>
-                </Text>
-            </div>
             <ReadOnlyInput
               id="gqlApiKey"
               label="API Key"
               value={galaxyGql.apiKey ?? 's3cr3t-l337-h4x0r5'}
               hidden={galaxyGql.apiKey ? false : true}
+              copyable={galaxyGql.apiKey ? true : false}
+              onCopy={() =>
+                toast.success('Client secret copied to clipboard!', {
+                  duration: 2000,
+                })
+              }
             />
           </Panel>
 
@@ -124,24 +119,19 @@ export const ApplicationDashboard = ({
                 label="Application ID"
                 value={oAuth.appId}
               />
-              <div className='flex justify-end' >
-                <Text size='sm'
-                  weight="medium"
-                  className={(!oAuth.appSecret ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-4'}
-                  onClick={() => {
-                    navigator.clipboard.writeText(oAuth.appSecret || '')
-                    toast.success("Client secret copied to clipboard!", { duration: 2000 })
-                  }}
-                >
-                  <FaCopy className='mr-3'></FaCopy>
-                </Text>
-              </div>
+
               <ReadOnlyInput
                 id="oAuthAppSecret"
                 label="Application Secret"
                 value={oAuth.appSecret ?? 's3cr3t-l337-h4x0r5'}
                 hidden={oAuth.appSecret ? false : true}
-              ></ReadOnlyInput>
+                copyable={oAuth.appSecret ? true : false}
+                onCopy={() =>
+                  toast.success('Client secret copied to clipboard!', {
+                    duration: 2000,
+                  })
+                }
+              />
             </div>
           </Panel>
 

--- a/apps/console/app/components/Applications/Dashboard/ApplicationDashboard.tsx
+++ b/apps/console/app/components/Applications/Dashboard/ApplicationDashboard.tsx
@@ -5,6 +5,8 @@ import { Button } from '@kubelt/design-system/src/atoms/buttons/Button'
 import { LoginsPanel } from '../LoginsPanel/LoginsPanel'
 import { RotateCredsModal } from '~/components/RotateCredsModal/RotateCredsModal'
 import { useState } from 'react'
+import { FaCopy } from 'react-icons/fa'
+import { Toaster, toast } from 'react-hot-toast'
 
 type ApplicationDashboardProps = {
   galaxyGql: {
@@ -36,6 +38,7 @@ export const ApplicationDashboard = ({
         Dashboard
       </Text>
 
+      <Toaster position="top-right" reverseOrder={false} />
       <RotateCredsModal
         isOpen={apiKeyRollModalOpen}
         rotateCallback={() => {
@@ -74,6 +77,18 @@ export const ApplicationDashboard = ({
               </div>
             }
           >
+            <div className='flex justify-end' >
+              <Text size='sm' 
+                weight="medium"
+                className={(!galaxyGql.apiKey ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-1'}
+                onClick={() => {
+                  navigator.clipboard.writeText(galaxyGql.apiKey || '')
+                  toast.success("API key copied to clipboard!", { duration: 2000 })
+                }}
+                >
+                  <FaCopy className='mr-3'></FaCopy>
+                </Text>
+            </div>
             <ReadOnlyInput
               id="gqlApiKey"
               label="API Key"
@@ -109,12 +124,24 @@ export const ApplicationDashboard = ({
                 label="Application ID"
                 value={oAuth.appId}
               />
+              <div className='flex justify-end' >
+                <Text size='sm'
+                  weight="medium"
+                  className={(!oAuth.appSecret ? 'hidden' : '') + ' absolute text-indigo-500 cursor-pointer py-4'}
+                  onClick={() => {
+                    navigator.clipboard.writeText(oAuth.appSecret || '')
+                    toast.success("Client secret copied to clipboard!", { duration: 2000 })
+                  }}
+                >
+                  <FaCopy className='mr-3'></FaCopy>
+                </Text>
+              </div>
               <ReadOnlyInput
                 id="oAuthAppSecret"
                 label="Application Secret"
                 value={oAuth.appSecret ?? 's3cr3t-l337-h4x0r5'}
                 hidden={oAuth.appSecret ? false : true}
-              />
+              ></ReadOnlyInput>
             </div>
           </Panel>
 

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -39,6 +39,7 @@
     "lodash": "4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hot-toast": "2.4.0",
     "react-icons": "4.7.1",
     "tiny-invariant": "1.3.1",
     "wagmi": "0.10.8"

--- a/packages/design-system/src/atoms/copier/Copier.tsx
+++ b/packages/design-system/src/atoms/copier/Copier.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { FaCopy } from 'react-icons/fa'
+
+export type CopierProps = {
+  value: string
+  visible?: boolean
+  onCopy?: (value: string) => void
+}
+export const Copier = ({ value, visible = true, onCopy }: CopierProps) => {
+  return visible ? (
+    <FaCopy
+      onClick={() => {
+        if (!navigator) {
+          console.warn('Copying is not available')
+
+          return
+        }
+
+        navigator.clipboard.writeText(value)
+
+        if (onCopy) {
+          onCopy(value)
+        }
+      }}
+      className="cursor-pointer text-indigo-500"
+    />
+  ) : null
+}

--- a/packages/design-system/src/atoms/form/ReadOnlyInput.tsx
+++ b/packages/design-system/src/atoms/form/ReadOnlyInput.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { InputHTMLAttributes } from 'react'
 import { HiEyeOff } from 'react-icons/hi'
+import { Copier } from '../copier/Copier'
 import { Text } from '../text/Text'
 
 export type ReadOnlyInputProps = InputHTMLAttributes<HTMLInputElement> & {
@@ -8,6 +9,8 @@ export type ReadOnlyInputProps = InputHTMLAttributes<HTMLInputElement> & {
   value: string
   label: string
   hidden?: boolean
+  copyable?: boolean
+  onCopy?: (value: string) => void
 }
 
 export const ReadOnlyInput = ({
@@ -18,17 +21,23 @@ export const ReadOnlyInput = ({
   readOnly,
   value,
   className,
+  copyable = false,
+  onCopy,
   ...rest
 }: ReadOnlyInputProps) => {
   const computedName = name ?? id
 
   return (
     <div className="flex flex-col">
-      <label htmlFor={id}>
-        <Text size="sm" weight="medium" className="text-gray-700 mb-2">
-          {label}
-        </Text>
-      </label>
+      <div className="flex flex-row justify-between">
+        <label htmlFor={id}>
+          <Text size="sm" weight="medium" className="text-gray-700 mb-2">
+            {label}
+          </Text>
+        </label>
+
+        {copyable && <Copier value={value} onCopy={onCopy} />}
+      </div>
 
       {/* Would `disabled` also work instead of overwriting focus properties ?*/}
       <div className="relative">

--- a/yarn.lock
+++ b/yarn.lock
@@ -6158,6 +6158,7 @@ __metadata:
     npm-run-all: 4.1.5
     react: 18.2.0
     react-dom: 18.2.0
+    react-hot-toast: 2.4.0
     react-icons: 4.7.1
     tailwindcss: 3.2.4
     tiny-invariant: 1.3.1


### PR DESCRIPTION
# Description

When secrets are revealed (upon new app creation or on secret rotation) a copy button is displayed over the secret field to copy the secret to the clipboard. A toast message noting the copy operation is added also.

- Closes #1345 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- New app
- Rotate API key in Dashboard page
- Rotate Client secret in Dashboard page
- Rotate Client secret in OxAuth page

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
