### PR TITLE
fix(passport): update account profile based on the node type

### DIFF
--- a/apps/passport/app/routes/authenticate/google/callback.ts
+++ b/apps/passport/app/routes/authenticate/google/callback.ts
@@ -30,7 +30,7 @@ export const loader: LoaderFunction = async ({ request }: LoaderArgs) => {
   const encoder = new TextEncoder()
   const hash = keccak256(encoder.encode(profile._json.email))
   const address = (AddressURNSpace.urn(hash) +
-    '?+node_type=oauth?=addr_type=google') as AddressURN
+    '?+node_type=oauth&addr_type=google') as AddressURN
   const addressClient = getAddressClient(address)
   const account = await addressClient.resolveAccount.query()
 

--- a/platform/address/src/jsonrpc/validators/oauth.ts
+++ b/platform/address/src/jsonrpc/validators/oauth.ts
@@ -3,7 +3,7 @@ import { GoogleRawProfileSchema } from './profile'
 
 export const GetGoogleOAuthDataSchema = z.object({
   accessToken: z.string(),
-  refreshToken: z.string(),
+  refreshToken: z.string().optional(),
   extraParams: z.object({
     expires_in: z.number(),
     scope: z.string(),


### PR DESCRIPTION
These changes make the `/authorize` compatible with the OAuth address node type. 