### PR TITLE
chore(galaxy): Changed header to standard "Authorization: Bearer (token)" format.

### DIFF
--- a/apps/console/app/routes/apps/$clientId.tsx
+++ b/apps/console/app/routes/apps/$clientId.tsx
@@ -14,6 +14,7 @@ import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import type { appDetailsProps } from '~/components/Applications/Auth/ApplicationAuth'
 import { RotatedSecrets } from '~/types'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 type AppData = {
   clientId: string
@@ -50,9 +51,10 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     })
     let avatarUrl = ''
     try {
-      const profileRes = await galaxyClient.getProfile(undefined, {
-        [PlatformJWTAssertionHeader]: jwt,
-      })
+      const profileRes = await galaxyClient.getProfile(
+        undefined,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
       avatarUrl = profileRes.profile?.pfp?.image || ''
     } catch (e) {
       console.error('Could not retrieve profile image.', e)

--- a/apps/console/app/routes/dashboard/index.tsx
+++ b/apps/console/app/routes/dashboard/index.tsx
@@ -25,6 +25,7 @@ import { getGalaxyClient } from '~/utilities/platform.server'
 import { InfoPanelDashboard } from '~/components/InfoPanel/InfoPanelDashboard'
 import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 type LoaderData = {
   apps: {
@@ -60,9 +61,10 @@ export const loader: LoaderFunction = async ({ request }) => {
 
     let avatarUrl = ''
     try {
-      const profileRes = await galaxyClient.getProfile(undefined, {
-        [PlatformJWTAssertionHeader]: jwt,
-      })
+      const profileRes = await galaxyClient.getProfile(
+        undefined,
+        getAuthzHeaderConditionallyFromToken(jwt)
+      )
       avatarUrl = profileRes.profile?.pfp?.image || ''
     } catch (e) {
       console.error('Could not retrieve profile image.', e)

--- a/apps/passport/app/routes/authorize.tsx
+++ b/apps/passport/app/routes/authorize.tsx
@@ -6,6 +6,7 @@ import { Outlet, useLoaderData } from '@remix-run/react'
 import { getAddressClient, getGalaxyClient } from '~/platform.server'
 import { getUserSession, requireJWT } from '~/session.server'
 import { generateGradient } from '~/utils/gradient.server'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 // TODO: loader function check if we have a session already
 // redirect if logged in
@@ -18,9 +19,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   const galaxyClient = await getGalaxyClient()
   const profileRes = await galaxyClient.getProfile(
     {},
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
   const profile = profileRes.profile
 
@@ -123,9 +122,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
     // set the default profile
     await galaxyClient.updateProfile(
       { profile: finalProfile },
-      {
-        [PlatformJWTAssertionHeader]: jwt,
-      }
+      getAuthzHeaderConditionallyFromToken(jwt)
     )
   }
 

--- a/apps/profile/app/helpers/nfts.ts
+++ b/apps/profile/app/helpers/nfts.ts
@@ -1,8 +1,10 @@
-import { gatewayFromIpfs } from '@kubelt/utils'
+import {
+  gatewayFromIpfs,
+  getAuthzHeaderConditionallyFromToken,
+} from '@kubelt/utils'
 import { getGalaxyClient } from './clients'
 import { getAccountProfile, getAddressProfile } from './profile'
 
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { AddressURN } from '@kubelt/urns/address'
 /**
  * Nfts are being sorted server-side
@@ -205,11 +207,7 @@ export const getGalleryWithMetadata = async (owner: string, jwt?: string) => {
     // Optional for when called by
     // a non authenticated visitor
     // of a public profile
-    jwt
-      ? {
-          [PlatformJWTAssertionHeader]: jwt,
-        }
-      : {}
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   const ownedNfts = metadata?.ownedNfts.map((nft) => {

--- a/apps/profile/app/helpers/profile.ts
+++ b/apps/profile/app/helpers/profile.ts
@@ -1,14 +1,15 @@
 import type { Profile, Link, Gallery, Node } from '@kubelt/galaxy-client'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { AddressURN } from '@kubelt/urns/address'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 import { getGalaxyClient } from '~/helpers/clients'
 
 export const getAccountProfile = async (jwt: string) => {
   const galaxyClient = await getGalaxyClient()
 
-  const profileRes = await galaxyClient.getProfile(undefined, {
-    [PlatformJWTAssertionHeader]: jwt,
-  })
+  const profileRes = await galaxyClient.getProfile(
+    undefined,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
 
   const { profile, links, gallery, connectedAddresses } = profileRes
   return { profile, links, gallery, connectedAddresses } as {
@@ -21,9 +22,11 @@ export const getAccountProfile = async (jwt: string) => {
 
 export const getAccountAddresses = async (jwt: string) => {
   const galaxyClient = await getGalaxyClient()
-  const addressesRes = await galaxyClient.getConnectedAddresses(undefined, {
-    [PlatformJWTAssertionHeader]: jwt,
-  })
+  const addressesRes = await galaxyClient.getConnectedAddresses(
+    undefined,
+    getAuthzHeaderConditionallyFromToken(jwt)
+  )
+
   const addresses = addressesRes.connectedAddresses
   return addresses
 }
@@ -53,9 +56,7 @@ export const getAddressProfiles = async (
     {
       addressURNList,
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   const { addressProfiles } = addressProfileRes

--- a/apps/profile/app/root.tsx
+++ b/apps/profile/app/root.tsx
@@ -34,7 +34,6 @@ import logo from './assets/three-id-logo.svg'
 
 import { ErrorPage } from '@kubelt/design-system/src/pages/error/ErrorPage'
 import { Loader } from '@kubelt/design-system/src/molecules/loader/Loader'
-import type { GetProfileQuery } from '@kubelt/galaxy-client'
 
 import HeadNav, { links as headNavLink } from '~/components/head-nav'
 
@@ -43,8 +42,6 @@ import { getProfileSession } from './utils/session.server'
 import { getRedirectUrlForProfile } from './utils/redirects.server'
 import { parseJwt } from './utils/session.server'
 import { getAccountProfile } from './helpers/profile'
-import type { AddressURN } from '@kubelt/urns/address'
-import { AddressURNSpace } from '@kubelt/urns/address'
 import { AccountURNSpace } from '@kubelt/urns/account'
 
 export const meta: MetaFunction = () => ({

--- a/apps/profile/app/routes/$type.$address.tsx
+++ b/apps/profile/app/routes/$type.$address.tsx
@@ -24,9 +24,11 @@ import { ogImageFromProfile } from '~/helpers/ogImage'
 
 import { Avatar } from '@kubelt/design-system/src/atoms/profile/avatar/Avatar'
 import { Text } from '@kubelt/design-system/src/atoms/text/Text'
-import { gatewayFromIpfs } from '@kubelt/utils'
+import {
+  gatewayFromIpfs,
+  getAuthzHeaderConditionallyFromToken,
+} from '@kubelt/utils'
 import { AddressURNSpace } from '@kubelt/urns/address'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import type { Profile } from '@kubelt/galaxy-client'
 
 import { Cover } from '~/components/profile/cover/Cover'
@@ -57,18 +59,13 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   // if not handle is this let's assume this is an idref
   let profile = undefined
   try {
-    console.debug('BEFORE CONST')
     const user = session.get('user')
     let jwt = user?.accessToken
     profile = await galaxyClient.getProfileFromAddress(
       {
         addressURN: `${urn}`,
       },
-      jwt
-        ? {
-            [PlatformJWTAssertionHeader]: jwt,
-          }
-        : {}
+      getAuthzHeaderConditionallyFromToken(jwt)
     )
 
     profile = {

--- a/apps/profile/app/routes/account/gallery.tsx
+++ b/apps/profile/app/routes/account/gallery.tsx
@@ -34,7 +34,6 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Text } from '@kubelt/design-system/src/atoms/text/Text'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import SaveButton from '~/components/accounts/SaveButton'
 import PfpNftModal from '~/components/accounts/PfpNftModal'
 import { LoadingGridSquaresGallery } from '~/components/nfts/grid/loading'
@@ -47,6 +46,7 @@ import { generateHashedIDRef } from '@kubelt/urns/idref'
 import type { Node, Profile } from '@kubelt/galaxy-client'
 import { CryptoAddressType } from '@kubelt/types/address'
 import { getMoreNftsModal } from '~/helpers/nfts'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
@@ -107,9 +107,7 @@ export const action: ActionFunction = async ({ request }) => {
     {
       gallery,
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   // TODO: update gallery on account

--- a/apps/profile/app/routes/account/settings/connections/rename.tsx
+++ b/apps/profile/app/routes/account/settings/connections/rename.tsx
@@ -1,4 +1,4 @@
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 import { ActionFunction } from '@remix-run/cloudflare'
 import { getGalaxyClient } from '~/helpers/clients'
 import { requireJWT } from '~/utils/session.server'
@@ -17,9 +17,7 @@ export const action: ActionFunction = async ({ request }) => {
       addressURN: id,
       nickname: name,
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   return null

--- a/apps/profile/app/routes/account/settings/links.tsx
+++ b/apps/profile/app/routes/account/settings/links.tsx
@@ -21,7 +21,6 @@ import type { Profile } from '@kubelt/galaxy-client'
 import { Button } from '@kubelt/design-system/src/atoms/buttons/Button'
 import { Text } from '@kubelt/design-system/src/atoms/text/Text'
 import { SortableList } from '@kubelt/design-system/src/atoms/lists/SortableList'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 
 import InputText from '~/components/inputs/InputText'
 import SaveButton from '~/components/accounts/SaveButton'
@@ -33,6 +32,7 @@ import { AddressURN } from '@kubelt/urns/address'
 import { InputToggle } from '@kubelt/design-system/src/atoms/form/InputToggle'
 import { CryptoAddressType, OAuthAddressType } from '@kubelt/types/address'
 import { imageFromAddressType } from '~/helpers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 
 export type ProfileData = {
   targetAddress: string
@@ -243,9 +243,7 @@ export const action: ActionFunction = async ({ request }) => {
       // links to be first; we add them first.
       links: connectedAccountLinks.concat(updatedLinks),
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   return { updatedLinks }

--- a/apps/profile/app/routes/account/settings/profile.tsx
+++ b/apps/profile/app/routes/account/settings/profile.tsx
@@ -14,7 +14,10 @@ import { Text } from '@kubelt/design-system/src/atoms/text/Text'
 import { Avatar } from '@kubelt/design-system/src/atoms/profile/avatar/Avatar'
 import { Spinner } from '@kubelt/design-system/src/atoms/spinner/Spinner'
 
-import { gatewayFromIpfs } from '@kubelt/utils'
+import {
+  gatewayFromIpfs,
+  getAuthzHeaderConditionallyFromToken,
+} from '@kubelt/utils'
 
 import PfpNftModal from '~/components/accounts/PfpNftModal'
 
@@ -24,7 +27,6 @@ import SaveButton from '~/components/accounts/SaveButton'
 import { getGalaxyClient } from '~/helpers/clients'
 import { getMoreNftsModal } from '~/helpers/nfts'
 import type { Node, Profile } from '@kubelt/galaxy-client'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 
 export const action: ActionFunction = async ({ request }) => {
   const jwt = await requireJWT(request)
@@ -55,9 +57,7 @@ export const action: ActionFunction = async ({ request }) => {
         },
       },
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   return null

--- a/apps/profile/app/routes/account/settings/profile/update-cover.tsx
+++ b/apps/profile/app/routes/account/settings/profile/update-cover.tsx
@@ -1,4 +1,4 @@
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 import { ActionFunction, json } from '@remix-run/cloudflare'
 import { getGalaxyClient } from '~/helpers/clients'
 import { requireJWT } from '~/utils/session.server'
@@ -16,9 +16,7 @@ export const action: ActionFunction = async ({ request }) => {
         cover: coverUrl,
       },
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   return json(coverUrl)

--- a/apps/profile/app/routes/nfts/collection.tsx
+++ b/apps/profile/app/routes/nfts/collection.tsx
@@ -1,9 +1,9 @@
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 import type { LoaderFunction } from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
 
 import { getGalaxyClient } from '~/helpers/clients'
 import { decorateNft, decorateNfts } from '~/helpers/nfts'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 import { getProfileSession } from '~/utils/session.server'
 
 export const loader: LoaderFunction = async ({ request }) => {
@@ -30,9 +30,7 @@ export const loader: LoaderFunction = async ({ request }) => {
       owner,
       contractAddresses: [collection],
     },
-    {
-      [PlatformJWTAssertionHeader]: jwt,
-    }
+    getAuthzHeaderConditionallyFromToken(jwt)
   )
 
   const ownedNfts = resColl?.ownedNfts.map((nft: any) => {

--- a/apps/profile/app/routes/nfts/index.tsx
+++ b/apps/profile/app/routes/nfts/index.tsx
@@ -1,10 +1,10 @@
+import { getAuthzHeaderConditionallyFromToken } from '@kubelt/utils'
 import type { LoaderFunction } from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
 
 import { getGalaxyClient } from '~/helpers/clients'
 import { decorateNft, decorateNfts } from '~/helpers/nfts'
 import { getProfileSession } from '~/utils/session.server'
-import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 
 export const loader: LoaderFunction = async ({ request }) => {
   const srcUrl = new URL(request.url)
@@ -26,9 +26,7 @@ export const loader: LoaderFunction = async ({ request }) => {
         owner,
         excludeFilters: ['SPAM'],
       },
-      {
-        [PlatformJWTAssertionHeader]: jwt,
-      }
+      getAuthzHeaderConditionallyFromToken(jwt)
     )
 
   const ownedNfts =

--- a/apps/profile/app/utils/session.server.tsx
+++ b/apps/profile/app/utils/session.server.tsx
@@ -64,8 +64,6 @@ export async function requireJWT(request: Request, headers = new Headers()) {
 
     const parsedToken = parseJwt(accessToken)
 
-    console.debug({ exp: parsedToken.exp, now: Date.now() })
-
     // if expired throw an error (we can extends Error to create this)
     if (!parsedToken.exp || parsedToken.exp <= Date.now()) {
       throw new AuthorizationError('Expired')

--- a/packages/utils/getAuthzHeaderConditionallyFromToken.ts
+++ b/packages/utils/getAuthzHeaderConditionallyFromToken.ts
@@ -1,0 +1,3 @@
+export default function (token: string | undefined): HeadersInit {
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}

--- a/packages/utils/getAuthzTokenFromReq.ts
+++ b/packages/utils/getAuthzTokenFromReq.ts
@@ -1,0 +1,11 @@
+export default function (request: Request): string | undefined {
+  const authHeader = request.headers.get('authorization')
+  if (!authHeader) return undefined
+
+  //This should be in the format "Bearer (token)"
+  const authorization = authHeader.split(' ')
+  if (authorization.length !== 2 || authorization[0] !== 'Bearer')
+    throw new Error('Invalid value provided in Authorization header')
+
+  return authorization[1] //token
+}

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,5 +1,13 @@
 import checkEnv from './checkEnv'
 import isFromCFBinding from './isFromCFBinding'
 import gatewayFromIpfs from './gateway-from-ipfs'
+import getAuthzHeaderConditionallyFromToken from './getAuthzHeaderConditionallyFromToken'
+import getAuthzTokenFromReq from './getAuthzTokenFromReq'
 
-export { checkEnv, isFromCFBinding, gatewayFromIpfs }
+export {
+  checkEnv,
+  isFromCFBinding,
+  gatewayFromIpfs,
+  getAuthzHeaderConditionallyFromToken,
+  getAuthzTokenFromReq,
+}

--- a/platform/galaxy/src/schema/resolvers/utils/index.ts
+++ b/platform/galaxy/src/schema/resolvers/utils/index.ts
@@ -7,7 +7,7 @@ import createStarbaseClient from '@kubelt/platform-clients/starbase'
 import createAccountClient from '@kubelt/platform-clients/account'
 
 import Env from '../../../env'
-import { isFromCFBinding } from '@kubelt/utils'
+import { getAuthzTokenFromReq, isFromCFBinding } from '@kubelt/utils'
 import { PlatformJWTAssertionHeader } from '@kubelt/types/headers'
 
 import { WriteAnalyticsDataPoint } from '@kubelt/packages/platform-clients/analytics'
@@ -30,7 +30,7 @@ export function parseJwt(token: string): JWTPayload {
 }
 
 export const setupContext = () => (next) => (root, args, context, info) => {
-  const jwt = context.request.headers.get(PlatformJWTAssertionHeader)
+  const jwt = getAuthzTokenFromReq(context.request)
   const apiKey = context.request.headers.get('X-GALAXY-KEY')
 
   const parsedJwt = jwt && parseJwt(jwt)


### PR DESCRIPTION
Changed the header for Galaxy calls (client and resolver middleware) to the `Authorization: Bearer (token)` format. 

Done this through introduction of 2 package utilities:
- One to produce appropriate headers or empty object from token
- One to get token from headers or returned undefined, in case of no Authorization header. This is used for operations with public access.

This brings user docs and code in alignment.

- Closes #1555

## Type of change

- Chore

# How Has This Been Tested?

- Logged in to Console and Profile with multiple accounts (MS, github, wallet) and verified avatar, name, other profile props, links and connected accounts.
- Viewed public profiles for accounts above without being logged in.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation website
- [ ] I have made corresponding changes to the literal docs
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
