### PR TITLE
chore(platform): Typed URN and IDRef utils

### DIFF
--- a/apps/passport/app/routes/authenticate/github/callback.ts
+++ b/apps/passport/app/routes/authenticate/github/callback.ts
@@ -1,13 +1,11 @@
 import type { LoaderArgs, LoaderFunction } from '@remix-run/cloudflare'
 
-import type { AddressURN } from '@kubelt/urns/address'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
 import { AddressURNSpace } from '@kubelt/urns/address'
-import { IDRefURNSpace } from '@kubelt/urns/idref'
 
 import { authenticator } from '~/auth.server'
 import { authenticateAddress } from '~/utils/authenticate.server'
 import { getAddressClient } from '~/platform.server'
-import { keccak256 } from '@ethersproject/keccak256'
 import { GitHubStrategyDefaultName } from 'remix-auth-github'
 import { NodeType, OAuthAddressType } from '@kubelt/types/address'
 import { OAuthData } from '@kubelt/platform.address/src/types'
@@ -23,13 +21,13 @@ export const loader: LoaderFunction = async ({ request }: LoaderArgs) => {
   if (profile.provider !== OAuthAddressType.GitHub)
     throw new Error('Unsupported provider returned in Github callback.')
 
-  const idref = IDRefURNSpace(OAuthAddressType.GitHub).urn(
-    profile.id.toString()
+  if (!profile._json?.login) throw new Error('Could not get Github login info.')
+
+  const address = AddressURNSpace.componentizedUrn(
+    generateHashedIDRef(OAuthAddressType.GitHub, profile.id),
+    { node_type: NodeType.OAuth, addr_type: OAuthAddressType.GitHub },
+    { alias: profile._json.login, hidden: 'true' }
   )
-  const encoder = new TextEncoder()
-  const hash = keccak256(encoder.encode(idref))
-  const address = (AddressURNSpace.urn(hash) +
-    `?+node_type=${NodeType.OAuth}&addr_type=${OAuthAddressType.GitHub}?=alias=${profile._json?.login}&hidden=true`) as AddressURN
   const addressClient = getAddressClient(address)
   const account = await addressClient.resolveAccount.query()
 

--- a/apps/passport/app/routes/authenticate/google/callback.ts
+++ b/apps/passport/app/routes/authenticate/google/callback.ts
@@ -1,11 +1,6 @@
 import type { LoaderArgs, LoaderFunction } from '@remix-run/cloudflare'
-import type { GoogleExtraParams, GoogleProfile } from 'remix-auth-google'
-
-import { keccak256 } from '@ethersproject/keccak256'
-
-import type { AddressURN } from '@kubelt/urns/address'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
 import { AddressURNSpace } from '@kubelt/urns/address'
-
 import { authenticator } from '~/auth.server'
 import { getAddressClient } from '~/platform.server'
 import { authenticateAddress } from '~/utils/authenticate.server'
@@ -23,10 +18,11 @@ export const loader: LoaderFunction = async ({ request }: LoaderArgs) => {
   if (profile.provider !== OAuthAddressType.Google)
     throw new Error('Unsupported provider returned in Google callback.')
 
-  const encoder = new TextEncoder()
-  const hash = keccak256(encoder.encode(profile._json.email))
-  const address = (AddressURNSpace.urn(hash) +
-    `?+node_type=${NodeType.OAuth}&addr_type=${OAuthAddressType.Google}?=alias=${profile._json.email}&hidden=true`) as AddressURN
+  const address = AddressURNSpace.componentizedUrn(
+    generateHashedIDRef(OAuthAddressType.Google, profile._json.email),
+    { node_type: NodeType.OAuth, addr_type: OAuthAddressType.Google },
+    { alias: profile._json.email, hidden: 'true' }
+  )
   const addressClient = getAddressClient(address)
   const account = await addressClient.resolveAccount.query()
 

--- a/apps/passport/app/routes/authenticate/twitter/callback.ts
+++ b/apps/passport/app/routes/authenticate/twitter/callback.ts
@@ -3,13 +3,10 @@ import type { LoaderArgs, LoaderFunction } from '@remix-run/cloudflare'
 import { TwitterStrategyDefaultName } from 'remix-auth-twitter'
 import type { TwitterStrategyVerifyParams } from 'remix-auth-twitter'
 
-import { keccak256 } from '@ethersproject/keccak256'
-
 import { NodeType, OAuthAddressType } from '@kubelt/types/address'
 
 import { AddressURNSpace } from '@kubelt/urns/address'
-import type { AddressURN } from '@kubelt/urns/address'
-import { IDRefURNSpace } from '@kubelt/urns/idref'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
 
 import { authenticator } from '~/auth.server'
 import { getAddressClient } from '~/platform.server'
@@ -22,11 +19,11 @@ export const loader: LoaderFunction = async ({ request }: LoaderArgs) => {
       request
     )) as TwitterStrategyVerifyParams
 
-  const idref = IDRefURNSpace(OAuthAddressType.Twitter).urn(profile.id_str)
-  const encoder = new TextEncoder()
-  const hash = keccak256(encoder.encode(idref))
-  const address = (AddressURNSpace.urn(hash) +
-    `?+node_type=${NodeType.OAuth}&addr_type=${OAuthAddressType.Twitter}?=alias=${profile.name}&hidden=true`) as AddressURN
+  const address = AddressURNSpace.componentizedUrn(
+    generateHashedIDRef(OAuthAddressType.Twitter, profile.id_str),
+    { node_type: NodeType.OAuth, addr_type: OAuthAddressType.Twitter },
+    { alias: profile.name, hidden: 'true' }
+  )
   const addressClient = getAddressClient(address)
   const account = await addressClient.resolveAccount.query()
 

--- a/apps/passport/app/routes/authorize/index.tsx
+++ b/apps/passport/app/routes/authorize/index.tsx
@@ -20,7 +20,7 @@ import {
 
 import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { generateGradient } from '~/utils/gradient.server'
-import { AddressURN } from '@kubelt/urns/address'
+import { AddressURN, AddressURNSpace } from '@kubelt/urns/address'
 
 export const loader: LoaderFunction = async ({ request, context }) => {
   const url = new URL(request.url)
@@ -31,6 +31,11 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const jwt = await requireJWT(request)
   const session = await getUserSession(request)
   const defaultProfileURN = session.get('defaultProfileUrn') as AddressURN
+
+  const parsedURN = AddressURNSpace.componentizedParse(defaultProfileURN)
+  const rparams = parsedURN.rcomponent
+
+  console.log({ defaultProfileURN, parsedURN, rparams })
 
   const galaxyClient = await getGalaxyClient()
   const profileRes = await galaxyClient.getProfile(

--- a/apps/passport/app/utils/cacheImageToCF.server.ts
+++ b/apps/passport/app/utils/cacheImageToCF.server.ts
@@ -30,7 +30,7 @@ export default async (
     body: cacheReqFormData,
     method: 'post',
   })
-  if (!cacheRes) throw new Error('Could not cache image.')
+  if (!cacheRes || !cacheRes.ok) throw new Error('Could not cache image.')
   const cacheResJson = await cacheRes.json<{ imageUrl: string }>()
   return cacheResJson.imageUrl
 }

--- a/apps/profile/app/routes/account/gallery.tsx
+++ b/apps/profile/app/routes/account/gallery.tsx
@@ -41,22 +41,18 @@ import { LoadingGridSquaresGallery } from '~/components/nfts/grid/loading'
 // Other helpers
 
 import { AddressURNSpace } from '@kubelt/urns/address'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
 import { getIndexerClient } from '~/helpers/clients'
 import type { Node, Profile } from '@kubelt/galaxy-client'
-import { IDRefURNSpace } from '@kubelt/urns/idref'
 import { CryptoAddressType } from '@kubelt/types/address'
-import { keccak256 } from 'ethers/lib/utils'
 import { getMoreNftsModal } from '~/helpers/nfts'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
-  const targetAddress = formData.get('address')?.toString()
-  const idref = IDRefURNSpace(CryptoAddressType.ETH).urn(
-    targetAddress as string
+  const targetAddress = formData.get('address')?.toString() || ''
+  const urn = AddressURNSpace.urn(
+    generateHashedIDRef(CryptoAddressType.ETH, targetAddress)
   )
-  const encoder = new TextEncoder()
-  const hash = keccak256(encoder.encode(idref))
-  const urn = AddressURNSpace.urn(hash)
 
   let errors: any = {}
 

--- a/packages/urns/access.ts
+++ b/packages/urns/access.ts
@@ -1,4 +1,6 @@
 import { createThreeIdURNSpace, ThreeIdURN } from './index'
 
 export type AccessURN = ThreeIdURN<`access/${string}`>
-export const AccessURNSpace = createThreeIdURNSpace<'access'>('access')
+export const AccessURNSpace = createThreeIdURNSpace<'access', never, never>(
+  'access'
+)

--- a/packages/urns/account.ts
+++ b/packages/urns/account.ts
@@ -1,4 +1,6 @@
 import { createThreeIdURNSpace, ThreeIdURN } from './index'
 
 export type AccountURN = ThreeIdURN<`account/${string}`>
-export const AccountURNSpace = createThreeIdURNSpace<'account'>('account')
+export const AccountURNSpace = createThreeIdURNSpace<'account', never, never>(
+  'account'
+)

--- a/packages/urns/address.ts
+++ b/packages/urns/address.ts
@@ -1,4 +1,19 @@
+import { AddressType, NodeType } from '../types/address'
 import { createThreeIdURNSpace, ThreeIdURN } from './index'
 
+export type AddressRComp = {
+  node_type?: NodeType
+  addr_type: AddressType
+}
+
+export type AddressQComp = {
+  alias: string
+  hidden?: string
+}
+
 export type AddressURN = ThreeIdURN<`address/${string}`>
-export const AddressURNSpace = createThreeIdURNSpace<'address'>('address')
+export const AddressURNSpace = createThreeIdURNSpace<
+  'address',
+  AddressRComp,
+  AddressQComp
+>('address')

--- a/packages/urns/application.ts
+++ b/packages/urns/application.ts
@@ -1,5 +1,8 @@
 import { createThreeIdURNSpace, ThreeIdURN } from './index'
 
 export type ApplicationURN = ThreeIdURN<`application/${string}`>
-export const ApplicationURNSpace =
-  createThreeIdURNSpace<'application'>('application')
+export const ApplicationURNSpace = createThreeIdURNSpace<
+  'application',
+  never,
+  never
+>('application')

--- a/packages/urns/idref.ts
+++ b/packages/urns/idref.ts
@@ -1,7 +1,20 @@
+import { keccak256 } from '@ethersproject/keccak256'
 import { createThreeIdURNSpace, ThreeIdURN } from '.'
 import { AddressType } from '../types/address'
 
 export type IDRefURN = ThreeIdURN<`idref/${string}`>
 export const IDRefURNSpace = <IDRefType extends AddressType>(
   idsrc: IDRefType
-) => createThreeIdURNSpace<`idref:${IDRefType}`>(`idref:${idsrc}`)
+) => createThreeIdURNSpace<`idref:${IDRefType}`, never, never>(`idref:${idsrc}`)
+
+type HashedIDRef = string
+
+export const generateHashedIDRef = (
+  idRefNamespace: AddressType,
+  clearTextId: string
+): HashedIDRef => {
+  const idref = IDRefURNSpace(idRefNamespace).urn(clearTextId)
+  const encoder = new TextEncoder()
+  const hash = keccak256(encoder.encode(idref))
+  return hash
+}

--- a/packages/urns/index.ts
+++ b/packages/urns/index.ts
@@ -120,7 +120,7 @@ class TypedComponentsURNSpace<
       qcomps = (Object.fromEntries(params.entries()) as QCompType) || null
     }
 
-    let result = {
+    const result = {
       nid: s.nid,
       nss: s.nss,
       nss_encoded: s.nss_encoded,

--- a/packages/urns/package.json
+++ b/packages/urns/package.json
@@ -29,6 +29,7 @@
     "typescript": "4.8.4"
   },
   "dependencies": {
+    "@ethersproject/keccak256": "5.7.0",
     "urns": "0.6.0"
   }
 }

--- a/platform/address/src/jsonrpc/methods/resolveAccount.ts
+++ b/platform/address/src/jsonrpc/methods/resolveAccount.ts
@@ -28,13 +28,13 @@ export const resolveAccountMethod = async ({
     if (AccountURNSpace.is(stored)) {
       return stored
     } else {
-      const urn = AccountURNSpace.urn(stored)
+      const urn = AccountURNSpace.componentizedUrn(stored)
       nodeClient?.storage.put('account', urn)
       return urn
     }
   } else {
     const name = hexlify(randomBytes(ACCOUNT_OPTIONS.length))
-    const urn = AccountURNSpace.urn(name)
+    const urn = AccountURNSpace.componentizedUrn(name)
 
     console.log('set account', { urn })
 

--- a/platform/address/src/jsonrpc/middlewares/checkCryptoNode.ts
+++ b/platform/address/src/jsonrpc/middlewares/checkCryptoNode.ts
@@ -5,9 +5,8 @@ import { Context } from '../../context'
 import { NodeType } from '../../types'
 import { isCryptoAddressType } from '../../utils'
 import ENSUtils from '@kubelt/platform-clients/ens-utils'
-import { IDRefURNSpace } from '@kubelt/urns/idref'
-import { keccak256 } from '@ethersproject/keccak256'
 import { CryptoAddressType } from '@kubelt/types/address'
+import { generateHashedIDRef } from '@kubelt/urns/idref'
 
 export const checkCryptoNodes: BaseMiddlewareFunction<Context> = async ({
   next,
@@ -35,9 +34,7 @@ export const checkCryptoNodes: BaseMiddlewareFunction<Context> = async ({
       const response = await ensClient.getEnsEntry(alias)
       const { address: ethAddress } = response
 
-      const encoder = new TextEncoder()
-      const idfUrn = IDRefURNSpace(CryptoAddressType.ETH).urn(ethAddress)
-      const hash = keccak256(encoder.encode(idfUrn))
+      const hash = generateHashedIDRef(CryptoAddressType.ETH, ethAddress)
 
       if (hash !== hashedIdref) {
         throw `Alias ${alias} does not match ${hashedIdref}`

--- a/platform/address/src/jsonrpc/middlewares/parse3RN.ts
+++ b/platform/address/src/jsonrpc/middlewares/parse3RN.ts
@@ -20,12 +20,11 @@ export const parse3RN: BaseMiddlewareFunction<Context> = async ({
     throw `missing 3RN name: ${addressURN}`
   }
 
-  const { rcomponent, qcomponent } = AddressURNSpace.parse(addressURN)
-  const rparams = new URLSearchParams(rcomponent || '')
-  const qparams = new URLSearchParams(qcomponent || '')
+  const { rcomponent, qcomponent } =
+    AddressURNSpace.componentizedParse(addressURN)
 
-  const addrType = rparams.get('addr_type')
-  const alias = qparams.get('alias')
+  const addrType = rcomponent?.addr_type
+  const alias = qcomponent?.alias
 
   // if (!addrType) {
   //   throw `cannot determine node type: ${addressURN}. Please provide a node_type or addr_type r-component.`
@@ -33,35 +32,28 @@ export const parse3RN: BaseMiddlewareFunction<Context> = async ({
 
   const nodeType = addrType
     ? isValidAddressType(addrType)
-    : rparams.get('node_type')
+    : rcomponent?.node_type
 
   // if (!nodeType) {
   //   throw `invalid 3RN address type: ${addrType}`
   // }
-
-  // add the name qc param
-  addressURN = `${AddressURNSpace.urn(hashedIdref)}`
 
   console.log('parse3RN', {
     hashedIdref,
     addrType,
     nodeType,
     alias,
-    rparams,
     addressURN,
   })
 
   return next({
     ctx: {
       ...ctx,
-      rparams,
-      qparams,
       addressURN,
       addrType,
       nodeType,
       alias,
       hashedIdref,
-      params: new URLSearchParams(qcomponent as string),
     },
   })
 }

--- a/platform/address/src/jsonrpc/middlewares/parse3RN.ts
+++ b/platform/address/src/jsonrpc/middlewares/parse3RN.ts
@@ -13,7 +13,7 @@ export const parse3RN: BaseMiddlewareFunction<Context> = async ({
   if (!header) {
     throw new Error('missing X-3RN header')
   }
-  let addressURN = header as AddressURN
+  const addressURN = header as AddressURN
   const hashedIdref = AddressURNSpace.decode(addressURN)
 
   if (!hashedIdref) {

--- a/platform/starbase/src/jsonrpc/methods/rotateApiKey.ts
+++ b/platform/starbase/src/jsonrpc/methods/rotateApiKey.ts
@@ -17,7 +17,7 @@ export const rotateApiKey = async ({
   input: z.infer<typeof RotateApiKeyInput>
   ctx: Context
 }): Promise<z.infer<typeof RotateApiKeyOutput>> => {
-  const appURN = ApplicationURNSpace.urn(input.clientId)
+  const appURN = ApplicationURNSpace.componentizedUrn(input.clientId)
   console.log(`rotating API key for ${appURN}`)
 
   const appDO = await getApplicationNodeByClientId(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,6 +5453,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kubelt/urns@workspace:packages/urns"
   dependencies:
+    "@ethersproject/keccak256": 5.7.0
     "@typescript-eslint/eslint-plugin": 5.45.0
     "@typescript-eslint/parser": 5.45.0
     eslint: 8.29.0


### PR DESCRIPTION
# Description

Added:

- [x] `TypedComponentsURNSpace` class to allow overriding and mapping related Q and R param types to an URN space
- [x] `componentizedUrn()` and `componentizedParse()` functions to act on typed R and Q params.
- [x] Mapped subtyping so `componentizedUrn()` returns the correct type and doesn't need to be manually cast, eg. `AddressURN`. 
- [x] `getBaseURN()` function to the class above get the base URN (no components) from a full URN
- [x] `generateIDRefHash()` function to generate hash of typed IDRefs

Closes #1413 

## Type of change

- Chore 

# How Has This Been Tested?

Locally across eth and OAuth accounts.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
