### PR TITLE
fix(passport): Authn & Authz screen icon, name and cleanup

### DIFF
--- a/apps/console/app/routes/apps/$clientId/auth.tsx
+++ b/apps/console/app/routes/apps/$clientId/auth.tsx
@@ -176,6 +176,7 @@ export const action: ActionFunction = async ({ request, params }) => {
         mediumUser: formData.get('mediumUser') as string | undefined,
         mirrorURL: formData.get('mirrorURL') as string | undefined,
         discordUser: formData.get('discordUser') as string | undefined,
+        scopes: Array.from(scopes),
       }
 
       const zodErrors = updatesSchema.safeParse(updates)
@@ -213,12 +214,11 @@ export const action: ActionFunction = async ({ request, params }) => {
 export default function AppDetailIndexPage() {
   const submit = useSubmit()
   const actionData = useActionData()
-  const outletContextData =
-    useOutletContext<{
-      notificationHandler: notificationHandlerType
-      appDetails: appDetailsProps
-      rotationResult: any
-    }>()
+  const outletContextData = useOutletContext<{
+    notificationHandler: notificationHandlerType
+    appDetails: appDetailsProps
+    rotationResult: any
+  }>()
   const { scopeMeta } = useLoaderData()
 
   const [isFormChanged, setIsFormChanged] = useState(false)

--- a/apps/console/app/utilities/session.server.tsx
+++ b/apps/console/app/utilities/session.server.tsx
@@ -44,12 +44,12 @@ const storage = createCookieSessionStorage({
     // normally you want this to be `secure: true`
     // but that doesn't work on localhost for Safari
     // https://web.dev/when-to-use-local-https/
-    secure: true,
+    secure: process.env.NODE_ENV === 'production',
     secrets: [SECRET_SESSION_SALT],
-    sameSite: true,
+    sameSite: 'strict',
     path: '/',
     maxAge: MAX_AGE,
-    // httpOnly: true,
+    httpOnly: true,
   },
 })
 

--- a/apps/passport/app/auth.server.ts
+++ b/apps/passport/app/auth.server.ts
@@ -18,7 +18,7 @@ export const initAuthenticator = (env: Env) => {
       httpOnly: true,
       name: 'oauth',
       path: '/',
-      sameSite: 'lax',
+      sameSite: 'strict',
       secure: process.env.NODE_ENV === 'production',
       maxAge: 60 * 60 * 4,
       secrets: [env.SECRET_SESSION_SALT],
@@ -88,10 +88,13 @@ export const getTwitterStrategy = (env: Env) => {
 }
 
 export const getAppleStrategy = (env: Env) => {
-  return new AppleStrategy({
-    clientID: env.INTERNAL_APPLE_OAUTH_CLIENT_ID,
-    clientSecret: env.SECRET_APPLE_OAUTH_CLIENT_SECRET,
-    callbackURL: env.INTERNAL_APPLE_OAUTH_CALLBACK_URL,
-    scope: 'name email',
-  }, async params => params)
+  return new AppleStrategy(
+    {
+      clientID: env.INTERNAL_APPLE_OAUTH_CLIENT_ID,
+      clientSecret: env.SECRET_APPLE_OAUTH_CLIENT_SECRET,
+      callbackURL: env.INTERNAL_APPLE_OAUTH_CALLBACK_URL,
+      scope: 'name email',
+    },
+    async (params) => params
+  )
 }

--- a/apps/passport/app/components/authentication/Authentication.tsx
+++ b/apps/passport/app/components/authentication/Authentication.tsx
@@ -4,6 +4,7 @@ import kubeltLogoSmall from './kubelt.svg'
 import ConnectOAuthButton from '../connect-oauth-button'
 import { Text } from '@kubelt/design-system/src/atoms/text/Text'
 import { lazy, Suspense } from 'react'
+import { Avatar } from '@kubelt/design-system'
 
 const ConnectButton = lazy(() =>
   import('../../../app/components/connect-button/ConnectButton').then(
@@ -13,6 +14,7 @@ const ConnectButton = lazy(() =>
 
 export type AuthenticationProps = {
   logoURL?: string
+  appName?: string
   enableWalletConnect: boolean
   connectCallback: (address: string) => void
   connectErrorCallback: (error: Error) => void
@@ -20,6 +22,7 @@ export type AuthenticationProps = {
 
 export function Authentication({
   logoURL,
+  appName,
   enableWalletConnect = true,
   connectCallback,
   connectErrorCallback,
@@ -38,11 +41,11 @@ export function Authentication({
         borderRadius: 8,
       }}
     >
-      <div className={''}>
-        <img className={''} src={logo} alt="3ID Logo" />
-      </div>
+      <Avatar src={logo} size="sm"></Avatar>
       <div className={'flex flex-col items-center gap-2'}>
-        <h1 className={'font-semibold text-xl'}>Welcome to the Private Web</h1>
+        <h1 className={'font-semibold text-xl'}>
+          {appName ? `Login to ${appName}` : 'Welcome to the Private Web'}
+        </h1>
         <h2 style={{ color: '#6B7280' }} className={'font-medium text-base'}>
           How would you like to continue?
         </h2>

--- a/apps/passport/app/components/authorization/Authorization.tsx
+++ b/apps/passport/app/components/authorization/Authorization.tsx
@@ -10,7 +10,7 @@ import accountClassIcon from './account-class-icon.svg'
 import addressClassIcon from './address-class-icon.svg'
 
 export type AppProfile = {
-  clientName: string
+  name: string
   published: boolean
   icon: string
   scopes: string[]
@@ -68,9 +68,9 @@ export function Authorization({
         <Avatar src={appProfile.icon} size={'sm'} />
       </div>
       <div className={'flex flex-col items-center justify-center gap-2'}>
-        <h1 className={'font-semibold text-xl'}>{appProfile.clientName}</h1>
+        <h1 className={'font-semibold text-xl'}>{appProfile.name}</h1>
         <p style={{ color: '#6B7280' }} className={'font-light text-base'}>
-          Would like access to the following information
+          would like access to the following information
         </p>
       </div>
       <div className={'flex flex-col gap-4 items-start justify-start'}>

--- a/apps/passport/app/root.tsx
+++ b/apps/passport/app/root.tsx
@@ -138,6 +138,8 @@ export default function App() {
 // https://remix.run/docs/en/v1/guides/errors
 // @ts-ignore
 export function ErrorBoundary({ error }) {
+  console.error('Error in error boundary', error)
+
   return (
     <html lang="en">
       <head>
@@ -165,6 +167,7 @@ export function ErrorBoundary({ error }) {
 export function CatchBoundary() {
   const browserEnv = useLoaderData()
   const caught = useCatch()
+  console.error('Caught in catch boundary', caught)
   const params = useParams()
   const { status } = caught
 

--- a/apps/passport/app/routes/authenticate/index.tsx
+++ b/apps/passport/app/routes/authenticate/index.tsx
@@ -1,11 +1,41 @@
+import { LoaderFunction } from '@remix-run/cloudflare'
+import { cli } from '@remix-run/dev'
+import { useLoaderData, useParams } from '@remix-run/react'
 import { useState } from 'react'
 import { Authentication } from '~/components'
+import { getStarbaseClient } from '~/platform.server'
+import { getConsoleParamsSession } from '~/session.server'
+
+export const loader: LoaderFunction = async ({ request, context }) => {
+  const consoleParmamsSessionFromCookie = await getConsoleParamsSession(
+    request,
+    context.env
+  )
+  const consoleParamsSession = consoleParmamsSessionFromCookie.get('params')
+  const parsedParams = consoleParamsSession
+    ? await JSON.parse(consoleParamsSession)
+    : undefined
+  const clientId = parsedParams?.clientId || undefined
+
+  if (clientId) {
+    const sbClient = getStarbaseClient('', context.env)
+    const response = await sbClient.getAppPublicProps.query({ clientId })
+    return response
+  } else {
+    return null
+  }
+}
 
 export default function Authenticate() {
   const [enableWalletConnect, setEnableWalletConnect] = useState(true)
+  const loaderData = useLoaderData<{ name: string; iconURL: string }>()
+  const name = loaderData?.name || undefined
+  const iconURL = loaderData?.iconURL || undefined
 
   return (
     <Authentication
+      logoURL={iconURL}
+      appName={name}
       enableWalletConnect={enableWalletConnect}
       connectCallback={async (address) => {
         window.location.href = `/authenticate/${address}/sign`

--- a/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
+++ b/platform/starbase/src/jsonrpc/methods/getAppPublicProps.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+import { Context } from '../context'
+import { getApplicationNodeByClientId } from '../../nodes/application'
+import { AppClientIdParamSchema } from '../validators/app'
+
+export const GetAppPublicPropsInput = AppClientIdParamSchema
+
+export const GetAppPublicPropsOutput = z.object({
+  name: z.string(),
+  iconURL: z.string(),
+})
+
+export const getAppPublicProps = async ({
+  input,
+  ctx,
+}: {
+  input: z.infer<typeof GetAppPublicPropsInput>
+  ctx: Context
+}): Promise<z.infer<typeof GetAppPublicPropsOutput>> => {
+  const appDO = await getApplicationNodeByClientId(
+    input.clientId,
+    ctx.StarbaseApp
+  )
+  const appDetails = await appDO.class.getDetails()
+
+  if (appDetails && appDetails.app) {
+    return {
+      name: appDetails.app?.name,
+      iconURL: appDetails.app?.icon || '',
+    }
+  } else {
+    throw new Error(
+      `Could not return properties of application with client ID: ${input.clientId}`
+    )
+  }
+}

--- a/platform/starbase/src/jsonrpc/router.ts
+++ b/platform/starbase/src/jsonrpc/router.ts
@@ -54,6 +54,11 @@ import { NoInput } from '@kubelt/platform-middleware/inputValidators'
 
 import { Analytics } from '@kubelt/platform-middleware/analytics'
 import { OwnAppsMiddleware } from './ownAppsMiddleware'
+import {
+  getAppPublicProps,
+  GetAppPublicPropsInput,
+  GetAppPublicPropsOutput,
+} from './methods/getAppPublicProps'
 
 const t = initTRPC.context<Context>().create()
 
@@ -133,6 +138,12 @@ export const appRouter = t.router({
     .input(CheckAppAuthInput)
     .output(CheckAppAuthOutput)
     .query(checkAppAuth),
+  getAppPublicProps: t.procedure
+    .use(LogUsage)
+    .use(Analytics)
+    .input(GetAppPublicPropsInput)
+    .output(GetAppPublicPropsOutput)
+    .query(getAppPublicProps),
   publishApp: t.procedure
     .use(JWTAssertionTokenFromHeader)
     .use(ValidateJWT)


### PR DESCRIPTION
# Description

Cleans up authorization screen, param checks, app name, etc.

- Closes #1498

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- By temporarily enabling setting of scopes in Console, setting some scopes on a couple of apps, and then hitting the `/authenticate` endpoint in passport with `client_id` and other query params.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
